### PR TITLE
Verify address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,5 +109,6 @@ test-suite.log
 *.db
 *.tar.gz
 *.pc
+**/__pycache__/
 *.py[cod]
-__pycache__/
+

--- a/bindings/py_wrappers/mini_shell.py
+++ b/bindings/py_wrappers/mini_shell.py
@@ -8,7 +8,9 @@ if __name__ == "__main__":
     # print option menu
     cmd_lst = ["gen_keypair <which_chain | 0:main, 1:test>",
                "gen_hdkeypair <which_chain | 0:main, 1:test>",
-               "derive_hdpubkey <master_privkey_wif>"]
+               "derive_hdpubkey <master_privkey_wif>",
+               "verify_keypair <privkey_wif> <p2pkh address> <which_chain | 0:main, 1, test>",
+               "verify_hdkeypair <privkey_wif_master> <p2pkh address_master> <which_chain | 0:main, 1, test"]
     print("="*85)
     print("Press [q] to quit CLI")
     print("Press [w] to repeat previous command\n")
@@ -56,10 +58,40 @@ if __name__ == "__main__":
                 res = libdogecoin.generate_derived_hd_pub_key(args[0])
                 print("new derived child public key:", res)
 
+        # verify private and p2pkh address pair
+        elif cmd == "verify_keypair":
+            if not args or not args[0].isdigit():
+                print(cmd+": enter WIF-encoded private key")
+            elif len(args) < 2 or args[1].isdigit():
+                print(cmd+": enter p2pkh address")
+            elif len(args) < 3 or not args[2].isdigit():
+                print(cmd+": enter valid chain code")
+            else:
+                res = libdogecoin.verify_priv_pub_keypair(args[0], args[1], int(args[2]))
+                if res:
+                    print("Keypair is valid.")
+                else:
+                    print("Keypair is invalid")
+
+        # verify hd master private and p2pkh address pair
+        elif cmd == "verify_hdkeypair":
+            if not args or args[0].isdigit():
+                print(cmd+": enter WIF-encoded private master key")
+            elif len(args) < 2 or args[1].isdigit():
+                print(cmd+": enter p2pkh master pubkey")
+            elif len(args) < 3 or not args[2].isdigit():
+                print(cmd+": enter valid chain code")
+            else:
+                res = libdogecoin.verify_master_priv_pub_keypair(args[0], args[1], int(args[2]))
+                if res:
+                    print("Keypair is valid.")
+                else:
+                    print("Keypair is invalid")
+
         # handle incorrect argument format
         else:
             print(cmd+": not a valid command")
 
-        #accept next command
+        # accept next command
         print()
         inp = input("$ ").split()

--- a/bindings/py_wrappers/wrappers.py
+++ b/bindings/py_wrappers/wrappers.py
@@ -4,19 +4,31 @@ import ctypes as ct
 import sys
 import os
 
-# LOAD SHARED LIBRARY ON INIT - TODO: change path to be more flexible
-path = os.path.abspath(__file__+"../../../../.libs")
-sys.path.insert(0, path)
-path = os.path.join(path, "libdogecoin.so")
+def load_libdogecoin():
+    """Load the libdogecoin library from "libdogecoin.so"."""
+    # TODO: change path to be more flexible
+    path = os.path.abspath(__file__+"../../../../.libs")
+    sys.path.insert(0, path)
+    path = os.path.join(path, "libdogecoin.so")
 
-# all functions from libdogecoin accessed through lib variable
-ct.cdll.LoadLibrary(path)
-lib = ct.CDLL(path)
+    # all functions from libdogecoin accessed through lib variable
+    ct.cdll.LoadLibrary(path)
+    return ct.CDLL(path)
+
+def dogecoin_ecc_start():
+    """Starts ecc context (required for running any key function)."""
+    lib.dogecoin_ecc_start()
+
+def dogecoin_ecc_stop():
+    """Stops currently running ecc context."""
+    lib.dogecoin_ecc_stop()
+
+lib = load_libdogecoin()
 
 #=======================================================ADDRESS.C
 def generate_priv_pub_key_pair(chain_code=0, as_bytes=False):
-    """Generate a valid private and public key pair.
-
+    """Generate a valid private key paired with the corresponding
+    p2pkh address
     Keyword arguments:
     chain_code -- 0 for mainnet pair, 1 for testnet pair
     as_bytes -- flag to return key pair as bytes object
