### PR TITLE
(API Change) Fixed the truncation of size_t's to int's in some places

### DIFF
--- a/include/dogecoin/address.h
+++ b/include/dogecoin/address.h
@@ -46,7 +46,7 @@ LIBDOGECOIN_API int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, 
 LIBDOGECOIN_API int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
 
 /* verify address based on length and checksum */
-LIBDOGECOIN_API int verifyP2pkhAddress(char* p2pkh_pubkey, uint8_t len);
+LIBDOGECOIN_API int verifyP2pkhAddress(char* p2pkh_pubkey, size_t len);
 
 /* generate an extended hd public/private child address */
 LIBDOGECOIN_API int getDerivedHDAddress(const char* masterkey, uint32_t account, bool ischange, uint32_t addressindex, char* outaddress, bool outprivkey);

--- a/include/dogecoin/aes.h
+++ b/include/dogecoin/aes.h
@@ -42,8 +42,8 @@
 
 LIBDOGECOIN_BEGIN_DECL
 
-LIBDOGECOIN_API int aes256_cbc_encrypt(const unsigned char aes_key[32], const unsigned char iv[AES_BLOCK_SIZE], const unsigned char* data, int size, int pad, unsigned char* out);
-LIBDOGECOIN_API int aes256_cbc_decrypt(const unsigned char aes_key[32], const unsigned char iv[AES_BLOCK_SIZE], const unsigned char* data, int size, int pad, unsigned char* out);
+LIBDOGECOIN_API size_t aes256_cbc_encrypt(const unsigned char aes_key[32], const unsigned char iv[AES_BLOCK_SIZE], const unsigned char* data, size_t size, int pad, unsigned char* out);
+LIBDOGECOIN_API size_t aes256_cbc_decrypt(const unsigned char aes_key[32], const unsigned char iv[AES_BLOCK_SIZE], const unsigned char* data, size_t size, int pad, unsigned char* out);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/base58.h
+++ b/include/dogecoin/base58.h
@@ -33,14 +33,14 @@
 
 LIBDOGECOIN_BEGIN_DECL
 
-LIBDOGECOIN_API int dogecoin_base58_encode_check(const uint8_t* data, int datalen, char* str, int strsize);
-LIBDOGECOIN_API int dogecoin_base58_decode_check(const char* str, uint8_t* data, size_t datalen);
+LIBDOGECOIN_API size_t dogecoin_base58_encode_check(const uint8_t* data, size_t datalen, char* str, size_t strsize);
+LIBDOGECOIN_API size_t dogecoin_base58_decode_check(const char* str, uint8_t* data, size_t datalen);
 
 LIBDOGECOIN_API int dogecoin_base58_encode(char* b58, size_t* b58sz, const void* data, size_t binsz);
 LIBDOGECOIN_API int dogecoin_base58_decode(void* bin, size_t* binszp, const char* b58, size_t b58sz);
 
-LIBDOGECOIN_API dogecoin_bool dogecoin_p2pkh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char *addrout, int len);
-LIBDOGECOIN_API dogecoin_bool dogecoin_p2sh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char* addrout, int len);
+LIBDOGECOIN_API dogecoin_bool dogecoin_p2pkh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char* addrout, size_t len);
+LIBDOGECOIN_API dogecoin_bool dogecoin_p2sh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char* addrout, size_t len);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/bip32.h
+++ b/include/dogecoin/bip32.h
@@ -56,12 +56,12 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_public_ckd(dogecoin_hdnode* inout,
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_from_seed(const uint8_t* seed, int seed_len, dogecoin_hdnode* out);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_private_ckd(dogecoin_hdnode* inout, uint32_t i);
 LIBDOGECOIN_API void dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node);
-LIBDOGECOIN_API void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, int strsize);
-LIBDOGECOIN_API void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, int strsize);
+LIBDOGECOIN_API void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
+LIBDOGECOIN_API void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 
 /* gives out the raw sha256/ripemd160 hash */
 LIBDOGECOIN_API void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_out);
-LIBDOGECOIN_API void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, int strsize);
+LIBDOGECOIN_API void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_get_pub_hex(const dogecoin_hdnode* node, char* str, size_t* strsize);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const dogecoin_chainparams* chain, dogecoin_hdnode* node);
 

--- a/include/dogecoin/key.h
+++ b/include/dogecoin/key.h
@@ -80,7 +80,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_hash_compact_recoverable(const d
 LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_recover_pubkey(const unsigned char* sig, const uint256 hash, int recid, dogecoin_pubkey* pubkey);
 
 //verifies a DER encoded signature with given pubkey and return true if valid
-LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_verify_sig(const dogecoin_pubkey* pubkey, const uint256 hash, unsigned char* sigder, int len);
+LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_verify_sig(const dogecoin_pubkey* pubkey, const uint256 hash, unsigned char* sigder, size_t len);
 
 LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_getaddr_p2pkh(const dogecoin_pubkey* pubkey, const dogecoin_chainparams* chain, char* addrout);
 

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -56,7 +56,7 @@ int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet)
 int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
 
 /* verify that a dogecoin address is valid. */
-int verifyP2pkhAddress(char* p2pkh_pubkey, uint8_t len);
+int verifyP2pkhAddress(char* p2pkh_pubkey, size_t len);
 
 
 /*transaction creation functions - builds a dogecoin transaction

--- a/include/dogecoin/mem.h
+++ b/include/dogecoin/mem.h
@@ -57,7 +57,7 @@ LIBDOGECOIN_API void* dogecoin_realloc(void* ptr, size_t size);
 LIBDOGECOIN_API void dogecoin_free(void* ptr);
 
 LIBDOGECOIN_API errno_t memset_safe(volatile void *v, rsize_t smax, int c, rsize_t n);
-LIBDOGECOIN_API void* memcpy_safe(void* destination, const void* source, unsigned int count);
+LIBDOGECOIN_API void* memcpy_safe(void* destination, const void* source, size_t count);
 LIBDOGECOIN_API volatile void* dogecoin_mem_zero(volatile void* dst, size_t len);
 
 LIBDOGECOIN_API uint32_t* dogecoin_uint32_vla(size_t size);

--- a/include/dogecoin/net.h
+++ b/include/dogecoin/net.h
@@ -160,7 +160,7 @@ LIBDOGECOIN_API void dogecoin_node_connection_state_changed(dogecoin_node* node)
 /* =================================== */
 
 LIBDOGECOIN_API dogecoin_bool dogecoin_node_group_add_peers_by_ip_or_seed(dogecoin_node_group *group, const char *ips);
