### PR TITLE
Fixed memory cleanup issue in dogecoin_base58_encode_check and updated its declaration

### DIFF
--- a/include/dogecoin/base58.h
+++ b/include/dogecoin/base58.h
@@ -33,7 +33,7 @@
 
 LIBDOGECOIN_BEGIN_DECL
 
-LIBDOGECOIN_API int dogecoin_base58_encode_check(const uint8_t* data, int len, char* str, int base58_length);
+LIBDOGECOIN_API int dogecoin_base58_encode_check(const uint8_t* data, int datalen, char* str, int strsize);
 LIBDOGECOIN_API int dogecoin_base58_decode_check(const char* str, uint8_t* data, size_t datalen);
 
 LIBDOGECOIN_API int dogecoin_base58_encode(char* b58, size_t* b58sz, const void* data, size_t binsz);

--- a/src/base58.c
+++ b/src/base58.c
@@ -200,7 +200,8 @@ int dogecoin_base58_encode_check(const uint8_t* data, int datalen, char* str, in
     if (datalen > 128) {
         return 0;
     }
-    uint8_t* buf = dogecoin_uint8_vla(1 + datalen + 0x20);
+    size_t buf_size = datalen + sizeof(uint256);
+    uint8_t* buf = dogecoin_uint8_vla(buf_size);
     uint8_t* hash = buf + datalen;
     memcpy_safe(buf, data, datalen);
     if (!dogecoin_dblhash(data, datalen, hash)) {
@@ -213,7 +214,7 @@ int dogecoin_base58_encode_check(const uint8_t* data, int datalen, char* str, in
     } else {
         ret = res;
     }
-    dogecoin_mem_zero(buf, sizeof(buf));
+    dogecoin_mem_zero(buf, buf_size);
     free(buf);
     return ret;
 }


### PR DESCRIPTION
- Fixed memory cleanup issue in dogecoin_base58_encode_check  (size of pointer vs size of buffer)
- Updated the parameter names for dogecoin_base58_encode_check's declaration to match its definition. 
 
I honestly think base58 needs a normalization/cleanup pass for better readability and consistency with the rest of the api, once some naming guidelines and such have been established