@@ -28,9 +40,13 @@ def generate_priv_pub_key_pair(chain_code=0, as_bytes=False):
     assert(chain_code==0 or chain_code==1)
     is_testnet = ct.c_bool(chain_code)
 
-    # call c functions
+    # start context
     lib.dogecoin_ecc_start()
+
+    # call c function
     lib.generatePrivPubKeypair(wif_privkey, p2pkh_pubkey, is_testnet)
+
+    # stop context
     lib.dogecoin_ecc_stop()
 
     # return results in str/bytes tuple form
@@ -43,7 +59,6 @@ def generate_hd_master_pub_key_pair(chain_code=0, as_bytes=False):
     """Generate a master private and public key pair for use in
     heirarchical deterministic wallets. Public key can be used for
     child key derivation using generate_derived_hd_pub_key().
-
     Keyword arguments:
     chain_code -- 0 for mainnet pair, 1 for testnet pair
     as_bytes -- flag to return key pair as bytes object
@@ -55,9 +70,13 @@ def generate_hd_master_pub_key_pair(chain_code=0, as_bytes=False):
     assert(int(chain_code)==0 or int(chain_code)==1)
     is_testnet = ct.c_bool(int(chain_code))
 
-    # call c functions
+    # start context
     lib.dogecoin_ecc_start()
+
+    # call c function
     lib.generateHDMasterPubKeypair(wif_privkey_master, p2pkh_pubkey_master, is_testnet)
+
+    # stop context
     lib.dogecoin_ecc_stop()
 
     # return results in bytes tuple form
@@ -68,13 +87,12 @@ def generate_hd_master_pub_key_pair(chain_code=0, as_bytes=False):
 
 def generate_derived_hd_pub_key(wif_privkey_master, as_bytes=False):
     """Given a HD master public key, derive a child key from it.
