### PR TITLE
tx: remove bloat from dogecoin_tx_sign_input

### DIFF
--- a/doc/tools.md
+++ b/doc/tools.md
@@ -35,10 +35,9 @@ Most of these commands require a flag following them to denote things like exist
 | -m, --derived_path | derived_path        | yes | derive_child_key -p <extended_private_key> -m <derived_path> |
 | -t, --testnet  | designate_testnet   | no  | generate_private_key -t |
 | -s  | script_hex          | yes | comp2der -s <compact_signature> |
-| -x  | transaction_hex     | yes | sign -x <transaction_hex> -s <pubkey_script> -i <index_of_utxo_to_sign> -h <sig_hash_type> -a <amount_in_utxo> |
+| -x  | transaction_hex     | yes | sign -x <transaction_hex> -s <pubkey_script> -i <index_of_utxo_to_sign> -h <sig_hash_type> |
 | -i  | input_index         | yes | see above |
 | -h  | sighash_type        | yes | see above |
-| -a  | amount              | yes | see above |
 
 Below is a list of all the commands and the flags that they require. As a reminder, any command that includes the `-t` flag will set the default chain used in internal calculations to _testnet_ rather than _mainnet_. Also included are descriptions of what each function does.
 
@@ -51,7 +50,7 @@ Below is a list of all the commands and the flags that they require. As a remind
 | bip32maintotest           | -p                     | None | Convert a mainnet private key into an equivalent testnet key. |
 | derive_child_keys         | -p, -m                 | -t   | Generates a child key derived from the specified private key using the specified derivation path. 
 | print_keys                | -p                     | -t   | Print all keys associated with the provided private key.
-| sign                      | -x, -s, -i, -h, -a, -p | -t   | See the definition of sign_raw_transaction in the Transaction API.
+| sign                      | -x, -s, -i, -h, -p     | -t   | See the definition of sign_raw_transaction in the Transaction API.
 | comp2der                  | -s                     | None | Convert a compact signature to a DER signature.
 | transaction               | None                   | None | Start the interactive transaction app. [Usage instructions below.]() |
 

