### PR TITLE
qa: omit python from codeql

### DIFF
--- a/.github/workflows/ql.yml
+++ b/.github/workflows/ql.yml
@@ -1,5 +1,5 @@
 # codeql gh-actions file
-name: codeql
+name: CodeQL
 
 on:
   push:
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'python' ]
+        language: [ 'cpp' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
 
     steps:


### PR DESCRIPTION
there is no python code in the repository thus we fail codeql analysis. omitting temporarily until python qa testing framework and tooltest is eventually ported.