-LIBDOGECOIN_API int dogecoin_get_peers_from_dns(const char* seed, vector* ips_out, int port, int family);
+LIBDOGECOIN_API size_t dogecoin_get_peers_from_dns(const char* seed, vector* ips_out, int port, int family);
 
 struct broadcast_ctx {
     const dogecoin_tx* tx;

--- a/include/dogecoin/sha2.h
+++ b/include/dogecoin/sha2.h
@@ -68,8 +68,8 @@ LIBDOGECOIN_API void sha512_write(sha512_context*, const uint8_t*, size_t);
 LIBDOGECOIN_API void sha512_finalize(sha512_context*, uint8_t[SHA512_DIGEST_LENGTH]);
 LIBDOGECOIN_API void sha512_raw(const uint8_t*, size_t, uint8_t[SHA512_DIGEST_LENGTH]);
 
-LIBDOGECOIN_API void hmac_sha256(const uint8_t* key, const uint32_t keylen, const uint8_t* msg, const uint32_t msglen, uint8_t* hmac);
-LIBDOGECOIN_API void hmac_sha512(const uint8_t* key, const uint32_t keylen, const uint8_t* msg, const uint32_t msglen, uint8_t* hmac);
+LIBDOGECOIN_API void hmac_sha256(const uint8_t* key, const size_t keylen, const uint8_t* msg, const size_t msglen, uint8_t* hmac);
+LIBDOGECOIN_API void hmac_sha512(const uint8_t* key, const size_t keylen, const uint8_t* msg, const size_t msglen, uint8_t* hmac);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/tx.h
+++ b/include/dogecoin/tx.h
@@ -101,7 +101,7 @@ LIBDOGECOIN_API void dogecoin_tx_serialize(cstring* s, const dogecoin_tx* tx);
 
 LIBDOGECOIN_API void dogecoin_tx_hash(const dogecoin_tx* tx, uint256 hashout);
 
-LIBDOGECOIN_API dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, unsigned int in_num, int hashtype, uint256 hash);
+LIBDOGECOIN_API dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, size_t in_num, int hashtype, uint256 hash);
 
 LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_address_out(dogecoin_tx* tx, const dogecoin_chainparams* chain, int64_t amount, const char* address);
 LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_p2sh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160 hash160);
@@ -125,7 +125,7 @@ enum dogecoin_tx_sign_result {
     DOGECOIN_SIGN_OK = 1,
 };
 const char* dogecoin_tx_sign_result_to_str(const enum dogecoin_tx_sign_result result);
-enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, const dogecoin_key* privkey, int inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, int* sigder_len);
+enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, const dogecoin_key* privkey, size_t inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, size_t* sigder_len);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/utils.h
+++ b/include/dogecoin/utils.h
@@ -42,14 +42,14 @@
 LIBDOGECOIN_BEGIN_DECL
 
 LIBDOGECOIN_API void utils_clear_buffers(void);
-LIBDOGECOIN_API void utils_hex_to_bin(const char* str, unsigned char* out, int inLen, int* outLen);
+LIBDOGECOIN_API void utils_hex_to_bin(const char* str, unsigned char* out, size_t inLen, size_t* outLen);
 LIBDOGECOIN_API void utils_bin_to_hex(unsigned char* bin_in, size_t inlen, char* hex_out);
 LIBDOGECOIN_API uint8_t* utils_hex_to_uint8(const char* str);
 LIBDOGECOIN_API char* utils_uint8_to_hex(const uint8_t* bin, size_t l);
-LIBDOGECOIN_API void utils_reverse_hex(char* h, int len);
+LIBDOGECOIN_API void utils_reverse_hex(char* h, size_t len);
 LIBDOGECOIN_API void utils_uint256_sethex(char* psz, uint8_t* out);
 LIBDOGECOIN_API void* safe_malloc(size_t size);
-LIBDOGECOIN_API void dogecoin_cheap_random_bytes(uint8_t* buf, uint32_t len);
+LIBDOGECOIN_API void dogecoin_cheap_random_bytes(uint8_t* buf, size_t len);
 LIBDOGECOIN_API void dogecoin_get_default_datadir(cstring* path_out);
 LIBDOGECOIN_API void dogecoin_file_commit(FILE* file);
 LIBDOGECOIN_API void print_image(FILE *fptr);

--- a/src/address.c
+++ b/src/address.c
@@ -297,7 +297,7 @@ int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master
  * 
  * @return 1 if it is a valid Dogecoin address, 0 otherwise.
  */
