### PR TITLE
trivial: fix remaining GCC warnings/errors

### DIFF
--- a/src/base58.c
+++ b/src/base58.c
@@ -121,7 +121,8 @@ int dogecoin_base58_decode(void* bin, size_t* binszp, const char* b58, size_t b5
 
 int dogecoin_b58check(const void* bin, size_t binsz, const char* base58str)
 {
-    uint256 buf[32] = {0};
+    uint256 buf[32];
+    dogecoin_mem_zero(buf, 32);
     const uint8_t* binc = bin;
     unsigned i = 0;
     if (binsz < 4) {

--- a/src/net.c
+++ b/src/net.c
@@ -192,7 +192,11 @@ void write_cb(struct bufferevent* ev, void* ctx)
  * 
  * @return dogecoin_bool (uint8_t)
  */
-void node_periodical_timer(int fd, short event, void* ctx)
+#if defined(_WIN32) && defined(__x86_64__)
+void node_periodical_timer(long long int fd, short int event, void* ctx)
+#else
+void node_periodical_timer(int fd, short int event, void* ctx)
+#endif
 {
     UNUSED(fd);
     UNUSED(event);

--- a/src/utils.c
+++ b/src/utils.c
@@ -411,14 +411,10 @@ void dogecoin_file_commit(FILE* file)
 #ifdef WIN32
     HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
     FlushFileBuffers(hFile);
-#else
-#if defined(__linux__) || defined(__NetBSD__)
+#elif defined(__linux__) || defined(__NetBSD__)
     fdatasync(fileno(file));
 #elif defined(__APPLE__) && defined(F_FULLFSYNC)
     fcntl(fileno(file), F_FULLFSYNC, 0);
-#else
-    fsync(fileno(file));
-#endif
 #endif
     }
 


### PR DESCRIPTION
-replace manually set mem zero for buf in dogecoin_b58check with dogecoin_mem_zero.
-silence incorrect GCC warning regarding GetProcAddress and add update_seed to dogecoin_random_bytes_internal when building for *-w64-mingw32.
-remove implicit declaration of fsync(fileno(file)) in dogecoin_file_commit since we cover all target architectures.
-wrap node_periodical_timer function in conditional for x86_64-w64-mingw32 to declare arg fd as long long int else int.
-fix segfault when editing transaction output and add bounds checks for amount and destination address in edit output menu in such.