### PR TITLE
qa: address_test

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -107,6 +107,7 @@ int generateHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_mast
 
     /* determine if mainnet or testnet/regtest */
     const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+
     /* generate a new hd master key */
     hd_gen_master(chain, hd_privkey_master, strsize);
 
@@ -132,7 +133,10 @@ int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey) 
     /* require master key */
     if (!wif_privkey_master) return false;
 
-    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+    /* determine address prefix for network chainparams */
+    char prefix[1];
+    memcpy(prefix, wif_privkey_master, 1);
+    const dogecoin_chainparams* chain = memcmp(prefix, "d", 1) == 0 ? &dogecoin_chainparams_main : &dogecoin_chainparams_test;
 
     size_t strsize = 128;
     char str[strsize];

--- a/test/address_tests.c
+++ b/test/address_tests.c
@@ -16,22 +16,25 @@ void test_address()
 {
     size_t privkeywiflen = 100;
     char privkeywif[privkeywiflen];
-    char privkeyhex[100];
-    u_assert_int_eq(generatePrivPubKeypair(privkeywif, privkeyhex, false), true)
+    char p2pkh_wif[36];
+    u_assert_int_eq(generatePrivPubKeypair(privkeywif, p2pkh_wif, false), true)
     u_assert_int_eq(generatePrivPubKeypair(privkeywif, NULL, false), true)
-    
+
     size_t masterkeysize = 200;
     char masterkey[masterkeysize];
-    char p2pkh_pubkey;
     u_assert_int_eq(generateHDMasterPubKeypair(masterkey, NULL, false), true)
     u_assert_int_eq(generateHDMasterPubKeypair(NULL, NULL, false), true)
     u_assert_int_eq(generateHDMasterPubKeypair(NULL, NULL, NULL), true)
     
     u_assert_int_eq(generateDerivedHDPubkey(masterkey, NULL), true)
     u_assert_int_eq(generateDerivedHDPubkey(NULL, NULL), false)
-
+    
     size_t strsize = 128;
     char str[strsize];
-    u_assert_int_eq(generateDerivedHDPubkey(masterkey, str), true)
 
+    u_assert_int_eq(generateDerivedHDPubkey("dgpv51eADS3spNJhA6LG5QycrFmQQtxg7ztFJQuamYiytZ4x4FUC7pG5B7fUTHBDB7g6oGaCVwuGF2i75r1DQKyFSauAHUGBAi89NaggpdUP3yK", str), true)
+    u_assert_str_eq("DEByFfUQ3AxcFFet9afr8wxxedQysRduWN", str);
+
+    u_assert_int_eq(generateDerivedHDPubkey("tprv8ZgxMBicQKsPeM5HaRoH4AuGX2Jsf8rgQvcFGCvjQxvAn1Bv8SAx8cPQsnmKsB6WjvGWsNiNsrNS2d3quUkYpK2ofctFw87SXodGhBPHiUM", str), true)
+    u_assert_str_eq("noBtVVtAvvh5oapFjHHyTSxxEUTykUZ3oR", str);
 }

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -35,6 +35,7 @@
         }                                                  \
     } while (0)
 
+extern void test_address();
 extern void test_aes();
 extern void test_base58();
 extern void test_bip32();
@@ -72,6 +73,7 @@ int U_TESTS_FAIL = 0;
 int main() {
     dogecoin_ecc_start();
 
+    u_run_test(test_address);
     u_run_test(test_aes);
     u_run_test(test_base58);
     u_run_test(test_bip32);


### PR DESCRIPTION
this fixes issue #17 with generateDerivedHDPubkey() within src/address.c wherein if passing a hd master key with testnet prefix it derives a mainnet p2pkh address.