### PR TITLE
ci/codeql: bump node.js actions from 12 to 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,11 +153,11 @@ jobs:
         run: ${{ matrix.postinstall }}
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: sdk cache
         if: ${{ matrix.sdk }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: sdk
         with:
@@ -177,7 +177,7 @@ jobs:
           tar -C depends/SDKs -xf depends/sdk-sources/${{ env.sdk-filename }}
 
       - name: dependency cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: depends
         with:
@@ -189,7 +189,7 @@ jobs:
           make $MAKEJOBS -C depends HOST=${{ matrix.host }} ${{ matrix.dep-opts }}
 
       - name: ccache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: ccache
         with:

--- a/.github/workflows/ql.yml
+++ b/.github/workflows/ql.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: update system
       run: |
@@ -41,7 +41,7 @@ jobs:
         sudo apt-get install -y autoconf automake libtool-bin libevent-dev build-essential python3
 
     - name: Dependency cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       env:
         cache-name: depends
       with:


### PR DESCRIPTION
-node.js 12 actions are deprecated therefore bump to 16 by increasing actions/checkout@v2 and actions/cache@v2 to v3