### PR TITLE
ci: fix apt-get update step for i686-w64-mingw32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           - name: x86_64-win
             host: x86_64-w64-mingw32
             arch: i386
-            os: ubuntu-20.04
+            os: ubuntu-18.04
             packages: python3 nsis g++-mingw-w64-x86-64 wine64 wine-stable bc wine-binfmt
             postinstall: |
               sudo dpkg -s mono-runtime && sudo apt-get remove mono-runtime || echo "Very nothing to uninstall."
@@ -82,7 +82,7 @@ jobs:
           - name: i686-win
             host: i686-w64-mingw32
             arch: i386
-            os: ubuntu-20.04
+            os: ubuntu-18.04
             packages: python3 nsis g++-mingw-w64 wine32 wine-stable bc wine-binfmt
             postinstall: |
               sudo dpkg -s mono-runtime && sudo apt-get remove mono-runtime || echo "Very nothing to uninstall."
@@ -117,16 +117,8 @@ jobs:
               brew install automake coreutils python3 ${{ matrix.packages }}
               echo PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH" >> ~/.bashrc
               source ~/.bashrc
-
           else
-            if ([ "${{ matrix.name }}" == "x86_64-win" ] || [ "${{ matrix.name }}" == "i686-win" ]); then
-              sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
-              sudo add-apt-repository 'deb [arch=amd64] https://mirror.mxe.cc/repos/apt focal main'
-              sudo apt -qq update
-              sudo apt install -y --allow-downgrades libpcre2-8-0=10.34-7
-            else
-              sudo apt-get update
-            fi
+            sudo apt-get update
             DEBIAN_FRONTEND=noninteractive sudo apt-get install -y autoconf automake libtool-bin libevent-dev build-essential curl python3 valgrind ${{ matrix.packages }}
           fi
 


### PR DESCRIPTION
revert i686/x86_64-w64-mingw32 to run on bionic after libwine:i386 workaround broke.