### PR TITLE
Fix for dogecoin_script_copy_without_op_codeseperator todo

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -82,7 +82,7 @@ dogecoin_bool dogecoin_script_copy_without_op_codeseperator(const cstring* scrip
             if (!deser_u32(&v32, &buf))
                 goto err_out;
             cstr_append_buf(script_out, &opcode, 1);
-            cstr_append_buf(script_out, &v32, 5); // todo: find out why this is 5 not 4
+            cstr_append_buf(script_out, &v32, 4);
             data_len = v32;
         } else if (opcode == OP_CODESEPARATOR)
             continue;
@@ -90,7 +90,10 @@ dogecoin_bool dogecoin_script_copy_without_op_codeseperator(const cstring* scrip
         if (data_len > 0) {
             assert(data_len < 16777215); //limit max push to 0xFFFFFF
             unsigned char* bufpush = (unsigned char*)dogecoin_calloc(1, data_len);
-            deser_bytes(bufpush, &buf, data_len);
+            if (!deser_bytes(bufpush, &buf, data_len)) {
+                dogecoin_free(bufpush);
+                goto err_out;
+            }
             cstr_append_buf(script_out, bufpush, data_len);
             dogecoin_free(bufpush);
         } else

--- a/test/tx_tests.c
+++ b/test/tx_tests.c
@@ -905,13 +905,15 @@ void test_tx_negative_version()
 
 struct script_test {
     char script[32];
+    uint8_t expected[16];
+    size_t expected_length;
 };
 
 const struct script_test script_tests[] =
     {
-        {"0x4c01"},
-        {"0x4d0200ff"},
-        {"0x4e03000000ffff"}};
+        {"4c0112", {0x4c, 0x01, 0x12}, 3},
+        {"4d02001234", {0x4d, 0x02, 0x00, 0x12, 0x34}, 5},
+        {"4e03000000123456", {0x4e, 0x03, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56}, 8}};
 
 void test_script_parse()
 {
@@ -942,10 +944,13 @@ void test_script_parse()
 
         cstring* script = cstr_new_buf(script_data, outlen);
         vector* vec = vector_new(10, dogecoin_script_op_free_cb);
-        dogecoin_script_get_ops(script, vec);
+        u_assert_int_eq(dogecoin_script_get_ops(script, vec), true);
 
         cstring* new_script = cstr_new_sz(script->len);
-        dogecoin_script_copy_without_op_codeseperator(script, new_script);
+        u_assert_int_eq(dogecoin_script_copy_without_op_codeseperator(script, new_script), true);
+        u_assert_int_eq(test->expected_length, new_script->len);
+        u_assert_mem_eq(test->expected, script->str, new_script->len);
+
         cstr_free(new_script, true);
         cstr_free(script, true);
         vector_free(vec, true);


### PR DESCRIPTION
- Fixed an issue with `dogecoin_script_copy_without_op_codeseperator` when parsing OP_PUSHDATA4 (it was reading out of bounds). It was also ignoring a failure state when there is not enough data to push, which hid the fact that the test inputs were actually failing

- Added some more checks in `test_script_parse()` and fixed the `script_tests` inputs so they don't have a 0x prefix (causing an erroneous \x00 prefix during hex2bin) and also added an appropriate amount of data to push for the OP_PUSHDATA1, OP_PUSHDATA2, and OP_PUSHDATA4 tests