-int verifyP2pkhAddress(char* p2pkh_pubkey, uint8_t len) 
+int verifyP2pkhAddress(char* p2pkh_pubkey, size_t len)
     {
         if (!p2pkh_pubkey || !len) return false;
         /* check length */

--- a/src/aes.c
+++ b/src/aes.c
@@ -25,9 +25,9 @@
 #include <dogecoin/ctaes.h>
 #include <dogecoin/mem.h>
 
-int aes256_cbc_encrypt(const unsigned char aes_key[32], const unsigned char iv[AES_BLOCK_SIZE], const unsigned char* data, int size, int pad, unsigned char* out)
+size_t aes256_cbc_encrypt(const unsigned char aes_key[32], const unsigned char iv[AES_BLOCK_SIZE], const unsigned char* data, size_t size, int pad, unsigned char* out)
 {
-    int written = 0;
+    size_t written = 0;
     int padsize = size % AES_BLOCK_SIZE;
     unsigned char mixed[AES_BLOCK_SIZE];
 
@@ -64,10 +64,10 @@ int aes256_cbc_encrypt(const unsigned char aes_key[32], const unsigned char iv[A
     return written;
 }
 
-int aes256_cbc_decrypt(const unsigned char aes_key[32], const unsigned char iv[AES_BLOCK_SIZE], const unsigned char* data, int size, int pad, unsigned char* out)
+size_t aes256_cbc_decrypt(const unsigned char aes_key[32], const unsigned char iv[AES_BLOCK_SIZE], const unsigned char* data, size_t size, int pad, unsigned char* out)
 {
     unsigned char padsize = 0;
-    int written = 0;
+    size_t written = 0;
     int fail = 0;
     const unsigned char* prev = iv;
 

--- a/src/base58.c
+++ b/src/base58.c
@@ -194,9 +194,9 @@ int dogecoin_base58_encode(char* b58, size_t* b58sz, const void* data, size_t bi
     return true;
 }
 
-int dogecoin_base58_encode_check(const uint8_t* data, int datalen, char* str, int strsize)
+size_t dogecoin_base58_encode_check(const uint8_t* data, size_t datalen, char* str, size_t strsize)
 {
-    int ret;
+    size_t ret;
     if (datalen > 128) {
         return 0;
     }
@@ -219,9 +219,9 @@ int dogecoin_base58_encode_check(const uint8_t* data, int datalen, char* str, in
     return ret;
 }
 
-int dogecoin_base58_decode_check(const char* str, uint8_t* data, size_t datalen)
+size_t dogecoin_base58_decode_check(const char* str, uint8_t* data, size_t datalen)
 {
-    int ret, i;
+    size_t ret, i;
     for (i = 0; str[i] && i < 1024; i++){};
     size_t strl = i;
     /* buffer needs to be at least the strsize, will be used
@@ -243,7 +243,7 @@ int dogecoin_base58_decode_check(const char* str, uint8_t* data, size_t datalen)
     return ret;
 }
 
-dogecoin_bool dogecoin_p2pkh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char *addrout, int len) {
+dogecoin_bool dogecoin_p2pkh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char *addrout, size_t len) {
     uint8_t hash160[sizeof(uint160)+1];
     hash160[0] = chain->b58prefix_pubkey_address;
     memcpy_safe(hash160 + 1, hashin, sizeof(uint160));
@@ -252,7 +252,7 @@ dogecoin_bool dogecoin_p2pkh_addr_from_hash160(const uint160 hashin, const dogec
 }
 
 dogecoin_bool dogecoin_p2sh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char* addrout,
-                                    int len)
+                                    size_t len)
 {
     uint8_t hash160[sizeof(uint160) + 1];
     hash160[0] = chain->b58prefix_script_address;

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -300,7 +300,7 @@ void dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node)
  * 
  * @return Nothing.
  */
-static void dogecoin_hdnode_serialize(const dogecoin_hdnode* node, uint32_t version, char use_public, char* str, int strsize)
+static void dogecoin_hdnode_serialize(const dogecoin_hdnode* node, uint32_t version, char use_public, char* str, size_t strsize)
 {
     uint8_t node_data[78];
     write_be(node_data, version);
@@ -329,7 +329,7 @@ static void dogecoin_hdnode_serialize(const dogecoin_hdnode* node, uint32_t vers
  * 
  * @return Nothing.
  */
-void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, int strsize)
+void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize)
 {
     dogecoin_hdnode_serialize(node, chain->b58prefix_bip32_pubkey, 1, str, strsize);
 }
@@ -346,7 +346,7 @@ void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoi
  * 
  * @return Nothing.
  */
-void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, int strsize)
+void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize)
 {
     dogecoin_hdnode_serialize(node, chain->b58prefix_bip32_privkey, 0, str, strsize);
 }
@@ -382,7 +382,7 @@ void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_ou
  * 
  * @return Nothing.
  */
-void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, int strsize)
+void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize)
 {
     uint8_t hash160[sizeof(uint160) + 1];
     hash160[0] = chain->b58prefix_pubkey_address;

--- a/src/cli/sendtx.c
+++ b/src/cli/sendtx.c
@@ -135,7 +135,7 @@ int main(int argc, char* argv[]) {
         return showError("Transaction in invalid or to large.\n");
         }
     uint8_t* data_bin = dogecoin_malloc(strlen(data) / 2 + 1);
-    int outlen = 0;
+    size_t outlen = 0;
     utils_hex_to_bin(data, data_bin, strlen(data), &outlen);
 
     dogecoin_tx* tx = dogecoin_tx_new();

--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -81,7 +81,7 @@ void broadcasting_menu(int txindex, int is_testnet) {
                                 printf("Transaction in invalid or to large.\n");
                             }
                             uint8_t* data_bin = dogecoin_malloc(strlen(raw_hexadecimal_tx) / 2 + 1);
-                            int outlen = 0;
+                            size_t outlen = 0;
                             utils_hex_to_bin(raw_hexadecimal_tx, data_bin, strlen(raw_hexadecimal_tx), &outlen);
 
                             /* Deserializing the transaction and broadcasting it to the network. */
@@ -851,7 +851,7 @@ int main(int argc, char* argv[])
         //deserialize transaction
         dogecoin_tx* tx = dogecoin_tx_new();
         uint8_t* data_bin = dogecoin_malloc(strlen(txhex) / 2 + 1);
-        int outlen = 0;
+        size_t outlen = 0;
         utils_hex_to_bin(txhex, data_bin, strlen(txhex), &outlen);
         if (!dogecoin_tx_deserialize(data_bin, outlen, tx, NULL)) {
             dogecoin_free(data_bin);
@@ -904,7 +904,7 @@ int main(int argc, char* argv[])
         }
         if (sign) {
             uint8_t sigcompact[64] = { 0 };
-            int sigderlen = 74 + 1; //&hashtype
+            size_t sigderlen = 74 + 1; //&hashtype
             uint8_t sigder_plus_hashtype[75] = { 0 };
             enum dogecoin_tx_sign_result res = dogecoin_tx_sign_input(tx, script, &key, inputindex, sighashtype, sigcompact, sigder_plus_hashtype, &sigderlen);
             cstr_free(script, true);
@@ -941,7 +941,7 @@ int main(int argc, char* argv[])
             return showError("Missing signature or invalid length (use hex, 128 chars == 64 bytes)\n");
             }
 
-        int outlen = 0;
+        size_t outlen = 0;
         uint8_t sig_comp[65];
         printf("%s\n", scripthex);
         utils_hex_to_bin(scripthex, sig_comp, 128, &outlen);

--- a/src/cli/tool.c
+++ b/src/cli/tool.c
@@ -64,7 +64,7 @@ dogecoin_bool addresses_from_pubkey(const dogecoin_chainparams* chain, const cha
     dogecoin_pubkey_init(&pubkey);
     pubkey.compressed = 1;
     size_t outlen = 0;
-    utils_hex_to_bin(pubkey_hex, pubkey.pubkey, strlen(pubkey_hex), (int*)&outlen);
+    utils_hex_to_bin(pubkey_hex, pubkey.pubkey, strlen(pubkey_hex), &outlen);
     assert(dogecoin_pubkey_is_valid(&pubkey) == 1);
     dogecoin_pubkey_getaddr_p2pkh(&pubkey, chain, p2pkh_address);
     return true;

--- a/src/key.c
+++ b/src/key.c
@@ -202,7 +202,7 @@ dogecoin_bool dogecoin_key_sign_recover_pubkey(const unsigned char* sig, const u
     return 1;
 }
 
-dogecoin_bool dogecoin_pubkey_verify_sig(const dogecoin_pubkey* pubkey, const uint256 hash, unsigned char* sigder, int len)
+dogecoin_bool dogecoin_pubkey_verify_sig(const dogecoin_pubkey* pubkey, const uint256 hash, unsigned char* sigder, size_t len)
 {
     return dogecoin_ecc_verify_sig(pubkey->pubkey, pubkey->compressed, hash, sigder, len);
 }

--- a/src/koinu.c
+++ b/src/koinu.c
@@ -71,7 +71,7 @@ const char* conversion_type_to_str(const enum conversion_type type)
     }
 }
 
-int check_length(char* string) {
+size_t check_length(char* string) {
     // set max length for all string inputs to 20 to account for total supply in 2022
     // (currently 132.67 billion dogecoin) + 1e8 koinu passing UINT64_MAX 184467440737
     // in 9.854916426 years (2032) with output of 5,256,000,000 mined dogecoins per year
@@ -83,7 +83,7 @@ int check_length(char* string) {
     // set max length for all string inputs to 21 to account for total supply passing 
     // 1T in ~180 years from 2022. this limit will be valid for the next 1980 years so 
     // make sure to update in year 4002. :)
-    int integer_length = strlen(string);
+    size_t integer_length = strlen(string);
     if (integer_length > 22) return false;
     else return integer_length;
 }
@@ -147,7 +147,7 @@ int koinu_to_coins_str(uint64_t koinu, char* str) {
     
     if (length < 9) {
         string(koinu, str);
-        int l = str ? strlen(str) : 0;
+        size_t l = str ? strlen(str) : 0;
         char* swap = dogecoin_char_vla(l + 1);
         memcpy_safe(swap, str, l + 1);
         for (; i < target; i++) {
@@ -176,14 +176,14 @@ int koinu_to_coins_str(uint64_t koinu, char* str) {
 
 uint64_t coins_to_koinu_str(char* coins) {
     if (coins[0] == '-') return false;
-    int length = check_length(coins);
+    size_t length = check_length(coins);
     if (!length) return false;
 
     char *end, dogecoin_string[21], koinu_string[9];
     dogecoin_mem_zero(dogecoin_string, 21);
     dogecoin_mem_zero(koinu_string, 9);
     
-    int i = 0, j = 0, mantissa_length = 0;
+    size_t i = 0, j = 0, mantissa_length = 0;
     for (; i < length; i++) { 
         dogecoin_string[i] = coins[i];
         if (coins[i] == '.') {

--- a/src/mem.c
+++ b/src/mem.c
@@ -206,7 +206,7 @@ void dogecoin_free_internal(void* ptr)
     free(ptr);
 }
 
-void* memcpy_safe(void* destination, const void* source, unsigned int count) {
+void* memcpy_safe(void* destination, const void* source, size_t count) {
     char *pszDest = (char *)destination;
     const char *pszSource =( const char*)source;
     if((pszDest!= NULL) && (pszSource!= NULL)) {

--- a/src/net.c
+++ b/src/net.c
@@ -724,9 +724,9 @@ int dogecoin_node_parse_message(dogecoin_node* node, dogecoin_p2p_msg_hdr* hdr, 
  * @param port The port to connect to.
  * @param family The address family of the socket. AF_INET or AF_INET6.
  * 
- * @return int
+ * @return size_t
  */
-int dogecoin_get_peers_from_dns(const char* seed, vector* ips_out, int port, int family)
+size_t dogecoin_get_peers_from_dns(const char* seed, vector* ips_out, int port, int family)
 {
     if (!seed || !ips_out || (family != AF_INET && family != AF_INET6) || port > 99999) {
         return 0;

--- a/src/script.c
+++ b/src/script.c
@@ -550,11 +550,11 @@ void dogecoin_script_append_pushdata(cstring* script_in, const unsigned char* da
         cstr_append_buf(script_in, (unsigned char*)&datalen, 1);
     } else if (datalen <= 0xffff) {
         dogecoin_script_append_op(script_in, OP_PUSHDATA2);
-        uint16_t v = htole16(datalen);
+        uint16_t v = htole16((uint16_t)datalen);
         cstr_append_buf(script_in, &v, sizeof(v));
     } else {
         dogecoin_script_append_op(script_in, OP_PUSHDATA4);
-        uint32_t v = htole32(datalen);
+        uint32_t v = htole32((uint32_t)datalen);
         cstr_append_buf(script_in, &v, sizeof(v));
     }
     cstr_append_buf(script_in, data, datalen);

--- a/src/sha2.c
+++ b/src/sha2.c
@@ -923,7 +923,7 @@ void sha512_raw(const sha2_byte* data, size_t len, uint8_t digest[SHA512_DIGEST_
     sha512_finalize(&context, digest);
 }
 
-void hmac_sha256(const uint8_t* key, const uint32_t keylen, const uint8_t* msg, const uint32_t msglen, uint8_t* hmac)
+void hmac_sha256(const uint8_t* key, const size_t keylen, const uint8_t* msg, const size_t msglen, uint8_t* hmac)
 {
     int i;
     uint8_t buf[SHA256_BLOCK_LENGTH], o_key_pad[SHA256_BLOCK_LENGTH],
@@ -950,7 +950,7 @@ void hmac_sha256(const uint8_t* key, const uint32_t keylen, const uint8_t* msg, 
     sha256_finalize(&ctx, hmac);
 }
 
-void hmac_sha512(const uint8_t* key, const uint32_t keylen, const uint8_t* msg, const uint32_t msglen, uint8_t* hmac)
+void hmac_sha512(const uint8_t* key, const size_t keylen, const uint8_t* msg, const size_t msglen, uint8_t* hmac)
 {
     int i;
     uint8_t buf[SHA512_BLOCK_LENGTH], o_key_pad[SHA512_BLOCK_LENGTH],

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -251,7 +251,7 @@ int save_raw_transaction(int txindex, const char* hexadecimal_transaction) {
     // deserialize transaction
     dogecoin_tx* txtmp = dogecoin_tx_new();
     uint8_t* data_bin = dogecoin_malloc(strlen(hexadecimal_transaction));
-    int outlength = 0;
+    size_t outlength = 0;
     // convert incomingrawtx to byte array to dogecoin_tx and if it fails free from memory
     utils_hex_to_bin(hexadecimal_transaction, data_bin, strlen(hexadecimal_transaction), &outlength);
     if (!dogecoin_tx_deserialize(data_bin, outlength, txtmp, NULL)) {
@@ -287,7 +287,7 @@ int add_utxo(int txindex, char* hex_utxo_txid, int vout) {
     // guard against null pointer exceptions
     if (tx == NULL) return false;
 
-    int flag = tx->transaction->vin->len;
+    size_t flag = tx->transaction->vin->len;
 
     // instantiate empty dogecoin_tx_in object to set previous output txid and output n:
     dogecoin_tx_in* tx_in = dogecoin_tx_in_new();
@@ -304,7 +304,7 @@ int add_utxo(int txindex, char* hex_utxo_txid, int vout) {
     // free tx_in struct since it has been added to our working tx
     // ensure the length of our working tx inputs length has incremented by 1
     // which will return true if successful:
-    return flag + 1 == (int)tx->transaction->vin->len;
+    return flag + 1 == tx->transaction->vin->len;
 }
 
 /**
@@ -489,7 +489,7 @@ int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, i
     // deserialize transaction
     dogecoin_tx* txtmp = dogecoin_tx_new();
     uint8_t* data_bin = dogecoin_malloc(strlen(incomingrawtx) / 2);
-    int outlength = 0;
+    size_t outlength = 0;
     // convert incomingrawtx to byte array to dogecoin_tx and if it fails free from memory
     utils_hex_to_bin(incomingrawtx, data_bin, strlen(incomingrawtx), &outlength);
 
@@ -551,7 +551,7 @@ int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, i
     }
     if (sign) {
         uint8_t sigcompact[64] = {0};
-        int sigderlen = 74+1; //&hashtype
+        size_t sigderlen = 74 + 1; //&hashtype
         uint8_t sigder_plus_hashtype[75] = {0};
         enum dogecoin_tx_sign_result res = dogecoin_tx_sign_input(txtmp, script, &key, inputindex, sighashtype, sigcompact, sigder_plus_hashtype, &sigderlen);
         cstr_free(script, true);
@@ -623,7 +623,7 @@ int sign_transaction(int txindex, char* script_pubkey, char* privkey) {
     // deserialize transaction
     dogecoin_tx* txtmp = dogecoin_tx_new();
     uint8_t* data_bin = dogecoin_malloc(strlen(raw_hexadecimal_transaction) / 2);
-    int outlength = 0;
+    size_t outlength = 0;
     // convert incomingrawtx to byte array to dogecoin_tx and if it fails free from memory
     utils_hex_to_bin(raw_hexadecimal_transaction, data_bin, strlen(raw_hexadecimal_transaction), &outlength);
     if (!dogecoin_tx_deserialize(data_bin, outlength, txtmp, NULL)) {
@@ -667,7 +667,7 @@ int store_raw_transaction(char* incomingrawtx) {
     int txindex = start_transaction();
     working_transaction* tx_raw = find_transaction(txindex);
     uint8_t* data_bin = dogecoin_malloc(strlen(incomingrawtx));
-    int outlength = 0;
+    size_t outlength = 0;
     // convert incomingrawtx to byte array to dogecoin_tx and if it fails free from memory
     utils_hex_to_bin(incomingrawtx, data_bin, strlen(incomingrawtx), &outlength);
     if (!dogecoin_tx_deserialize(data_bin, outlength, txtmp, NULL)) {

--- a/src/tx.c
+++ b/src/tx.c
@@ -272,7 +272,7 @@ char* dogecoin_p2pkh_to_script_hash(char* p2pkh) {
     unsigned char dec[35]; //problem is here, it works if its char**
 
     // MLUMIN: MSVC
-    int decoded_length = dogecoin_base58_decode_check(p2pkh, (uint8_t*)&dec, sizeof(dec)/sizeof(dec[0]));
+    size_t decoded_length = dogecoin_base58_decode_check(p2pkh, (uint8_t*)&dec, sizeof(dec) / sizeof(dec[0]));
     if (decoded_length==0)
     {
         printf("failed base58 decode\n");
@@ -747,7 +747,7 @@ void dogecoin_tx_outputs_hash(const dogecoin_tx* tx, uint256 hash)
  * 
  * @return 1 if signature hash is generated successfully, 0 otherwise.
  */
-dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, unsigned int in_num, int hashtype, uint256 hash)
+dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, size_t in_num, int hashtype, uint256 hash)
 {
     if (in_num >= tx_to->vin->len || !tx_to->vout) {
         return false;
@@ -762,7 +762,7 @@ dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromP
     cstring* new_script = cstr_new_sz(fromPubKey->len);
     dogecoin_script_copy_without_op_codeseperator(fromPubKey, new_script);
 
-    unsigned int i;
+    size_t i;
     dogecoin_tx_in* tx_in;
     for (i = 0; i < tx_tmp->vin->len; i++) {
         tx_in = vector_idx(tx_tmp->vin, i);
@@ -788,7 +788,7 @@ dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromP
             }
         }
     } else if ((hashtype & 0x1f) == SIGHASH_SINGLE) {
-        unsigned int n_out = in_num;
+        size_t n_out = in_num;
         if (n_out >= tx_tmp->vout->len) {
             //TODO: set error code
             ret = false;
@@ -908,7 +908,7 @@ dogecoin_bool dogecoin_tx_add_address_out(dogecoin_tx* tx, const dogecoin_chainp
 {
     const size_t buflen = sizeof(uint8_t) * strlen(address) * 2;
     uint8_t* buf = dogecoin_calloc(1, buflen);
-    int r = dogecoin_base58_decode_check(address, buf, buflen);
+    size_t r = dogecoin_base58_decode_check(address, buf, buflen);
     if (r > 0 && buf[0] == chain->b58prefix_pubkey_address) {
         dogecoin_tx_add_p2pkh_hash160_out(tx, amount, &buf[1]);
     } else if (r > 0 && buf[0] == chain->b58prefix_script_address) {
@@ -1061,13 +1061,13 @@ const char* dogecoin_tx_sign_result_to_str(const enum dogecoin_tx_sign_result re
  * 
  * @return The code denoting which errors occurred, if any.
  */
-enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, const dogecoin_key* privkey, int inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, int* sigder_len_out)
+enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, const dogecoin_key* privkey, size_t inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, size_t* sigder_len_out)
 {
     if (!tx_in_out || !script) {
         return DOGECOIN_SIGN_INVALID_TX_OR_SCRIPT;
     }
 
-    if ((size_t)inputindex >= tx_in_out->vin->len) {
+    if (inputindex >= tx_in_out->vin->len) {
         return DOGECOIN_SIGN_INPUTINDEX_OUT_OF_RANGE;
     }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -100,10 +100,10 @@ void utils_clear_buffers(void)
  *
  * @return Nothing.
  */
-void utils_hex_to_bin(const char* str, unsigned char* out, int inLen, int* outLen)
+void utils_hex_to_bin(const char* str, unsigned char* out, size_t inLen, size_t* outLen)
     {
-    int bLen = inLen / 2;
-    int i;
+    size_t bLen = inLen / 2;
+    size_t i;
     dogecoin_mem_zero(out, bLen);
     for (i = 0; i < bLen; i++) {
         if (str[i * 2] >= '0' && str[i * 2] <= '9') {
@@ -230,10 +230,10 @@ char* utils_uint8_to_hex(const uint8_t* bin, size_t l)
  *
  * @return Nothing.
  */
-void utils_reverse_hex(char* h, int len)
+void utils_reverse_hex(char* h, size_t len)
     {
     char* copy = dogecoin_calloc(1, len);
-    int i;
+    size_t i;
     memcpy_safe(copy, h, len);
     for (i = 0; i < len - 1; i += 2) {
         h[i] = copy[len - i - 2];
@@ -351,10 +351,10 @@ void* safe_malloc(size_t size)
  *
  * @return Nothing.
  */
-void dogecoin_cheap_random_bytes(uint8_t* buf, uint32_t len)
+    void dogecoin_cheap_random_bytes(uint8_t* buf, size_t len)
     {
     srand(time(NULL)); // insecure
-    for (uint32_t i = 0; i < len; i++) {
+    for (size_t i = 0; i < len; i++) {
         buf[i] = rand(); // weak non secure cryptographic rng
         }
     }
@@ -484,7 +484,7 @@ void prepend(char* s, const char* t)
  */
 void append(char* s, char* t)
     {
-    int i = 0, length = 0;
+    size_t i = 0, length = 0;
     /* get length of char* s */
     for (; memcmp(&s[i], "\0", 1) != 0; i++) length++;
 
@@ -503,8 +503,8 @@ void append(char* s, char* t)
  * @param output
  */
 void text_to_hex(char* in, char* out) {
-    int length = 0;
-    int i = 0;
+    size_t length = 0;
+    size_t i = 0;
 
     while (in[length] != '\0') {
         sprintf((char*)(out + i), "%02X", in[length]);
@@ -531,7 +531,7 @@ const char* get_build() {
 /* reverse:  reverse string s in place */
 void dogecoin_str_reverse(char s[])
 {
-    int i, j;
+    size_t i, j;
     char c;
 
     for (i = 0, j = strlen(s)-1; i<j; i++, j--) {

--- a/src/vector.c
+++ b/src/vector.c
@@ -210,7 +210,7 @@ void vector_remove_range(vector* vec, size_t pos, size_t len)
     }
 
     if (vec->elem_free_f) {
-        unsigned int i, count;
+        size_t i, count;
         for (i = pos, count = 0; count < len; i++, count++) {
             vec->elem_free_f(vec->data[i]);
         }
@@ -270,7 +270,7 @@ dogecoin_bool vector_remove(vector* vec, void* data)
  */
 dogecoin_bool vector_resize(vector* vec, size_t newsz)
 {
-    unsigned int i;
+    size_t i;
 
     /* same size */
     if (newsz == vec->len) {

--- a/test/aes_tests.c
+++ b/test/aes_tests.c
@@ -552,16 +552,16 @@ void test_aes()
     for (i = 0; i < (sizeof(nist_aes_test_vectors_encrypt) / sizeof(nist_aes_test_vectors_encrypt[0])); i++) {
         struct nist_aes_test_vector tv = nist_aes_test_vectors_encrypt[i];
 
-        int outlen_key;
+        size_t outlen_key;
         utils_hex_to_bin(tv.key, key_bin, strlen(tv.key), &outlen_key);
 
-        int outlen_iv;
+        size_t outlen_iv;
         utils_hex_to_bin(tv.iv, iv_bin, strlen(tv.iv), &outlen_iv);
 
-        int outlen_plaintext;
+        size_t outlen_plaintext;
         utils_hex_to_bin(tv.in, plaintext_bin, strlen(tv.in), &outlen_plaintext);
 
-        int outlen_cipthertext;
+        size_t outlen_cipthertext;
         utils_hex_to_bin(tv.out, ciphertext_bin, strlen(tv.out), &outlen_cipthertext);
 
         aes256_cbc_encrypt(key_bin, iv_bin, plaintext_bin, outlen_plaintext, 1, ciphertext_bin);
@@ -577,16 +577,16 @@ void test_aes()
     for (i = 0; i < (sizeof(nist_aes_test_vectors_decrypt) / sizeof(nist_aes_test_vectors_decrypt[0])); i++) {
         struct nist_aes_test_vector tv = nist_aes_test_vectors_decrypt[i];
 
-        int outlen_key;
+        size_t outlen_key;
         utils_hex_to_bin(tv.key, key_bin, strlen(tv.key), &outlen_key);
 
-        int outlen_iv;
+        size_t outlen_iv;
         utils_hex_to_bin(tv.iv, iv_bin, strlen(tv.iv), &outlen_iv);
 
-        int outlen_plaintext;
+        size_t outlen_plaintext;
         utils_hex_to_bin(tv.in, plaintext_bin, strlen(tv.in), &outlen_plaintext);
 
-        int outlen_cipthertext;
+        size_t outlen_cipthertext;
         utils_hex_to_bin(tv.out, ciphertext_bin, strlen(tv.out), &outlen_cipthertext);
 
         aes256_cbc_decrypt(key_bin, iv_bin, plaintext_bin, outlen_plaintext, 1, ciphertext_bin);

--- a/test/base58_tests.c
+++ b/test/base58_tests.c
@@ -142,11 +142,11 @@ void test_base58()
     while (*raw && *str) {
         size_t len = strlen(*raw) / 2;
         memcpy_safe(rawn, utils_hex_to_uint8(*raw), len);
-        int r = dogecoin_base58_encode_check(rawn, len, strn, sizeof(strn));
-        assert(r == (int)strlen(*str) + 1);
+        size_t r = dogecoin_base58_encode_check(rawn, len, strn, sizeof(strn));
+        assert(r == strlen(*str) + 1);
         assert(strcmp(strn, *str) == 0);
         r = dogecoin_base58_decode_check(strn, rawn, sizeof(rawn));
-        assert(r == (int)len + 4);
+        assert(r == len + 4);
         raw += 2;
         str += 2;
     }
@@ -157,7 +157,7 @@ void test_base58()
         size_t len = strlen(*i_raw) / 2;
         memcpy_safe(i_rawn, utils_hex_to_uint8(*i_raw), len);
         unsigned char outbuf[1024];
-        int r = 0;
+        size_t r = 0;
         if (strncmp(*i_cmd, "ec", 2) == 0)
             r = dogecoin_base58_encode_check(i_rawn, len, strn, sizeof(strn));
         else

--- a/test/bip32_tests.c
+++ b/test/bip32_tests.c
@@ -232,7 +232,7 @@ void test_bip32()
     r = dogecoin_hdnode_get_pub_hex(&node4, str, &sizeSmall);
     u_assert_int_eq(r, false);
     r = dogecoin_hdnode_get_pub_hex(&node4, str, &size);
-    u_assert_int_eq(size, 66);
+    u_assert_uint32_eq(size, 66);
     u_assert_int_eq(r, true);
     u_assert_str_eq(str, "0345717c8722bd243ec5c7109ce52e95a353588403684057c2664f7ad3d7065ed5");
     dogecoin_hdnode_serialize_public(&node4, &dogecoin_chainparams_test, str, sizeof(str));

--- a/test/block_tests.c
+++ b/test/block_tests.c
@@ -42,7 +42,7 @@ static const struct blockheadertest block_header_tests[] =
 
 void test_block_header()
 {
-    int outlen;
+    size_t outlen;
     char hexbuf[161];
     unsigned int i;
     for (i = 0; i < (sizeof(block_header_tests) / sizeof(block_header_tests[0])); i++) {

--- a/test/ecc_tests.c
+++ b/test/ecc_tests.c
@@ -50,6 +50,6 @@ void test_ecc()
     size_t sigderlen = 74;
     u_assert_int_eq(dogecoin_ecc_der_to_compact(sig, outlen, sigcomp), true);
     u_assert_int_eq(dogecoin_ecc_compact_to_der_normalized(sigcomp, sigder, &sigderlen), true);
-    u_assert_int_eq(outlen, sigderlen);
+    u_assert_uint32_eq(outlen, sigderlen);
     u_assert_int_eq(memcmp(sig, sigder, sigderlen), 0);
 }

--- a/test/key_tests.c
+++ b/test/key_tests.c
@@ -69,7 +69,7 @@ void test_key()
     size_t size = sizeof(str);
     int r = dogecoin_pubkey_get_hex(&pubkey, str, &size);
     u_assert_int_eq(r, true);
-    u_assert_int_eq(size, 66);
+    u_assert_uint32_eq(size, 66);
     size = 50;
     r = dogecoin_pubkey_get_hex(&pubkey, str, &size);
     u_assert_int_eq(r, false);

--- a/test/opreturn_tests.c
+++ b/test/opreturn_tests.c
@@ -41,7 +41,7 @@ void test_op_return() {
     size_t length = (strlen((char*)msg_hex) / 2) + 1; // 69
     
     char decimal[32];
-    sprintf(decimal, "%zx", length - 1);
+    sprintf(decimal, "%x", length - 1);
     prepend((char*)msg_hex, decimal);
 
     u_assert_int_eq(memcmp(msg_hex, expected_hexmsg, strlen(expected_hexmsg)), 0);

--- a/test/opreturn_tests.c
+++ b/test/opreturn_tests.c
@@ -38,15 +38,15 @@ void test_op_return() {
     // convert message text to hexadecimal:
     text_to_hex(msg, (char*)msg_hex);
 
-    int length = (strlen((char*)msg_hex) / 2) + 1; // 69
+    size_t length = (strlen((char*)msg_hex) / 2) + 1; // 69
     
     char decimal[32];
-    sprintf(decimal, "%x", length - 1);
+    sprintf(decimal, "%zx", length - 1);
     prepend((char*)msg_hex, decimal);
 
     u_assert_int_eq(memcmp(msg_hex, expected_hexmsg, strlen(expected_hexmsg)), 0);
 
-    int outlen;
+    size_t outlen;
     uint8_t* script_data=dogecoin_uint8_vla(strlen((char*)msg_hex));
     utils_hex_to_bin((char*)msg_hex, script_data, strlen((char*)msg_hex), &outlen);
 

--- a/test/protocol_tests.c
+++ b/test/protocol_tests.c
@@ -85,9 +85,8 @@ void test_protocol()
 
     u_assert_mem_eq(hdr.netmagic, &dogecoin_chainparams_main.netmagic, 4);
     u_assert_str_eq(hdr.command, DOGECOIN_MSG_VERSION);
-    u_assert_int_eq(hdr.data_len, version_msg_cstr->len);
-    u_assert_int_eq(buf.len, hdr.data_len);
-    u_assert_int_eq(buf.len, hdr.data_len);
+    u_assert_uint32_eq(hdr.data_len, version_msg_cstr->len);
+    u_assert_uint32_eq(buf.len, hdr.data_len);
     u_assert_mem_eq(buf.p, version_msg_cstr->str, hdr.data_len);
 
     dogecoin_p2p_version_msg v_msg_check;
@@ -113,7 +112,7 @@ void test_protocol()
     buf.len = p2p_msg->len;
     dogecoin_p2p_deser_msghdr(&hdr, &buf);
     u_assert_str_eq(hdr.command, DOGECOIN_MSG_GETHEADERS);
-    u_assert_int_eq(hdr.data_len, getheader_msg->len);
+    u_assert_uint32_eq(hdr.data_len, getheader_msg->len);
 
 
     uint256 hashstop_check;

--- a/test/sha2_tests.c
+++ b/test/sha2_tests.c
@@ -417,7 +417,7 @@ void test_sha_256()
     sha256_context context;
     uint8_t buf[SHA256_DIGEST_LENGTH];
     uint8_t* digest_out; /* use non thread save buffer (optimized for embedded systems) */
-    int oLen;
+    size_t oLen;
     unsigned char msg_buf[20480];
 
     unsigned int i;
@@ -433,7 +433,7 @@ void test_sha_256()
 
         sha256_init(&context);
         if (oLen == 3680 / 8) {
-            int j;
+            size_t j;
             for (j = 0; j < oLen; j += oLen / 10) {
                 sha256_write(&context, msg_buf + j, oLen / 10);
             }
@@ -451,7 +451,7 @@ void test_sha_512()
     sha512_context context;
     uint8_t buf[SHA512_DIGEST_LENGTH];
     uint8_t* digest_out; /* use non thread save buffer (optimized for embedded systems) */
-    int oLen;
+    size_t oLen;
     unsigned char msg_buf[20480];
 
     unsigned int i;
@@ -468,7 +468,7 @@ void test_sha_512()
         sha512_init(&context);
 
         if (oLen == 12800) {
-            int j;
+            size_t j;
             for (j = 0; j < oLen; j += oLen / 1280) {
                 sha512_write(&context, msg_buf + j, oLen / 1280);
             }
@@ -486,14 +486,14 @@ void test_sha_hmac()
 {
     uint8_t buf[SHA512_DIGEST_LENGTH];
     uint8_t* digest_out;
-    int oLenMsg;
-    int oLenKey;
+    size_t oLenMsg;
+    size_t oLenKey;
     unsigned char msg_buf[550];
     unsigned char key_buf[200];
 
     unsigned int i;
     for (i = 0; i < (sizeof(sha_hmac_test_vectors) / sizeof(sha_hmac_test_vectors[0])); i++) {
-        int msglen = strlen(sha_hmac_test_vectors[i].msg);
+        size_t msglen = strlen(sha_hmac_test_vectors[i].msg);
         utils_hex_to_bin((char*)sha_hmac_test_vectors[i].msg, msg_buf, msglen, &oLenMsg);
         utils_hex_to_bin((char*)sha_hmac_test_vectors[i].key, key_buf, sha_hmac_test_vectors[i].klen * 2, &oLenKey);
 

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -49,7 +49,7 @@ void test_transaction()
     dogecoin_tx* tx_worth_2 = dogecoin_tx_new();
 
     uint8_t* data_bin_2 = dogecoin_malloc(strlen(raw_hexadecimal_transaction_from_tx_worth_2_dogecoin) / 2 + 1);
-    int outlength_2 = 0;
+    size_t outlength_2 = 0;
     // convert raw_hexadecimal_transaction_from_tx_worth_2_dogecoin to byte array to dogecoin_tx and if it fails free from memory
     utils_hex_to_bin(raw_hexadecimal_transaction_from_tx_worth_2_dogecoin, data_bin_2, strlen(raw_hexadecimal_transaction_from_tx_worth_2_dogecoin), &outlength_2);
 
@@ -149,7 +149,7 @@ void test_transaction()
 
     dogecoin_tx* tx_worth_10 = dogecoin_tx_new();
     uint8_t* data_bin_10 = dogecoin_malloc(strlen(raw_hexadecimal_transaction_from_tx_worth_10_dogecoin));
-    int outlength_10 = 0;
+    size_t outlength_10 = 0;
 
     // convert incomingrawtx to byte array to dogecoin_tx and if it fails free from memory
     utils_hex_to_bin(raw_hexadecimal_transaction_from_tx_worth_10_dogecoin, data_bin_10, strlen(raw_hexadecimal_transaction_from_tx_worth_10_dogecoin), &outlength_10);

--- a/test/utils_tests.c
+++ b/test/utils_tests.c
@@ -17,7 +17,7 @@ static const char hex2[] = "AA969cdfFFffFF3bad960b0b000aca2ac329deea5c2328ebc6f2
 
 void test_utils()
     {
-    int outlen = 0;
+    size_t outlen = 0;
     unsigned char data[] = { 0x00, 0xFF, 0x00, 0xAA, 0x00, 0xFF, 0x00, 0xAA };
     char hash[] = "28969cdfa74a12c82f3bad960b0b000aca2ac329deea5c2328ebc6f2ba9802c1";
     char hex[sizeof(data) * 2 + 1];

--- a/test/vector_tests.c
+++ b/test/vector_tests.c
@@ -72,7 +72,7 @@ void test_vector()
     char str[80];
     size_t i;
     for (i = 0; i < 20; i++) {
-        sprintf(str, "TEST%zu", i);
+        sprintf(str, "TEST%d", i);
         res = vector_add(vec, strdup(str));
         assert(res == true);
         assert(vec->len == i + 1);

--- a/test/vector_tests.c
+++ b/test/vector_tests.c
@@ -70,12 +70,12 @@ void test_vector()
     res = vector_resize(vec, 30);
     assert(res == true);
     char str[80];
-    int i;
+    size_t i;
     for (i = 0; i < 20; i++) {
-        sprintf(str, "TEST%d", i);
+        sprintf(str, "TEST%zu", i);
         res = vector_add(vec, strdup(str));
         assert(res == true);
-        assert(vec->len == (size_t)i + 1);
+        assert(vec->len == i + 1);
     }
     res = vector_resize(vec, 5);
     assert(res == true);

--- a/wrappers/golang/libdogecoin/libdogecoin.go
+++ b/wrappers/golang/libdogecoin/libdogecoin.go
@@ -80,7 +80,7 @@ func W_verify_hd_master_pub_keypair(wif_privkey_master string, p2pkh_pubkey_mast
 func W_verify_p2pkh_address(p2pkh_pubkey string) (result bool) {
 	c_p2pkh_pubkey := C.CString(p2pkh_pubkey)
 	len := len(p2pkh_pubkey)
-	c_len := C.uchar(len)
+	c_len := C.size_t(len)
 	if C.verifyP2pkhAddress(c_p2pkh_pubkey, c_len) == 1 {
 		result = true
 	} else {

--- a/wrappers/python/libdogecoin/libdogecoin.pyx
+++ b/wrappers/python/libdogecoin/libdogecoin.pyx
@@ -14,7 +14,7 @@ cdef extern from "libdogecoin.h":
     int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey)
     int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bint is_testnet)
     int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bint is_testnet)
-    int verifyP2pkhAddress(char* p2pkh_pubkey, cy.uchar len)
+    int verifyP2pkhAddress(char* p2pkh_pubkey, cy.size_t len)
 
     # transaction.c
     int start_transaction()


### PR DESCRIPTION
Stuff dealing with array sizes/lengths/memory locations/etc really should be consistently `size_t` even though a lot of these cases will never exceed 32bit values. Both for security reasons and because it's annoying as an end user to call an api and have to truncate your own data down from a proper `size_t` to `int`. I should be able to just call `SomeApiCall(buff, sizeof(buff))` without having to cast a bunch of stuff `SomeApiCall(buff, (int)sizeof(buff))`

Bad things can happen when these conversions are ignored, such as in this somewhat recent linux vulnerability https://packetstormsecurity.com/files/163621/Sequoia-A-Deep-Root-In-Linuxs-Filesystem-Layer.html. I'm just not sure why these are not popping up as warnings. Warning settings may need to be reevaluated