### PR TITLE
ci: fix brew python err

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@
 name: CI
 
 on:
+  push:
+    branches: [ "*-dev-*"]
   pull_request:
     branches: [ "*" ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           if ([ "${{ matrix.name }}" == "x86_64-macos" ]); then
               brew update
-              brew install automake coreutils python3 ${{ matrix.packages }}
+              brew install automake coreutils ${{ matrix.packages }}
               echo PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH" >> ~/.bashrc
               source ~/.bashrc
           else


### PR DESCRIPTION
Removed `python3` from list of macOS packages since nothing needs it and it was causing that runner to fail.

Additionally I've added back the run on push trigger for our CI but only if it matches `*-dev-*` wildcard. I can go either way but had initially removed due to personal pricing concerns despite it potentially being helpful for contributors prior to opening a PR against upstream. I can also move to a different PR if anyone has a desire to limit scope.