### PR TITLE
Fixing unit_tests - Increase size of char array

### DIFF
--- a/test/address_tests.c
+++ b/test/address_tests.c
@@ -17,8 +17,8 @@ void test_address()
     size_t privkeywiflen = 53;  
     char privkeywif_main[privkeywiflen];
     char privkeywif_test[privkeywiflen];
-    char p2pkh_pubkey_main[33];
-    char p2pkh_pubkey_test[33];
+    char p2pkh_pubkey_main[35];
+    char p2pkh_pubkey_test[35];
     memset(privkeywif_main, 0, privkeywiflen);
     memset(privkeywif_test, 0, privkeywiflen);
     // test generation ability


### PR DESCRIPTION
Unit tests failed on Mac M1.
By increasing the array size to 35 all tests pass.

Will take a look on the reason why it is failing on Mac.