-
     Keyword arguments:
     wif_privkey_master -- HD master public key as wif-encoded string
     as_bytes -- flag to return key pair as bytes object
     """
     # verify arguments are valid
-    assert(isinstance(wif_privkey_master, str) or isinstance(wif_privkey_master, bytes))
+    assert(isinstance(wif_privkey_master, (str, bytes)))
     if not isinstance(wif_privkey_master, bytes):
         wif_privkey_master = wif_privkey_master.encode('utf-8')
 
@@ -83,9 +101,15 @@ def generate_derived_hd_pub_key(wif_privkey_master, as_bytes=False):
     wif_privkey_master_ptr = ct.c_char_p(wif_privkey_master)
     child_p2pkh_pubkey = (ct.c_char * size)()
 
-    # call c functions
+    # start context
     lib.dogecoin_ecc_start()
+
+    # call c function
+    # TODO derived key is the same each time, most likely because of context start
+    # should ecc_start/stop be wrapped too?
     lib.generateDerivedHDPubkey(wif_privkey_master_ptr, child_p2pkh_pubkey)
+
+    # stop context
     lib.dogecoin_ecc_stop()
 
     # return results in bytes
@@ -93,17 +117,115 @@ def generate_derived_hd_pub_key(wif_privkey_master, as_bytes=False):
         return child_p2pkh_pubkey.value
     return child_p2pkh_pubkey.value.decode('utf-8')
 
+
+def verify_priv_pub_keypair(wif_privkey, p2pkh_pubkey, chain_code=0):
+    """Given a keypair from generate_priv_pub_key_pair, verify that the keys
+    are valid and are associated with each other.
+    Keyword arguments:
+    wif_privkey -- string containing wif-encoded private key
+    p2pkh_pubkey -- string containing address derived from wif_privkey
+    chain_code -- 0 for mainnet, 1 for testnet
+    """
+    # verify arguments are valid
+    assert isinstance(wif_privkey, str) and isinstance(p2pkh_pubkey, str)
+    assert isinstance(chain_code, int)
+
+    # prepare arguments
+    wif_privkey_ptr = ct.c_char_p(wif_privkey.encode('utf-8'))
+    p2pkh_pubkey_ptr = ct.c_char_p(p2pkh_pubkey.encode('utf-8'))
+
+    # start context
+    lib.dogecoin_ecc_start()
+
+    # call c function
+    res = ct.c_bool()
+    res = lib.verifyPrivPubKeypair(wif_privkey_ptr, p2pkh_pubkey_ptr, ct.c_int(chain_code))
+
+    # stop context
+    lib.dogecoin_ecc_stop()
+
+    # return boolean result
+    return res
+
+
+def verify_master_priv_pub_keypair(wif_privkey_master, p2pkh_pubkey_master, chain_code=0):
+    """Given a keypair from generate_hd_master_pub_key_pair, verify that the
+    keys are valid and are associated with each other.
+    Keyword arguments:
+    wif_privkey_master -- string containing wif-encoded private master key
+    p2pkh_pubkey_master -- string containing address derived from wif_privkey
+    chain_code -- 0 for mainnet, 1 for testnet
+    """
+    # verify arguments are valid
+    assert isinstance(wif_privkey_master, str) and isinstance(p2pkh_pubkey_master, str)
+    assert isinstance(chain_code, int)
+
+    # prepare arguments
+    wif_privkey_master_ptr = ct.c_char_p(wif_privkey_master.encode('utf-8'))
+    p2pkh_pubkey_master_ptr = ct.c_char_p(p2pkh_pubkey_master.encode('utf-8'))
+
+    # start context
+    lib.dogecoin_ecc_start()
+
+    # call c function
+    res = ct.c_bool()
+    res = lib.verifyHDMasterPubKeypair(wif_privkey_master_ptr, p2pkh_pubkey_master_ptr, ct.c_int(chain_code))
+
+    # stop context
+    lib.dogecoin_ecc_stop()
+
+    # return boolean result
+    return res
+
+
+def verify_p2pkh_address(p2pkh_pubkey, chain_code=0):
+    """Given a p2pkh address, confirm address is in correct format and
+    passes simple Shannon entropy threshold
+    Keyword arguments:
+    p2pkh_pubkey -- string containing basic p2pkh address
+    chain_code -- 0 for mainnet, 1 for testnet
+    """
+    # verify arguments are valid
+    assert isinstance(p2pkh_pubkey, str) and isinstance(chain_code, int)
+
+    # prepare arguments
+    p2pkh_pubkey_ptr = ct.c_char_p(p2pkh_pubkey.encode('utf-8'))
+
+    # start context
+    lib.dogecoin_ecc_start()
+
+    # call c function
+    res = ct.c_bool()
+    res = lib.verifyP2pkhAddress(p2pkh_pubkey_ptr, ct.c_int(chain_code))
+
+    # stop context
+    lib.dogecoin_ecc_stop()
+
+    # return boolean result
+    return res
+
+
 #=======================================================TOOLFUNC.C (deprecated)
-class DogecoinChain(ct.Structure):
-    """Class to mimic dogecoin_chain struct from libdogecoin"""
+class DogecoinDNSSeed(ct.Structure):
+    """Class to mimic dogecoin_dns_seed struct from libdogecoin"""
+    _fields_ = [
+        ("domain",                      ct.c_char * 256),
+    ]
+
+class DogecoinChainparams(ct.Structure):
+    """Class to mimic dogecoin_chainparams struct from libdogecoin"""
     _fields_ = [
         ("chainname",                   ct.c_char * 32),
-        ("b58prefix_pubkey_address",    ct.c_ubyte),
-        ("b58prefix_script_address",    ct.c_ubyte),
+        ("b58prefix_pubkey_address",    ct.c_uint8),
+        ("b58prefix_script_address",    ct.c_uint8),
+        ("bech32_hrp",                  ct.c_char * 5),
         ("b58prefix_secret_address",    ct.c_ubyte),
         ("b58prefix_bip32_privkey",     ct.c_uint32),
         ("b58prefix_bip32_pubkey",      ct.c_uint32),
         ("netmagic",                    ct.c_ubyte * 4),
+        ("genesisblockhash",            ct.c_uint8 * 32),
+        ("default port",                ct.c_int),
+        ("dnsseeds",                    DogecoinDNSSeed * 8),
     ]
 
 class DogecoinHDNode(ct.Structure):
@@ -126,123 +248,61 @@ class DogecoinKey(ct.Structure):
 class DogecoinPubkey(ct.Structure):
     """Class to mimic dogecoin_pubkey struct from libdogecoin"""
     _fields_ = [
-        ("compressed",                  ct.c_bool),
+        ("compressed",                  ct.c_ubyte),
         ("pubkey",                      ct.c_ubyte * 65),
     ]
 
-def get_chain(code):
-    """Load info into DogecoinChain object, depending on which net.
-
+def get_chainparams(code):
+    """Load info into DogecoinChainparams object, depending on which net.
     Keyword arguments:
     code -- 0 for mainnet, 1 for testnet, 2 for regtest
     """
