### PR TITLE
expose derived hd address and p2pkh scripthash conversion functions

### DIFF
--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -58,6 +58,11 @@ int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master
 /* verify that a dogecoin address is valid. */
 int verifyP2pkhAddress(char* p2pkh_pubkey, size_t len);
 
+/* get a derived hd address. */
+int getDerivedHDAddress(const char* masterkey, uint32_t account, bool ischange, uint32_t addressindex, char* outaddress, bool outprivkey);
+
+/* get a derived hd address with a custom path. e.g. m/44'/3'/0'/0/0 */
+int getDerivedHDAddressByPath(const char* masterkey, const char* derived_path, char* outaddress, bool outprivkey);
 
 /*transaction creation functions - builds a dogecoin transaction
 ----------------------------------------------------------------

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -32,6 +32,9 @@
 #include <string.h>
 #include <stdbool.h>
 
+#include <dogecoin/cstr.h>
+#include <dogecoin/tx.h>
+
 /* basic address functions: return 1 if succesful 
    ----------------------------------------------
 *///!init static ecc context


### PR DESCRIPTION
-expose both getDerivedHDAddress and getDerviedHDAddressByPath in libdogecoin.h
-expose cstr and tx headers in order to access dogecoin_private_key_wif_to_script_hash, dogecoin_p2pkh_to_script_hash and dogecoin_script_hash_to_p2pkh