### PR TITLE
Fix go get error

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -160,7 +160,7 @@ pip3 install libdogecoin
 ```
 Or download the Golang wrappers through `go get`:
 ```
-go get -u github.com/jaxlotl/go-libdogecoin-sandbox
+go get -u github.com/jaxlotl/go-libdogecoin
 go mod tidy
 ```
 


### PR DESCRIPTION
Fixes this error message:

```
go: downloading github.com/jaxlotl/go-libdogecoin-sandbox v0.0.40
go: github.com/jaxlotl/go-libdogecoin-sandbox@v0.0.40: parsing go.mod:
	module declares its path as: github.com/jaxlotl/go-libdogecoin
	        but was required as: github.com/jaxlotl/go-libdogecoin-sandbox
```