-    byte_buf = (ct.c_ubyte * 4)()
+    magic_bytes = (ct.c_ubyte * 4)()
+    genesis_blockhash = (ct.c_uint8 * 32)()
+    dns_seeds = (DogecoinDNSSeed * 8)()
+
+    # TODO: fix dns_seeds part below, no info for now
 
     # main
     if int(code)==0:
-        byte_buf[:] = [0xc0, 0xc0, 0xc0, 0xc0]
-        return DogecoinChain(bytes("main", 'utf-8'),
-                             0x1E, 0x16, 0x9E, 0x02fac398, 0x02facafd, byte_buf)
+        magic_bytes[:] = [0xc0, 0xc0, 0xc0, 0xc0]
+        genesis_blockhash[:] = [0x91, 0x56, 0x35, 0x2c, 0x18, 0x18, 0xb3, 0x2e,
+                                0x90, 0xc9, 0xe7, 0x92, 0xef, 0xd6, 0xa1, 0x1a,
+                                0x82, 0xfe, 0x79, 0x56, 0xa6, 0x30, 0xf0, 0x3b,
+                                0xbe, 0xe2, 0x36, 0xce, 0xda, 0xe3, 0x91, 0x1a]
+
+        dns_seeds = (DogecoinChainparams * 8)()
+        return DogecoinChainparams(bytes("main", 'utf-8'),
+                                   0x1E, 0x16, bytes("doge", 'utf-8'), 0x9E,
+                                   0x02fac398, 0x02facafd,
+                                   magic_bytes, genesis_blockhash, 22556, dns_seeds)
 
     # testnet
     elif int(code)==1:
-        byte_buf[:] = [0xfc, 0xc1, 0xb7, 0xdc]
-        return DogecoinChain(bytes("testnet3", 'utf-8'),
-                             0x71, 0xc4, 0xf1, 0x04358394, 0x043587cf, byte_buf)
+        magic_bytes[:] = [0xfc, 0xc1, 0xb7, 0xdc]
+        genesis_blockhash[:] = [0x9e, 0x55, 0x50, 0x73, 0xd0, 0xc4, 0xf3, 0x64,
+                                0x56, 0xdb, 0x89, 0x51, 0xf4, 0x49, 0x70, 0x4d,
+                                0x54, 0x4d, 0x28, 0x26, 0xd9, 0xaa, 0x60, 0x63,
+                                0x6b, 0x40, 0x37, 0x46, 0x26, 0x78, 0x0a, 0xbb]
+        return DogecoinChainparams(bytes("testnet3", 'utf-8'),
+                                   0x71, 0xc4, bytes("tdge", 'utf-8'), 0xf1,
+                                   0x04358394, 0x043587cf,
+                                   magic_bytes, genesis_blockhash, 44556, dns_seeds)
 
     # regtest
     elif int(code)==2:
-        byte_buf[:] = [0xfa, 0xbf, 0xb5, 0xda]
-        return DogecoinChain(bytes("regtest", 'utf-8'),
-                             0x6f, 0xc4, 0xEF, 0x04358394, 0x043587CF, byte_buf)
+        magic_bytes[:] = [0xfa, 0xbf, 0xb5, 0xda]
+        genesis_blockhash[:] = [0xa5, 0x73, 0xe9, 0x1c, 0x17, 0x72, 0x07, 0x6c,
+                                0x0d, 0x40, 0xf7, 0x0e, 0x44, 0x08, 0xc8, 0x3a,
+                                0x31, 0x70, 0x5f, 0x29, 0x6a, 0xe6, 0xe7, 0x62,
+                                0x9d, 0x4a, 0xdc, 0xb5, 0xa3, 0x60, 0x21, 0x3d]
+        return DogecoinChainparams(bytes("regtest", 'utf-8'),
+                             0x6f, 0xc4, bytes("dcrt", 'utf-8'), 0xEF,
+                             0x04358394, 0x043587CF,
+                             magic_bytes, genesis_blockhash, 18332, dns_seeds)
 
     else:
         print("Bad chain code provided\n")