--- a/doc/transaction.md
+++ b/doc/transaction.md
@@ -456,8 +456,8 @@ int main() {
     //sign both inputs of the current finalized transaction
     dogecoin_ecc_start();
     char* rawhex = get_raw_transaction(index);
-    sign_raw_transaction(0, rawhex, my_script_pubkey, 1, "2.0", my_privkey);
-    sign_raw_transaction(1, rawhex, my_script_pubkey, 1, "10.0", my_privkey);
+    sign_raw_transaction(0, rawhex, my_script_pubkey, 1, my_privkey);
+    sign_raw_transaction(1, rawhex, my_script_pubkey, 1, my_privkey);
     dogecoin_ecc_stop();
     printf("The final signed transaction hex is: %s\n", rawhex);
     clear_transaction(index);
@@ -472,7 +472,6 @@ prev_output_txid_2 = "b4455e7b7b7acb51fb6feba7a2702c42a5100f61f61abafa31851ed6ae
 prev_output_txid_10 = "42113bdc65fc2943cf0359ea1a24ced0b6b0b5290db4c63a3329c6601c4616e2" # worth 10 dogecoin
 prev_output_n_2 = 1
 prev_output_n_10 = 1
-amounts = ["2.0", "10.0"]
 external_address = "nbGfXLskPh7eM1iG5zz5EfDkkNTo9TRmde"
 my_address = "noxKJyGPugPRN4wqvrwsrtYXuQCk7yQEsy"
 my_script_pubkey = "76a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac"
@@ -487,8 +486,8 @@ l.w_finalize_transaction(index, external_address, "0.00226", "12.0", my_address)
 # sign both inputs of the current finalized transaction
 l.context_start()
 rawhex = l.w_get_raw_transaction(index)
-half_signed_hex = l.w_sign_raw_transaction(0, rawhex, my_script_pubkey, 1, "2.0", my_privkey)
-full_signed_hex = l.w_sign_raw_transaction(1, half_signed_hex, my_script_pubkey, 1, "10.0", my_privkey)
+half_signed_hex = l.w_sign_raw_transaction(0, rawhex, my_script_pubkey, 1, my_privkey)
+full_signed_hex = l.w_sign_raw_transaction(1, half_signed_hex, my_script_pubkey, 1, my_privkey)
 print("The final signed transaction hex is:", full_signed_hex)
 l.context_stop()
 l.w_clear_transaction(index)
@@ -524,8 +523,8 @@ func main() {
 	// sign both inputs of the current finalized transaction
 	libdogecoin.W_context_start()
     rawhex := libdogecoin.W_get_raw_transaction(index)
-	half_signed_hex := libdogecoin.W_sign_raw_transaction(0, rawhex, my_script_pubkey, 1, "2.0", my_privkey)
-    full_signed_hex := libdogecoin.W_sign_raw_transaction(1, half_signed_hex, my_script_pubkey, 1, "10.0", my_privkey)
+	half_signed_hex := libdogecoin.W_sign_raw_transaction(0, rawhex, my_script_pubkey, 1, my_privkey)
+    full_signed_hex := libdogecoin.W_sign_raw_transaction(1, half_signed_hex, my_script_pubkey, 1, my_privkey)
 	libdogecoin.W_context_stop()
 	fmt.Printf("The final signed transaction hex is: %s.\n", full_signed_hex)
 }
@@ -550,7 +549,6 @@ int main() {
     char* prev_output_txid_10 = "42113bdc65fc2943cf0359ea1a24ced0b6b0b5290db4c63a3329c6601c4616e2"; // worth 10 dogecoin
     int prev_output_n_2 = 1;
     int prev_output_n_10 = 1;
-    char* amounts[] = {"2", "10"};
     char* external_address = "nbGfXLskPh7eM1iG5zz5EfDkkNTo9TRmde";
     char* my_address = "noxKJyGPugPRN4wqvrwsrtYXuQCk7yQEsy";
     char* my_script_pubkey = "76a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac";
@@ -564,7 +562,7 @@ int main() {
 
     //sign both inputs of the current finalized transaction
     dogecoin_ecc_start();
-    if (!sign_transaction(index, amounts, my_script_pubkey, my_privkey)) {
+    if (!sign_transaction(index, my_script_pubkey, my_privkey)) {
         // error handling here
     }
     dogecoin_ecc_stop();
@@ -581,7 +579,6 @@ prev_output_txid_2 = "b4455e7b7b7acb51fb6feba7a2702c42a5100f61f61abafa31851ed6ae
 prev_output_txid_10 = "42113bdc65fc2943cf0359ea1a24ced0b6b0b5290db4c63a3329c6601c4616e2" # worth 10 dogecoin
 prev_output_n_2 = 1
 prev_output_n_10 = 1
-amounts = [2.0, 10.0]
 external_address = "nbGfXLskPh7eM1iG5zz5EfDkkNTo9TRmde"
 my_address = "noxKJyGPugPRN4wqvrwsrtYXuQCk7yQEsy"
 my_script_pubkey = "76a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac"
@@ -595,7 +592,7 @@ l.w_finalize_transaction(index, external_address, "0.00226", "12.0", my_address)
 
 # sign both inputs of the current finalized transaction
 l.context_start()
-if not l.w_sign_transaction(index, amounts, my_script_pubkey, my_privkey):
+if not l.w_sign_transaction(index, my_script_pubkey, my_privkey):
     # error handling here
 l.context_stop()
 print("The final signed transaction hex is:", l.w_get_raw_transaction(index))
@@ -616,7 +613,6 @@ func main() {
     prev_output_txid_10 := "42113bdc65fc2943cf0359ea1a24ced0b6b0b5290db4c63a3329c6601c4616e2" // worth 10 dogecoin
     prev_output_n_2 := 1
     prev_output_n_10 := 1
-    amounts := []string{"2.0", "10.0"}
     external_address := "nbGfXLskPh7eM1iG5zz5EfDkkNTo9TRmde"
     my_address := "noxKJyGPugPRN4wqvrwsrtYXuQCk7yQEsy"
     my_script_pubkey := "76a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac"
@@ -630,7 +626,7 @@ func main() {
     libdogecoin.W_finalize_transaction(index, external_address, "0.00226", "12.0", my_address)
 
     // sign both inputs of the current finalized transaction
-    if libdogecoin.W_sign_transaction(index, amounts, my_script_pubkey, my_privkey)!=1:
+    if libdogecoin.W_sign_transaction(index, my_script_pubkey, my_privkey)!=1:
         // error handling here
     fmt.Println("The final signed transaction hex is:", libdogecoin.W_get_raw_transaction(index))
 }

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -76,8 +76,8 @@ int add_output(int txindex, char* destinationaddress, char* amount);
 /* re-specify the amount in dogecoin for verification, and change address for change. If not specified, change will go to the first utxo's address. */
 char* finalize_transaction(int txindex, char* destinationaddress, char* subtractedfee, char* out_dogeamount_for_verification, char* changeaddress);
 
-/* sign a raw transaction in memory at (txindex), sign (inputindex) with (scripthex) of (sighashtype) for (amount - koinu? dogecoin? why a 3rd time), with (privkey) */
-int sign_transaction(int txindex, char* amounts[], char* script_pubkey, char* privkey);
+/* sign a raw transaction in memory at (txindex), sign (inputindex) with (scripthex) of (sighashtype), with (privkey) */
+int sign_transaction(int txindex, char* script_pubkey, char* privkey);
 
 /* clear all internal working transactions */
 void remove_all();
@@ -92,8 +92,8 @@ void clear_transaction(int txindex);
 --------------------------------------------------------------------------
 */
 
-/*Sign a raw transaction hexadecimal string using inputindex, scripthex, sighashtype, amount and privkey. */
-int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, char* amount, char* privkey);
+/*Sign a raw transaction hexadecimal string using inputindex, scripthex, sighashtype and privkey. */
+int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, char* privkey);
 
 /*Store a raw transaction that's already formed, and give it a txindex in memory. (txindex) is returned as int. */
 int store_raw_transaction(char* incomingrawtx);

--- a/include/dogecoin/transaction.h
+++ b/include/dogecoin/transaction.h
@@ -29,7 +29,6 @@
 #include <stdio.h>     /* printf       */
 #include <string.h>    /* memset       */
 #include <uthash/uthash.h>
-
 #include <dogecoin/dogecoin.h>
 #include <dogecoin/tx.h>
 
@@ -88,11 +87,11 @@ LIBDOGECOIN_API void clear_transaction(int txindex); // #clears a tx in memory. 
 // sign a given inputted transaction with a given private key, and return a hex signed transaction.
 // we may want to add such things to 'advanced' section:
 // locktime, possibilities for multiple outputs, data, sequence.
-LIBDOGECOIN_API int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, char* amount, char* privkey);
+LIBDOGECOIN_API int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, char* privkey);
 
-LIBDOGECOIN_API int sign_indexed_raw_transaction(int txindex, int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, char* amount, char* privkey);
+LIBDOGECOIN_API int sign_indexed_raw_transaction(int txindex, int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, char* privkey);
 
-LIBDOGECOIN_API int sign_transaction(int txindex, char* amounts[], char* script_pubkey, char* privkey);
+LIBDOGECOIN_API int sign_transaction(int txindex, char* script_pubkey, char* privkey);
 
 LIBDOGECOIN_API int store_raw_transaction(char* incomingrawtx);
 

--- a/include/dogecoin/tx.h
+++ b/include/dogecoin/tx.h
@@ -123,9 +123,9 @@ LIBDOGECOIN_API int dogecoin_tx_deserialize(const unsigned char* tx_serialized, 
 //!serialize a dogecoin data structure into a p2p serialized buffer
 LIBDOGECOIN_API void dogecoin_tx_serialize(cstring* s, const dogecoin_tx* tx);
 
-LIBDOGECOIN_API void dogecoin_tx_hash(const dogecoin_tx* tx, uint8_t* hashout);
+LIBDOGECOIN_API void dogecoin_tx_hash(const dogecoin_tx* tx, uint256 hashout);
 
-LIBDOGECOIN_API dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, unsigned int in_num, int hashtype, const uint64_t amount, const enum dogecoin_sig_version sigversion, uint8_t* hash);
+LIBDOGECOIN_API dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, unsigned int in_num, int hashtype, uint256 hash);
 
 LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_address_out(dogecoin_tx* tx, const dogecoin_chainparams* chain, int64_t amount, const char* address);
 LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_p2sh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160 hash160);
