### PR TITLE
Fix all go get errors caused by rename

### DIFF
--- a/doc/address.md
+++ b/doc/address.md
@@ -100,7 +100,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/jaxlotl/go-libdogecoin-sandbox"
+	"github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {
@@ -160,7 +160,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/jaxlotl/go-libdogecoin-sandbox"
+	"github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {
@@ -225,7 +225,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/jaxlotl/go-libdogecoin-sandbox"
+	"github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {
@@ -293,7 +293,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/jaxlotl/go-libdogecoin-sandbox"
+	"github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {
@@ -362,7 +362,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/jaxlotl/go-libdogecoin-sandbox"
+	"github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {
@@ -431,7 +431,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/jaxlotl/go-libdogecoin-sandbox"
+	"github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {

--- a/doc/bindings.md
+++ b/doc/bindings.md
@@ -100,18 +100,18 @@ If you are interested in making your own modifications to these wrappers, you ca
 
 
 ## Golang Wrappers
-The Go Libdogecoin module uses cgo to build wrappers call the functions in the C library, and this module can be downloaded from Github at https://github.com/jaxlotl/go-libdogecoin-sandbox. Unlike Python, this module does not require building and can be used directly out of the box; **however, the library module for Go currently only supports Linux 64-bit architecture.**
+The Go Libdogecoin module uses cgo to build wrappers call the functions in the C library, and this module can be downloaded from Github at https://github.com/jaxlotl/go-libdogecoin. Unlike Python, this module does not require building and can be used directly out of the box; **however, the library module for Go currently only supports Linux 64-bit architecture.**
 
 ### Integration
 To use these wrappers inside of your own project, you must first include the correct import statement in your source code:
 ```go
 package main
 
-import "github.com/jaxlotl/go-libdogecoin-sandbox"
+import "github.com/jaxlotl/go-libdogecoin"
 ```
 If a module has not yet been created for your project, create it with `go mod init myproject`. From there, the following commands will make sure you are up to date with the most recent MINOR.PATCH:
 ```
-go get -u github.com/jaxlotl/go-libdogecoin-sandbox
+go get -u github.com/jaxlotl/go-libdogecoin
 go mod tidy
 ```
 The output, if any, should tell you which version of go-libdogecoin you have downloaded. Now you are ready to call the functions from inside your project!
@@ -122,7 +122,7 @@ _Example:_
 ```go
 package main
 
-import "github.com/jaxlotl/go-libdogecoin-sandbox"
+import "github.com/jaxlotl/go-libdogecoin"
 
 func main() {
     index := libdogecoin.W_start_transaction()

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -160,7 +160,7 @@ pip3 install libdogecoin
 ```
 Or download the Golang wrappers through `go get`:
 ```
-go get -u github.com/jaxlotl/go-libdogecoin-sandbox
+go get -u github.com/jaxlotl/go-libdogecoin
 go mod tidy
 ```
 

--- a/doc/transaction.md
+++ b/doc/transaction.md
@@ -131,7 +131,7 @@ _Golang usage:_
 ```go
 package main
 
-import "github.com/jaxlotl/go-libdogecoin-sandbox"
+import "github.com/jaxlotl/go-libdogecoin"
 
 func main() {
     index := libdogecoin.W_start_transaction()
@@ -180,7 +180,7 @@ _Golang usage:_
 ```go
 package main
 
-import "github.com/jaxlotl/go-libdogecoin-sandbox"
+import "github.com/jaxlotl/go-libdogecoin"
 
 func main() {
     previous_output_txid := "b4455e7b7b7acb51fb6feba7a2702c42a5100f61f61abafa31851ed6ae076074"
@@ -238,7 +238,7 @@ _Golang usage:_
 ```go
 package main
 
-import "github.com/jaxlotl/go-libdogecoin-sandbox"
+import "github.com/jaxlotl/go-libdogecoin"
 
 func main() {
     prev_output_txid := "42113bdc65fc2943cf0359ea1a24ced0b6b0b5290db4c63a3329c6601c4616e2"
@@ -312,7 +312,7 @@ package main
 
 import (
     "fmt"
-    "github.com/jaxlotl/go-libdogecoin-sandbox"
+    "github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {
@@ -369,7 +369,7 @@ package main
 
 import (
     "fmt"
-    "github.com/jaxlotl/go-libdogecoin-sandbox"
+    "github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {
@@ -415,7 +415,7 @@ package main
 
 import (
     "fmt"
-    "github.com/jaxlotl/go-libdogecoin-sandbox"
+    "github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {
@@ -500,7 +500,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/jaxlotl/go-libdogecoin-sandbox"
+	"github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {
@@ -605,7 +605,7 @@ package main
 
 import (
     "fmt"
-    "github.com/jaxlotl/go-libdogecoin-sandbox"
+    "github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {
@@ -668,7 +668,7 @@ package main
 
 import (
     "fmt"
-    "github.com/jaxlotl/go-libdogecoin-sandbox"
+    "github.com/jaxlotl/go-libdogecoin"
 )
 
 func main() {


### PR DESCRIPTION
Replaces all instances of `github.com/jaxlotl/go-libdogecoin-sandbox` with `github.com/jaxlotl/go-libdogecoin`