-
-
-
-def gen_privkey(chain_code):
-    """Generate private key only.
-
-    Keyword arguments:
-    chain_code -- 0 for mainnet, 1 for testnet, 2 for regtest
-    """
-    #start context
-    lib.dogecoin_ecc_start()
-
-    #init constants from chain.h... 0=main, 1=testnet, 2=regtest
-    chain = get_chain(chain_code)
-
-    #prepare arguments
-    sizeout = 128
-    newprivkey_wif = (ct.c_char*sizeout)()
-    newprivkey_hex = (ct.c_char*sizeout)()
-
-    #call gen_privatekey()
-    lib.gen_privatekey.restype = ct.c_bool
-    lib.gen_privatekey(ct.byref(chain), newprivkey_wif, sizeout, newprivkey_hex)
-
-    #stop context
-    lib.dogecoin_ecc_stop()
-
-    #return (wif-encoded private key, private key hex)
-    return (str(bytes(newprivkey_wif).decode('utf-8')), str(bytes(newprivkey_hex).decode('utf-8')))
-
-
-def pubkey_from_privatekey(chain, pkey_wif):
-    """Generate public key given a valid private key.
-
-    Keyword arguments:
-    chain -- DogecoinChain object built from get_chain()
-    pkey_wif -- private key as wif-encoded string
-    """
-    #start context
-    lib.dogecoin_ecc_start()
-
-    #prepare arguments
-    pkey = ct.c_char_p(pkey_wif.encode('utf-8'))
-    size = 128
-    sizeout = ct.c_ulong(size)
-    pubkey_hex = (ct.c_char * size)()
-
-    #call pubkey_from_privatekey()
-    lib.pubkey_from_privatekey.restype = ct.c_bool
-    lib.pubkey_from_privatekey(ct.byref(chain), pkey, ct.byref(pubkey_hex), ct.byref(sizeout))
-
-    #stop context
-    lib.dogecoin_ecc_stop()
-
-    #return pubkey hex
-    return str(bytes(pubkey_hex).decode('utf-8'))
-
-
-def address_from_pubkey(chain_code, pubkey_hex):
-    """Generate dogecoin address given valid public key.
-
-    Keyword arguments:
-    chain_code -- 0 for mainnet, 1 for testnet, 2 for regtest
-    pubkey_hex -- public key as hex-encoded string"""
-
-    #start context
-    lib.dogecoin_ecc_start()
-
-    #init constants from chain.h (0=main, 1=testnet, 2=regtest)
-    chain = get_chain(chain_code)
-
-    #prepare arguments
-    pubkey = ct.c_char_p(pubkey_hex.encode('utf-8'))
-    address = (ct.c_char * 40)() # temporary fix, want ct.c_char_p but causes segfault
-
-    #call address_from_pubkey()
-    lib.address_from_pubkey.restype = ct.c_bool
-    lib.address_from_pubkey(ct.byref(chain), pubkey, ct.byref(address))
-
-    #stop context
-    lib.dogecoin_ecc_stop()
-
-    #return dogecoin address
-    return str(bytes(address).decode('utf-8'))
-
 
 #=======================================================BLOCK.C
 class ConstBuffer(ct.Structure):

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ AC_PROG_CC_C99
 
 CFLAGS="$CFLAGS -W"
 
-warn_CFLAGS="-std=gnu99 -pedantic -Wno-unused-function -Wno-long-long -Wno-overlength-strings"
+warn_CFLAGS="-std=gnu99 -lm -pedantic -Wno-unused-function -Wno-long-long -Wno-overlength-strings"
 saved_CFLAGS="$CFLAGS"
 CFLAGS="$CFLAGS $warn_CFLAGS"
 AC_MSG_CHECKING([if ${CC} supports ${warn_CFLAGS}])

--- a/include/dogecoin/address.h
+++ b/include/dogecoin/address.h
@@ -40,6 +40,15 @@ LIBDOGECOIN_API int generateHDMasterPubKeypair(char* wif_privkey_master, char* p
 /* generate an extended public key */
 LIBDOGECOIN_API int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey);
 
+/* verify private and public keys are valid and associated with each other*/
+LIBDOGECOIN_API int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet);
+
+/* verify private and public masters keys are valid and associated with each other */
+LIBDOGECOIN_API int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
+
+/* verify address based on appearance only */
+LIBDOGECOIN_API int verifyP2pkhAddress(char* p2pkh_pubkey, bool is_testnet);
+
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_ADDRESS_H__