@@ -149,7 +149,7 @@ enum dogecoin_tx_sign_result {
     DOGECOIN_SIGN_OK = 1,
 };
 const char* dogecoin_tx_sign_result_to_str(const enum dogecoin_tx_sign_result result);
-enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, uint64_t amount, const dogecoin_key* privkey, int inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, int* sigder_len);
+enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, const dogecoin_key* privkey, int inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, int* sigder_len);
 
 LIBDOGECOIN_END_DECL
 

--- a/src/script.c
+++ b/src/script.c
@@ -489,7 +489,6 @@ enum dogecoin_tx_out_type dogecoin_script_classify(const cstring* script, vector
     if (dogecoin_script_is_multisig(ops))
         tx_out_type = DOGECOIN_TX_MULTISIG;
 
-    uint8_t version = 0;
     vector_free(ops, true);
     return tx_out_type;
 }
@@ -687,22 +686,4 @@ const char* dogecoin_tx_out_type_to_str(const enum dogecoin_tx_out_type type)
     } else {
         return "TX_NONSTANDARD";
     }
-}
-
-
-/**
- * @brief This function takes a small int opcode and
- * translates it back into an unsigned byte.
- * 
- * @param op The opcode to translate.
- * 
- * @return The numerical value of the opcode as an unsigned byte.
- */
-static uint8_t dogecoin_decode_op_n(enum opcodetype op)
-{
-    if (op == OP_0) {
-        return 0;
-    }
-    assert(op >= OP_1 && op <= OP_16);
-    return (uint8_t)op - (uint8_t)(OP_1 - 1);
 }

--- a/src/tx.c
+++ b/src/tx.c
@@ -978,13 +978,11 @@ void dogecoin_tx_outputs_hash(const dogecoin_tx* tx, uint256 hash)
  * @param fromPubKey The pointer to the cstring containing the public key of the sender.
  * @param in_num The index of the input being signed.
  * @param hashtype The type of signature hash to perform.
- * @param amount The amount to be sent over this transaction.
- * @param sigversion The signature version.
  * @param hash The generated signature hash.
  * 
  * @return 1 if signature hash is generated successfully, 0 otherwise.
  */
-dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, unsigned int in_num, int hashtype, const uint64_t amount, const enum dogecoin_sig_version sigversion, uint256 hash)
+dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, unsigned int in_num, int hashtype, uint256 hash)
 {
     if (in_num >= tx_to->vin->len || !tx_to->vout) {
         return false;
@@ -1289,7 +1287,6 @@ const char* dogecoin_tx_sign_result_to_str(const enum dogecoin_tx_sign_result re
  * 
  * @param tx_in_out The pointer to the transaction to be signed.
  * @param script The pointer to the cstring containing the script to be signed.
- * @param amount The amount that will be sent in the transaction.
  * @param privkey The pointer to the private key to be used to sign the transaction.
  * @param inputindex The index of the input in the transaction.
  * @param sighashtype The type of signature hash to use.
@@ -1299,7 +1296,7 @@ const char* dogecoin_tx_sign_result_to_str(const enum dogecoin_tx_sign_result re
  * 
  * @return The code denoting which errors occurred, if any.
  */
-enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, uint64_t amount, const dogecoin_key* privkey, int inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, int* sigder_len_out)
+enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, const dogecoin_key* privkey, int inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, int* sigder_len_out)
 {
     if (!tx_in_out || !script) {
         return DOGECOIN_SIGN_INVALID_TX_OR_SCRIPT;
@@ -1327,7 +1324,6 @@ enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, cons
     vector* script_pushes = vector_new(1, free);
 
     enum dogecoin_tx_out_type type = dogecoin_script_classify(script, script_pushes);
-    enum dogecoin_sig_version sig_version = SIGVERSION_BASE;
     if (type == DOGECOIN_TX_PUBKEYHASH && script_pushes->len == 1) {
         // check if given private key matches the script
         uint160 hash160;
@@ -1344,7 +1340,7 @@ enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, cons
 
     uint256 sighash;
     dogecoin_mem_zero(sighash, sizeof(sighash));
-    if (!dogecoin_tx_sighash(tx_in_out, script_sign, inputindex, sighashtype, amount, sig_version, sighash)) {
+    if (!dogecoin_tx_sighash(tx_in_out, script_sign, inputindex, sighashtype, sighash)) {
         cstr_free(script_sign, true);
         return DOGECOIN_SIGN_SIGHASH_FAILED;
     }

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -288,8 +288,7 @@ void test_transaction()
     // validate external p2pkh address by converting script hash to p2pkh and asserting equal:
     char* raw_hexadecimal_transaction  = finalize_transaction(working_transaction_index, external_p2pkh_address, ".00226", "12.0", internal_p2pkh_address);
 
-    char* input_amounts[] = {"2.0", "10.0"};
-    u_assert_int_eq(sign_transaction(working_transaction_index, input_amounts, utxo_scriptpubkey, private_key_wif), 1);
+    u_assert_int_eq(sign_transaction(working_transaction_index, utxo_scriptpubkey, private_key_wif), 1);
     u_assert_str_eq(raw_hexadecimal_transaction, expected_signed_raw_hexadecimal_transaction);
 
     // ----------------------------------------------------------------
@@ -309,8 +308,7 @@ void test_transaction()
     // validate external p2pkh address by converting script hash to p2pkh and asserting equal:
     raw_hexadecimal_transaction  = finalize_transaction(working_transaction_index, external_p2pkh_address, ".00113", "10.0", internal_p2pkh_address);
 
-    char* input_amounts2[] = {"10.0"};
-    u_assert_int_eq(sign_transaction(working_transaction_index, input_amounts2, utxo_scriptpubkey, private_key_wif), 1);
+    u_assert_int_eq(sign_transaction(working_transaction_index, utxo_scriptpubkey, private_key_wif), 1);
     u_assert_str_eq(raw_hexadecimal_transaction, expected_single_utxo_signed_transaction);
 
     // ----------------------------------------------------------------
@@ -362,7 +360,7 @@ void test_transaction()
 
     // sign current working transaction input index 0 of raw tx hex with script pubkey from utxo with sighash type of 1 (SIGHASH_ALL),
     // amount of 2 dogecoin represented as koinu (multiplied by 100 million) and with private key in wif format
-    u_assert_int_eq(sign_raw_transaction(0, raw_hexadecimal_transaction, utxo_scriptpubkey, 1, "2.0", private_key_wif), 1);
+    u_assert_int_eq(sign_raw_transaction(0, raw_hexadecimal_transaction, utxo_scriptpubkey, 1, private_key_wif), 1);
 
     // assert that our hexadecimal buffer (raw_hexadecimal_transaction) is equal to the expected transaction
     // with the first input signed:
@@ -372,7 +370,7 @@ void test_transaction()
 
     // sign current working transaction input index 1 of raw tx hex with script pubkey from utxo with sighash type of 1 (SIGHASH_ALL),
     // amount of 10 dogecoin represented as koinu (multiplied by 100 million) and with private key in wif format
-    u_assert_int_eq(sign_raw_transaction(1, raw_hexadecimal_transaction, utxo_scriptpubkey, 1, "10", private_key_wif), 1);
+    u_assert_int_eq(sign_raw_transaction(1, raw_hexadecimal_transaction, utxo_scriptpubkey, 1, private_key_wif), 1);
 
     // assert that our hexadecimal bufer (raw_hexadecimal_transaction) is equal to the expected finalized
     // transaction with both inputs signed:

--- a/test/tx_tests.c
+++ b/test/tx_tests.c
@@ -831,7 +831,7 @@ void test_tx_sighash_ext()
         utils_hex_to_bin(txvalid_sighash[i].script, script_data, strlen(txvalid_sighash[i].script), &outlen_sighash);
         cstring* str = cstr_new_buf(script_data, outlen_sighash);
         uint256 hash;
-        dogecoin_tx_sighash(tx_sighash, str, txvalid_sighash[i].i, SIGHASH_ALL, txvalid_sighash[i].amount, SIGVERSION_BASE, hash);
+        dogecoin_tx_sighash(tx_sighash, str, txvalid_sighash[i].i, SIGHASH_ALL, hash);
 
         dogecoin_tx_free(tx_sighash);
         cstr_free(str, true);
@@ -863,7 +863,7 @@ void test_tx_sighash()
         cstring* script = cstr_new_buf(script_data, outlen);
         uint256 sighash;
         dogecoin_mem_zero(sighash, sizeof(sighash));
-        dogecoin_tx_sighash(tx, script, test->inputindex, test->hashtype, 0, SIGVERSION_BASE, sighash);
+        dogecoin_tx_sighash(tx, script, test->inputindex, test->hashtype, sighash);
 
         vector* vec = vector_new(10, dogecoin_script_op_free_cb);
         dogecoin_script_get_ops(script, vec);
@@ -1062,7 +1062,7 @@ void test_script_parse()
 
     uint8_t sigdata[38] = {0x42, 0x49, 0x50, 0x00, 0x00, 0x00, 0x00};
 
-    dogecoin_hash(rev_code, DOGECOIN_HASH_LENGTH, &sigdata[7]);
+    dogecoin_hash(rev_code, DOGECOIN_HASH_LENGTH, &sigdata[7] - 1);
 
     dogecoin_hash(sigdata, sizeof(sigdata), sig_hash);
 
@@ -1139,7 +1139,6 @@ void test_tx_sign_p2pkh(dogecoin_tx* tx)
     const char* pkey_wif = "cRpSdivawavdAPgEYGXusWt64cJG9zLcgDPsEvnhHWtizVtmGk5b";
     const char* expected_sigder = "304402205d44c682a69da1ca10e1149548bf7e7b53f0ce8f2d2bd2ea74026cba57cd4fe702200e0f9d87aafa1c88697238aaf1059b7718a97ff681efe474097221d456eb7ea201";
     const char* expected_tx_signed = "02000000027409797c31feecc4e69b51c58b477b72c53355743a6f6124f9d78221672df370010000006a47304402205d44c682a69da1ca10e1149548bf7e7b53f0ce8f2d2bd2ea74026cba57cd4fe702200e0f9d87aafa1c88697238aaf1059b7718a97ff681efe474097221d456eb7ea2012102c5b9d2d528f13b7b745736f6fd198614a09200c3c5cb0554327e110b4a8efcf1ffffffff6e1709c1e2bdd85aed24dccfd48293993617f249d4d4381296a9c914be3e85e60100000000ffffffff01c07fdc0b0000000017a914ba277fd56b69177464fcb6a27a530f03740345ed8700000000";
-    uint64_t amount = 100000000;
     int sighashtype = SIGHASH_ALL;
     int inputindex = 0;
 
@@ -1164,7 +1163,7 @@ void test_tx_sign_p2pkh(dogecoin_tx* tx)
     uint8_t sigcomp[64] = {0};
     uint8_t sigder[76] = {0};
     int sigder_len = 0;
-    dogecoin_tx_sign_input(tx, script, amount, &pkey, inputindex, sighashtype, sigcomp, sigder, &sigder_len);
+    dogecoin_tx_sign_input(tx, script, &pkey, inputindex, sighashtype, sigcomp, sigder, &sigder_len);
     u_assert_mem_eq(sigder, expected_sigder_data, sigder_len);
 
     cstring* tx_ser = cstr_new_sz(1024);
@@ -1186,7 +1185,6 @@ void test_tx_sign_p2pkh_i2(dogecoin_tx* tx)
     const char* pkey_wif = "cS8Xxe3MNoeWp5SckUfVw3WuaCNZ9eeQ4awjwkkARQ4xmXS5B1VW";
     const char* expected_sigder = "304502210084181199e59f30ab947fa751662b20899a3c89a45f13b5aff8096eae56a68aa502204ea5d1b96c15099315be0a3583628a09d18530a9f937a88e74fa8c24a49449a401";
     const char* expected_tx_signed = "02000000027409797c31feecc4e69b51c58b477b72c53355743a6f6124f9d78221672df370010000006a47304402205d44c682a69da1ca10e1149548bf7e7b53f0ce8f2d2bd2ea74026cba57cd4fe702200e0f9d87aafa1c88697238aaf1059b7718a97ff681efe474097221d456eb7ea2012102c5b9d2d528f13b7b745736f6fd198614a09200c3c5cb0554327e110b4a8efcf1ffffffff6e1709c1e2bdd85aed24dccfd48293993617f249d4d4381296a9c914be3e85e6010000006b48304502210084181199e59f30ab947fa751662b20899a3c89a45f13b5aff8096eae56a68aa502204ea5d1b96c15099315be0a3583628a09d18530a9f937a88e74fa8c24a49449a401210228f47e13841624ec8669f71176558927105207c138a65772331b7fc19c117b64ffffffff01c07fdc0b0000000017a914ba277fd56b69177464fcb6a27a530f03740345ed8700000000";
-    uint64_t amount = 100000000;
     int sighashtype = SIGHASH_ALL;
     int inputindex = 1;
 
@@ -1211,11 +1209,11 @@ void test_tx_sign_p2pkh_i2(dogecoin_tx* tx)
     uint8_t sigcomp[64] = {0};
     uint8_t sigder[76] = {0};
     int sigder_len = 0;
-    enum dogecoin_tx_sign_result res = dogecoin_tx_sign_input(tx, script_wrong, amount, &pkey, inputindex, sighashtype, sigcomp, sigder, &sigder_len);
+    enum dogecoin_tx_sign_result res = dogecoin_tx_sign_input(tx, script_wrong, &pkey, inputindex, sighashtype, sigcomp, sigder, &sigder_len);
     u_assert_int_eq(res, DOGECOIN_SIGN_NO_KEY_MATCH);
     dogecoin_tx_in* in = vector_idx(tx->vin, 1);
     cstr_resize(in->script_sig, 0);
-    res = dogecoin_tx_sign_input(tx, script, amount, &pkey, inputindex, sighashtype, sigcomp, sigder, &sigder_len);
+    res = dogecoin_tx_sign_input(tx, script, &pkey, inputindex, sighashtype, sigcomp, sigder, &sigder_len);
     u_assert_int_eq(res, DOGECOIN_SIGN_OK);
     //u_assert_mem_eq(sigcomp, expected_sigcomp_data, 64);
     u_assert_mem_eq(sigder, expected_sigder_data, sigder_len);

--- a/wrappers/golang/libdogecoin/libdogecoin.go
+++ b/wrappers/golang/libdogecoin/libdogecoin.go
@@ -151,7 +151,7 @@ func W_clear_transaction(tx_index int) {
 	C.clear_transaction(c_tx_index)
 }
 
-func W_sign_raw_transaction(input_index int, incoming_raw_tx string, script_hex string, sig_hash_type int, amount string, privkey string) (result string) {
+func W_sign_raw_transaction(input_index int, incoming_raw_tx string, script_hex string, sig_hash_type int, privkey string) (result string) {
 	c_input_index := C.int(input_index)
 	c_incoming_raw_tx := [1024 * 100]C.char{}
 	for i := 0; i < len(incoming_raw_tx) && i < 1024; i++ {
@@ -159,16 +159,10 @@ func W_sign_raw_transaction(input_index int, incoming_raw_tx string, script_hex 
 	}
 	c_script_hex := C.CString(script_hex)
 	c_sig_hash_type := C.int(sig_hash_type)
-	_, err := strconv.ParseFloat(amount, 64)
 
-	if err != nil {
-		fmt.Println("Error: amount is not numeric.")
-		return ""
-	}
-	c_amount := C.CString(amount)
 	c_privkey := C.CString(privkey)
 
-	if C.sign_raw_transaction(c_input_index, &c_incoming_raw_tx[0], c_script_hex, c_sig_hash_type, c_amount, c_privkey) == 1 {
+	if C.sign_raw_transaction(c_input_index, &c_incoming_raw_tx[0], c_script_hex, c_sig_hash_type, c_privkey) == 1 {
 		result = C.GoString(&c_incoming_raw_tx[0])
 	} else {
 		result = ""
@@ -178,20 +172,11 @@ func W_sign_raw_transaction(input_index int, incoming_raw_tx string, script_hex 
 	return
 }
 
-func W_sign_transaction(tx_index int, amounts []string, script_pubkey string, privkey string) (result int) {
+func W_sign_transaction(tx_index int, script_pubkey string, privkey string) (result int) {
 	c_tx_index := C.int(tx_index)
-	c_amounts := make([]*C.char, len(amounts))
-	for i := 0; i < len(amounts); i++ {
-		_, err := strconv.ParseFloat(amounts[i], 64)
-		if err != nil {
-			fmt.Println("Error: amount is not numeric.")
-			return 0
-		}
-		c_amounts[i] = (C.CString(amounts[i]))
-	}
 	c_script_pubkey := C.CString(script_pubkey)
 	c_privkey := C.CString(privkey)
-	result = int(C.sign_transaction(c_tx_index, &c_amounts[0], c_script_pubkey, c_privkey))
+	result = int(C.sign_transaction(c_tx_index, c_script_pubkey, c_privkey))
 	C.free(unsafe.Pointer(c_script_pubkey))
 	C.free(unsafe.Pointer(c_privkey))
 	return

--- a/wrappers/golang/libdogecoin/transaction_test.go
+++ b/wrappers/golang/libdogecoin/transaction_test.go
@@ -199,7 +199,7 @@ func TestTransaction(t *testing.T) {
 			t.Errorf("Error while deserializing expected transaction.")
 		}
 		rawhex := W_get_raw_transaction(idx)
-		rawhex = W_sign_raw_transaction(0, rawhex, utxo_scriptpubkey, 1, input1_amt, bad_privkey_wif)
+		rawhex = W_sign_raw_transaction(0, rawhex, utxo_scriptpubkey, 1, bad_privkey_wif)
 		if rawhex != "" {
 			t.Errorf("Bad private key should yield empty transaction.")
 		}
@@ -212,11 +212,11 @@ func TestTransaction(t *testing.T) {
 			t.Errorf("Error while deserializing expected transaction.")
 		}
 		rawhex := W_get_raw_transaction(idx)
-		rawhex = W_sign_raw_transaction(0, rawhex, utxo_scriptpubkey, 1, input1_amt, privkey_wif)
+		rawhex = W_sign_raw_transaction(0, rawhex, utxo_scriptpubkey, 1, privkey_wif)
 		if rawhex != expected_signed_single_input_tx_hex {
 			t.Errorf("Error signing first input.")
 		}
-		rawhex = W_sign_raw_transaction(1, rawhex, utxo_scriptpubkey, 1, input2_amt, privkey_wif)
+		rawhex = W_sign_raw_transaction(1, rawhex, utxo_scriptpubkey, 1, privkey_wif)
 		if rawhex != expected_signed_raw_tx_hex {
 			t.Errorf("Error signing second input.")
 		}
@@ -228,8 +228,7 @@ func TestTransaction(t *testing.T) {
 		if idx == 0 {
 			t.Errorf("Error while deserializing expected transaction.")
 		}
-		var inputs = []string{input1_amt, input2_amt}
-		if W_sign_transaction(idx, inputs, utxo_scriptpubkey, privkey_wif) == 0 {
+		if W_sign_transaction(idx, utxo_scriptpubkey, privkey_wif) == 0 {
 			t.Errorf("Error signing transaction.")
 		}
 		if W_get_raw_transaction(idx) != expected_signed_raw_tx_hex {
@@ -256,8 +255,7 @@ func TestTransaction(t *testing.T) {
 		if W_get_raw_transaction(idx) != expected_unsigned_tx_hex {
 			t.Errorf("Returned hex does not match expected hex after making change.")
 		}
-		var inputs = []string{input1_amt, input2_amt}
-		W_sign_transaction(idx, inputs, utxo_scriptpubkey, privkey_wif)
+		W_sign_transaction(idx, utxo_scriptpubkey, privkey_wif)
 		if W_get_raw_transaction(idx) != expected_signed_raw_tx_hex {
 			t.Errorf("Returned hex does not match expected hex after signing inputs.")
 		}
@@ -278,8 +276,7 @@ func TestTransaction(t *testing.T) {
 		if W_get_raw_transaction(idx) != expected_unsigned_tx_hex2 {
 			t.Errorf("Returned hex does not match expected hex after making change.")
 		}
-		var inputs = []string{decimal_input_amt}
-		W_sign_transaction(idx, inputs, utxo_scriptpubkey2, privkey_wif2)
+		W_sign_transaction(idx, utxo_scriptpubkey2, privkey_wif2)
 		if W_get_raw_transaction(idx) != expected_signed_raw_tx_hex2 {
 			t.Errorf("Returned hex does not match expected hex after signing inputs.")
 		}

--- a/wrappers/python/pytest/transaction_test.py
+++ b/wrappers/python/pytest/transaction_test.py
@@ -235,16 +235,16 @@ class TestTransactionFunctions(unittest.TestCase):
     def test_sign_raw_transaction(self):
         """Test that the updated transaction matches the
         expected hex after each input has been signed."""
-        rawhex = l.w_sign_raw_transaction(0, expected_unsigned_tx_hex, utxo_scriptpubkey, 1, input1_amt, privkey_wif)
+        rawhex = l.w_sign_raw_transaction(0, expected_unsigned_tx_hex, utxo_scriptpubkey, 1, privkey_wif)
         self.assertTrue(rawhex==expected_signed_single_input_tx_hex)
-        rawhex = l.w_sign_raw_transaction(1, expected_signed_single_input_tx_hex, utxo_scriptpubkey, 1, input2_amt, privkey_wif)
+        rawhex = l.w_sign_raw_transaction(1, expected_signed_single_input_tx_hex, utxo_scriptpubkey, 1, privkey_wif)
         self.assertTrue(rawhex==expected_signed_raw_tx_hex)
 
     def test_sign_raw_transaction_bad_privkey(self):
         """Test that a transaction cannot be signed by
         an incorrect private key."""
-        self.assertFalse(l.w_sign_raw_transaction(0, expected_unsigned_tx_hex, utxo_scriptpubkey, 1, input1_amt, bad_privkey_wif))
-        self.assertFalse(l.w_sign_raw_transaction(1, expected_unsigned_tx_hex, utxo_scriptpubkey, 1, input2_amt, bad_privkey_wif))
+        self.assertFalse(l.w_sign_raw_transaction(0, expected_unsigned_tx_hex, utxo_scriptpubkey, 1, bad_privkey_wif))
+        self.assertFalse(l.w_sign_raw_transaction(1, expected_unsigned_tx_hex, utxo_scriptpubkey, 1, bad_privkey_wif))
 
     def test_sign_raw_transaction_high_send_amt(self):
         """Test that a transaction cannot be signed if
@@ -252,8 +252,8 @@ class TestTransactionFunctions(unittest.TestCase):
         idx = l.w_store_raw_transaction(expected_unsigned_double_utxo_tx_hex)
         l.w_add_output(idx, external_p2pkh_addr, high_send_amt) # spending more than received
         finalized_rawhex = l.w_finalize_transaction(idx, external_p2pkh_addr, fee, total_utxo_input, p2pkh_addr)
-        half_signed_rawhex = l.w_sign_raw_transaction(0, finalized_rawhex, utxo_scriptpubkey, 1, input1_amt, privkey_wif)
-        full_signed_rawhex = l.w_sign_raw_transaction(1, half_signed_rawhex, utxo_scriptpubkey, 1, input2_amt, privkey_wif)
+        half_signed_rawhex = l.w_sign_raw_transaction(0, finalized_rawhex, utxo_scriptpubkey, 1, privkey_wif)
+        full_signed_rawhex = l.w_sign_raw_transaction(1, half_signed_rawhex, utxo_scriptpubkey, 1, privkey_wif)
         print("\nTransaction looks valid but will get rejected:", full_signed_rawhex)
         l.w_clear_transaction(idx)
 
@@ -261,7 +261,7 @@ class TestTransactionFunctions(unittest.TestCase):
         """Test that the updated transaction matches the
         expected hex after each input has been signed."""
         idx = l.w_store_raw_transaction(expected_unsigned_tx_hex)
-        res = l.w_sign_transaction(idx, [input1_amt, input2_amt], utxo_scriptpubkey, privkey_wif)
+        res = l.w_sign_transaction(idx, utxo_scriptpubkey, privkey_wif)
         self.assertTrue(res)
         l.w_clear_transaction(idx)
         
@@ -269,7 +269,7 @@ class TestTransactionFunctions(unittest.TestCase):
         """Test that the updated transaction matches the
         expected hex after each input has been signed."""
         idx = l.w_store_raw_transaction(expected_unsigned_tx_hex)
-        l.w_sign_transaction(idx, [input1_amt, input2_amt], utxo_scriptpubkey, privkey_wif)
+        l.w_sign_transaction(idx, utxo_scriptpubkey, privkey_wif)
         self.assertTrue(l.w_get_raw_transaction(idx)==expected_signed_raw_tx_hex)
         l.w_clear_transaction(idx)
 
@@ -287,7 +287,7 @@ class TestTransactionFunctions(unittest.TestCase):
         self.assertTrue(l.w_get_raw_transaction(idx)==expected_unsigned_double_utxo_single_output_tx_hex)
         finalized_rawhex = l.w_finalize_transaction(idx, external_p2pkh_addr, fee, total_utxo_input, p2pkh_addr)
         self.assertTrue(finalized_rawhex==expected_unsigned_tx_hex)
-        l.w_sign_transaction(idx, [input1_amt, input2_amt], utxo_scriptpubkey, privkey_wif)
+        l.w_sign_transaction(idx, utxo_scriptpubkey, privkey_wif)
         self.assertTrue(l.w_get_raw_transaction(idx)==expected_signed_raw_tx_hex)
         l.w_clear_transaction(idx)
 
@@ -302,7 +302,7 @@ class TestTransactionFunctions(unittest.TestCase):
         l.w_add_output(idx, external_p2pkh_addr, decimal_send_amt)
         finalized_rawhex = l.w_get_raw_transaction(idx)
         self.assertTrue(finalized_rawhex==expected_unsigned_single_utxo_single_output_tx_hex2)
-        l.w_sign_transaction(idx, decimal_input_amt, utxo_scriptpubkey2, privkey_wif2)
+        l.w_sign_transaction(idx, utxo_scriptpubkey2, privkey_wif2)
         self.assertTrue(l.w_get_raw_transaction(idx)==expected_signed_raw_tx_hex2)
         l.w_clear_transaction(idx)
 


### PR DESCRIPTION
-remove unnecessary function variables from dogecoin_tx_sign_input and dogecoin_tx_sighash.
-remove unused function dogecoin_decode_op_n.
-subtract 1 from sigdata length in dogecoin_hash in tx_tests.