--- a/include/dogecoin/utils.h
+++ b/include/dogecoin/utils.h
@@ -48,6 +48,7 @@ LIBDOGECOIN_API uint8_t* utils_hex_to_uint8(const char* str);
 LIBDOGECOIN_API char* utils_uint8_to_hex(const uint8_t* bin, size_t l);
 LIBDOGECOIN_API void utils_reverse_hex(char* h, int len);
 LIBDOGECOIN_API void utils_uint256_sethex(char* psz, uint8_t* out);
+LIBDOGECOIN_API void utils_calculate_shannon_entropy(const char* str, double *entropy);
 LIBDOGECOIN_API void* safe_malloc(size_t size);
 LIBDOGECOIN_API void dogecoin_cheap_random_bytes(uint8_t* buf, uint32_t len);
 LIBDOGECOIN_API void dogecoin_get_default_datadir(cstring* path_out);

--- a/src/address.c
+++ b/src/address.c
@@ -186,3 +186,76 @@ int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey)
 
     return true;
 }
+
+int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet) {
+    /* require both private and public key */
+    if (!wif_privkey || !p2pkh_pubkey) return false;
+
+    /* set chain */
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+    size_t sizeout = 100;
+
+    /* verify private key */
+    dogecoin_key key;
+    dogecoin_privkey_decode_wif(wif_privkey, chain, &key);
+    if (!dogecoin_privkey_is_valid(&key)) return false;
+    char new_wif_privkey[sizeout];
+    dogecoin_privkey_encode_wif(&key, chain, new_wif_privkey, &sizeout);
+
+    /* verify public key */
+    dogecoin_pubkey pubkey;
+    dogecoin_pubkey_init(&pubkey);
+    dogecoin_pubkey_from_key(&key, &pubkey);
+    if (!dogecoin_pubkey_is_valid(&pubkey)) return false;
+
+    /* verify address derived matches provided address */
+    char new_p2pkh_pubkey[sizeout];
+    dogecoin_pubkey_getaddr_p2pkh(&pubkey, chain, new_p2pkh_pubkey);
+    if (strcmp(p2pkh_pubkey, new_p2pkh_pubkey)) return false;
+
+    return true;
+}
+
+int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet) {
+    /* require both private and public key */
+    if (!wif_privkey_master || !p2pkh_pubkey_master) return false;
+
+    /* determine if mainnet or testnet/regtest */
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+
+    /* validate private key */
+    // dogecoin_key key;
+    // dogecoin_privkey_init(&key);
+    // dogecoin_privkey_decode_wif(wif_privkey_master, chain, &key);
+    // if (!dogecoin_privkey_is_valid(&key)) {
+    //     printf("validate method does not apply to hd master\n");
+    //     return false;
+    // }
+
+    /* calculate master pubkey from master privkey */
+    dogecoin_hdnode node;
+    dogecoin_hdnode_deserialize(wif_privkey_master, chain, &node);
+    size_t sizeout = 128;
+    char new_p2pkh_pubkey_master[sizeout];
+    dogecoin_hdnode_get_p2pkh_address(&node, chain, new_p2pkh_pubkey_master, sizeout);
+
+    /* compare derived and given pubkeys */
+    if (strcmp(p2pkh_pubkey_master, new_p2pkh_pubkey_master)) return false;
+
+    return true;
+}
+
+int verifyP2pkhAddress(char* p2pkh_pubkey, bool is_testnet) {
+    /* check length */
+    if (strlen(p2pkh_pubkey) != 34) return false;
+
+    /* check first character */
+    if (p2pkh_pubkey[0] != (is_testnet ? 'n' : 'D')) return false;
+
+    /* check randomness */
+    double entropy;
+    utils_calculate_shannon_entropy(p2pkh_pubkey, &entropy);
+    if (entropy < 0.12244) return false;
+
+    return true;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <math.h>
 
 #include <dogecoin/mem.h>
 #include <dogecoin/utils.h>
@@ -236,6 +237,24 @@ void utils_uint256_sethex(char* psz, uint8_t* out)
             p1++;
         }
     }
+}
+
+void utils_calculate_shannon_entropy(const char* str, double *metricEntropy) {
+    int tableSize = 100;
+    int freqTable[tableSize];
+    int len = (int) strlen(str);
+    for (int i=0; i<tableSize; i++) freqTable[i] = 0; // all freqs start at 0
+    for (int i=0; i<len; i++) {
+        char c = str[i];
+        freqTable[c-48]++;  // increment the frequency upon occurrence
+    }
+    double sumTotal = 0;
+    double frequency;
+    for (int i=0; i<tableSize; i++) {
+        frequency = freqTable[i]/(double)len;
+        if (frequency) sumTotal += frequency * (log(frequency)/log(2));
+    }
+    *metricEntropy = (sumTotal * (-1))/(double)len;
 }
 
 void* safe_malloc(size_t size)

--- a/test/address_tests.c
+++ b/test/address_tests.c
@@ -14,24 +14,74 @@
 
 void test_address()
 {
-    size_t privkeywiflen = 100;
-    char privkeywif[privkeywiflen];
-    char p2pkh_wif[36];
-    u_assert_int_eq(generatePrivPubKeypair(privkeywif, p2pkh_wif, false), true)
-    u_assert_int_eq(generatePrivPubKeypair(privkeywif, NULL, false), true)
+    size_t privkeywiflen = 100;    
+    char privkeywif_main[privkeywiflen];
+    char privkeywif_test[privkeywiflen];
+    char p2pkh_pubkey_main[DOGECOIN_ECKEY_COMPRESSED_LENGTH];
+    char p2pkh_pubkey_test[DOGECOIN_ECKEY_COMPRESSED_LENGTH];
 
+    // test generation ability
+    u_assert_int_eq(generatePrivPubKeypair(privkeywif_main, NULL, false), true)
+    u_assert_int_eq(generatePrivPubKeypair(privkeywif_main, p2pkh_pubkey_main, false), true)
+    u_assert_int_eq(generatePrivPubKeypair(privkeywif_test, p2pkh_pubkey_test, true), true);
+
+    // test keypair validity and association
+    u_assert_int_eq(verifyPrivPubKeypair(privkeywif_main, p2pkh_pubkey_main, false), true);
+    u_assert_int_eq(verifyPrivPubKeypair(privkeywif_test, p2pkh_pubkey_test, true), true);
+    u_assert_int_eq(verifyPrivPubKeypair(privkeywif_main, p2pkh_pubkey_main, true), false);
+    u_assert_int_eq(verifyPrivPubKeypair(privkeywif_test, p2pkh_pubkey_test, false), false);
+    u_assert_int_eq(verifyPrivPubKeypair(privkeywif_main, p2pkh_pubkey_test, false), false);
+    u_assert_int_eq(verifyPrivPubKeypair("QWgNKvA5LPD1HpopRFghjz6jPipHRAUrLjqTt7paxYX8cTbu5eRs", "D7AM5jDQ7xRRK7bMCZ87e4BsFxHxCdDbXd", false), true);
+    u_assert_int_eq(verifyPrivPubKeypair("QWgNKvA5LPD1HpopRFghjz6jPipHRAUrLjqTt7paxYX8cTbu5eRs", "DCncxpcZW3GEyqs17KrqAfs4cR844JkimG", false), false);
+
+    // test entropy check
+    u_assert_int_eq(verifyP2pkhAddress("Dasdfasdfasdfasdfasdfasdfasdfasdfx", false), false);
+    u_assert_int_eq(verifyP2pkhAddress("DP6xxxDJxxxJAaWucRfsPvXLPGRyF3DdeP", false), false);
+
+    // test address format correctness (0.3% false negative rate)
+    u_assert_int_eq(verifyP2pkhAddress(p2pkh_pubkey_main, false), true);
+    u_assert_int_eq(verifyP2pkhAddress(p2pkh_pubkey_test, true), true);
+    u_assert_int_eq(verifyP2pkhAddress(p2pkh_pubkey_main, true), false);
+    u_assert_int_eq(verifyP2pkhAddress(p2pkh_pubkey_test, false), false);
+
+    // test master key generation ability
     size_t masterkeysize = 200;
-    char masterkey[masterkeysize];
-    u_assert_int_eq(generateHDMasterPubKeypair(masterkey, NULL, false), true)
+    char masterkey_main[masterkeysize];
+    char masterkey_test[masterkeysize];
+    char p2pkh_master_pubkey_main[DOGECOIN_ECKEY_COMPRESSED_LENGTH];
+    char p2pkh_master_pubkey_test[DOGECOIN_ECKEY_COMPRESSED_LENGTH];
+    u_assert_int_eq(generateHDMasterPubKeypair(masterkey_main, NULL, false), true)
     u_assert_int_eq(generateHDMasterPubKeypair(NULL, NULL, false), true)
     u_assert_int_eq(generateHDMasterPubKeypair(NULL, NULL, NULL), true)
+    u_assert_int_eq(generateHDMasterPubKeypair(masterkey_main, p2pkh_master_pubkey_main, false), true);
+    u_assert_int_eq(generateHDMasterPubKeypair(masterkey_test, p2pkh_master_pubkey_test, true), true);
     
-    u_assert_int_eq(generateDerivedHDPubkey(masterkey, NULL), true)
+    // test child key derivation ability
+    char child_key_main[DOGECOIN_ECKEY_COMPRESSED_LENGTH];
+    char child_key_test[DOGECOIN_ECKEY_COMPRESSED_LENGTH];
+    u_assert_int_eq(generateDerivedHDPubkey(masterkey_main, NULL), true)
     u_assert_int_eq(generateDerivedHDPubkey(NULL, NULL), false)
+    u_assert_int_eq(generateDerivedHDPubkey(masterkey_main, child_key_main), true);
+    u_assert_int_eq(generateDerivedHDPubkey(masterkey_test, child_key_test), true);
+
+    // test master keypair validity and association
+    u_assert_int_eq(verifyHDMasterPubKeypair(masterkey_main, child_key_main, false), true);
+    // u_assert_int_eq(verifyHDMasterPubKeypair(masterkey_test, child_key_test, true), true);
+    u_assert_int_eq(verifyHDMasterPubKeypair("dgpv51eADS3spNJh7z2oc8LgNLeJiwiPNgdEFcdtAhtCqDQ76SwphcQq74jZCRTZ2nF5RpmKx9P4Mm55RTopNQePWiSBfzyJ3jgRoxVbVLF6BCY", "DJt45oTXDxBiJBRZeMtXm4wu4kc5yPePYn", false), true);
+    u_assert_int_eq(verifyHDMasterPubKeypair("dgpv51eADS3spNJh7z2oc8LgNLeJiwiPNgdEFcdtAhtCqDQ76SwphcQq74jZCRTZ2nF5RpmKx9P4Mm55RTopNQePWiSBfzyJ3jgRoxVbVLF6BCY", "DDDXCMUCXCFK3UHXsjqSkzwoqt79K6Rn6k", false), false);
+
+    // test hd address format correctness
+    u_assert_int_eq(verifyP2pkhAddress(p2pkh_master_pubkey_main, false), true);
+    // u_assert_int_eq(verifyP2pkhAddress(p2pkh_master_pubkey_test, true), true);
+
+    // test derived hd address format correctness
+    u_assert_int_eq(generateDerivedHDPubkey(masterkey_main, child_key_main), true);
+    u_assert_int_eq(verifyP2pkhAddress(child_key_main, false), true);
+    u_assert_int_eq(generateDerivedHDPubkey(masterkey_test, child_key_test), true);
+    //u_assert_int_eq(verifyP2pkhAddress(child_key_test, true), true);
     
     size_t strsize = 128;
     char str[strsize];
-
     u_assert_int_eq(generateDerivedHDPubkey("dgpv51eADS3spNJhA6LG5QycrFmQQtxg7ztFJQuamYiytZ4x4FUC7pG5B7fUTHBDB7g6oGaCVwuGF2i75r1DQKyFSauAHUGBAi89NaggpdUP3yK", str), true)
     u_assert_str_eq("DEByFfUQ3AxcFFet9afr8wxxedQysRduWN", str);
 


### PR DESCRIPTION
This branch features 2 new functions in address.c:

    verifyPrivPubKeypair(), which takes a keypair as input and returns a boolean whether the provided private and public key are both valid and associated with each other
    verifyP2pkhAddress(), which takes a p2pkh address only as input and returns a boolean whether the simple p2pkh address is formatted correctly and checks whether the entropy is above a certain threshold (0.3% false negative rate currently)

verifyPrivPubKeypair() is much more reliable as it validates the low-level building blocks of the keypair. verifyP2pkhAddress() is only a surface level evaluation of whether a p2pkh address "looks right"... not to be treated as an official verification method but as more of a placeholder for when we decide the rules for valid dogecoin addresses.

Additionally, there are now wrappers for these functions in bindings/py_wrappers/wrappers.py along with unit tests for these.
