### PR TITLE
spvnode/wallet: support multiple watch addresses per init

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,6 +133,9 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([[void myfunc() {__builtin_expect(0,0);}]])],
   [ AC_MSG_RESULT([no])
   ])
 
+# Check for daemon(3)
+AC_CHECK_DECLS([daemon])
+
 m4_include(m4/macros/with.m4)
 ARG_WITH_SET([random-device], [/dev/urandom], [set the device to read random data from])
 if test "x$random_device" = x"/dev/urandom"; then

--- a/include/dogecoin/constants.h
+++ b/include/dogecoin/constants.h
@@ -38,6 +38,7 @@ LIBDOGECOIN_BEGIN_DECL
 #define WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN 53
 #define DERIVED_PATH_STRINGLEN 33
 /* NOTE: Path string composed of m/44/3/+32bits_Account+/+bool_ischange+/+32bits_Address + string terminator; for a total of 33 bytes. */
+#define KOINU_STRINGLEN 21
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/constants.h
+++ b/include/dogecoin/constants.h
@@ -39,6 +39,7 @@ LIBDOGECOIN_BEGIN_DECL
 #define DERIVED_PATH_STRINGLEN 33
 /* NOTE: Path string composed of m/44/3/+32bits_Account+/+bool_ischange+/+32bits_Address + string terminator; for a total of 33 bytes. */
 #define KOINU_STRINGLEN 21
+#define SCRIPT_PUBKEY_STRINGLEN 51
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/tx.h
+++ b/include/dogecoin/tx.h
@@ -70,9 +70,10 @@ typedef struct dogecoin_tx_ {
 } dogecoin_tx;
 
 //!p2pkh utilities
-LIBDOGECOIN_API int dogecoin_tx_out_pubkey_hash_to_p2pkh_address(dogecoin_tx_out* txout, char* p2pkh, int is_testnet);
+LIBDOGECOIN_API int dogecoin_tx_out_pubkey_hash_to_p2pkh_address(dogecoin_tx_out* txout, char* p2pkh, int is_mainnet);
 LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_hash_to_p2pkh_address(char* script_pubkey_hex, size_t script_pubkey_hex_length, char* p2pkh, const dogecoin_chainparams* chain);
 LIBDOGECOIN_API dogecoin_bool dogecoin_p2pkh_address_to_pubkey_hash(char* p2pkh, char* scripthash);
+LIBDOGECOIN_API char* dogecoin_address_to_pubkey_hash(char* p2pkh);
 LIBDOGECOIN_API char* dogecoin_private_key_wif_to_pubkey_hash(char* private_key_wif);
 
 //!create a new tx input

--- a/include/dogecoin/utils.h
+++ b/include/dogecoin/utils.h
@@ -76,6 +76,7 @@ unsigned int base64_encoded_size(unsigned int in_size);
 unsigned int base64_decoded_size(unsigned int in_size);
 unsigned int base64_encode(const unsigned char* in, unsigned int in_len, unsigned char* out);
 unsigned int base64_decode(const unsigned char* in, unsigned int in_len, unsigned char* out);
+int integer_length(int x);
 
 #define _SEARCH_PRIVATE
 #ifdef _SEARCH_PRIVATE

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -36,6 +36,7 @@ LIBDOGECOIN_BEGIN_DECL
 #include <dogecoin/blockchain.h>
 #include <dogecoin/bip32.h>
 #include <dogecoin/buffer.h>
+#include <dogecoin/constants.h>
 #include <dogecoin/tx.h>
 
 #include <stdint.h>
@@ -72,10 +73,10 @@ typedef struct dogecoin_wtx_ {
 typedef struct dogecoin_utxo_ {
     uint256 txid;
     int vout;
-    char* address;
+    char address[P2PKH_ADDR_STRINGLEN];
     char* account;
     cstring* script_pubkey;
-    char* amount;
+    char amount[KOINU_STRINGLEN];
     int confirmations;
     dogecoin_bool spendable;
     dogecoin_bool solvable;

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -174,7 +174,7 @@ LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_read(char* address);
 LIBDOGECOIN_API int dogecoin_register_watch_address_with_node(char* address);
 LIBDOGECOIN_API int dogecoin_unregister_watch_address_with_node(char* address);
 LIBDOGECOIN_API int dogecoin_get_utxo_vector(char* address, vector* utxos);
-LIBDOGECOIN_API int dogecoin_get_utxos(char* address, uint8_t* utxos);
+LIBDOGECOIN_API uint8_t* dogecoin_get_utxos(char* address);
 LIBDOGECOIN_API unsigned int dogecoin_get_utxos_length(char* address);
 LIBDOGECOIN_API char* dogecoin_get_utxo_txid_str(char* address, unsigned int index);
 LIBDOGECOIN_API uint8_t* dogecoin_get_utxo_txid(char* address, unsigned int index);

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -170,13 +170,14 @@ LIBDOGECOIN_API void dogecoin_wallet_check_transaction(void *ctx, dogecoin_tx *t
  */
 LIBDOGECOIN_API dogecoin_wtx * dogecoin_wallet_get_wtx(dogecoin_wallet* wallet, const uint256 hash);
 
-LIBDOGECOIN_API int dogecoin_register_watch_address_with_node(dogecoin_wallet* wallet, char* address);
-LIBDOGECOIN_API int dogecoin_unregister_watch_address_with_node(dogecoin_wallet* wallet, char* address);
-LIBDOGECOIN_API uint64_t dogecoin_get_balance(dogecoin_wallet* wallet, char* address, int number_of_utxos);
-LIBDOGECOIN_API char* dogecoin_get_balance_str(dogecoin_wallet* wallet, char* address, int number_of_utxos);
-LIBDOGECOIN_API int dogecoin_get_utxo_vector(dogecoin_wallet* wallet, char* address, vector* utxos);
-LIBDOGECOIN_API char* dogecoin_get_utxo_txid_str(dogecoin_wallet* wallet, char* address, unsigned int index);
-LIBDOGECOIN_API uint256* dogecoin_get_utxo_txid(dogecoin_wallet* wallet, char* address, unsigned int index);
+LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_read(char* address);
+LIBDOGECOIN_API int dogecoin_register_watch_address_with_node(char* address);
+LIBDOGECOIN_API int dogecoin_unregister_watch_address_with_node(char* address);
+LIBDOGECOIN_API uint64_t dogecoin_get_balance(char* address, int number_of_utxos);
+LIBDOGECOIN_API char* dogecoin_get_balance_str(char* address, int number_of_utxos);
+LIBDOGECOIN_API int dogecoin_get_utxo_vector(char* address, vector* utxos);
+LIBDOGECOIN_API char* dogecoin_get_utxo_txid_str(char* address, unsigned int index);
+LIBDOGECOIN_API uint8_t* dogecoin_get_utxo_txid(char* address, unsigned int index);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -173,11 +173,11 @@ LIBDOGECOIN_API dogecoin_wtx * dogecoin_wallet_get_wtx(dogecoin_wallet* wallet, 
 LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_read(char* address);
 LIBDOGECOIN_API int dogecoin_register_watch_address_with_node(char* address);
 LIBDOGECOIN_API int dogecoin_unregister_watch_address_with_node(char* address);
-LIBDOGECOIN_API uint64_t dogecoin_get_balance(char* address, int number_of_utxos);
-LIBDOGECOIN_API char* dogecoin_get_balance_str(char* address, int number_of_utxos);
 LIBDOGECOIN_API int dogecoin_get_utxo_vector(char* address, vector* utxos);
 LIBDOGECOIN_API char* dogecoin_get_utxo_txid_str(char* address, unsigned int index);
 LIBDOGECOIN_API uint8_t* dogecoin_get_utxo_txid(char* address, unsigned int index);
+LIBDOGECOIN_API uint64_t dogecoin_get_balance(char* address, int number_of_utxos);
+LIBDOGECOIN_API char* dogecoin_get_balance_str(char* address, int number_of_utxos);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -170,6 +170,14 @@ LIBDOGECOIN_API void dogecoin_wallet_check_transaction(void *ctx, dogecoin_tx *t
  */
 LIBDOGECOIN_API dogecoin_wtx * dogecoin_wallet_get_wtx(dogecoin_wallet* wallet, const uint256 hash);
 
+LIBDOGECOIN_API int dogecoin_register_watch_address_with_node(dogecoin_wallet* wallet, char* address);
+LIBDOGECOIN_API int dogecoin_unregister_watch_address_with_node(dogecoin_wallet* wallet, char* address);
+LIBDOGECOIN_API uint64_t dogecoin_get_balance(dogecoin_wallet* wallet, char* address, int number_of_utxos);
+LIBDOGECOIN_API char* dogecoin_get_balance_str(dogecoin_wallet* wallet, char* address, int number_of_utxos);
+LIBDOGECOIN_API int dogecoin_get_utxo_vector(dogecoin_wallet* wallet, char* address, vector* utxos);
+LIBDOGECOIN_API char* dogecoin_get_utxo_txid_str(dogecoin_wallet* wallet, char* address, unsigned int index);
+LIBDOGECOIN_API uint256* dogecoin_get_utxo_txid(dogecoin_wallet* wallet, char* address, unsigned int index);
+
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_WALLET_H__

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -75,7 +75,7 @@ typedef struct dogecoin_utxo_ {
     int vout;
     char address[P2PKH_ADDR_STRINGLEN];
     char* account;
-    cstring* script_pubkey;
+    char script_pubkey[SCRIPT_PUBKEY_STRINGLEN];
     char amount[KOINU_STRINGLEN];
     int confirmations;
     dogecoin_bool spendable;

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -174,10 +174,12 @@ LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_read(char* address);
 LIBDOGECOIN_API int dogecoin_register_watch_address_with_node(char* address);
 LIBDOGECOIN_API int dogecoin_unregister_watch_address_with_node(char* address);
 LIBDOGECOIN_API int dogecoin_get_utxo_vector(char* address, vector* utxos);
+LIBDOGECOIN_API int dogecoin_get_utxos(char* address, uint8_t* utxos);
+LIBDOGECOIN_API unsigned int dogecoin_get_utxos_length(char* address);
 LIBDOGECOIN_API char* dogecoin_get_utxo_txid_str(char* address, unsigned int index);
 LIBDOGECOIN_API uint8_t* dogecoin_get_utxo_txid(char* address, unsigned int index);
-LIBDOGECOIN_API uint64_t dogecoin_get_balance(char* address, int number_of_utxos);
-LIBDOGECOIN_API char* dogecoin_get_balance_str(char* address, int number_of_utxos);
+LIBDOGECOIN_API uint64_t dogecoin_get_balance(char* address);
+LIBDOGECOIN_API char* dogecoin_get_balance_str(char* address);
 
 LIBDOGECOIN_END_DECL
 

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -343,8 +343,17 @@ int main(int argc, char* argv[]) {
         dogecoin_ecc_stop();
     } else if (strcmp(data, "wallet") == 0) {
 #if WITH_WALLET
-        dogecoin_wallet* wallet = dogecoin_wallet_init(chain, address, mnemonic_in);
-        dogecoin_wallet_free(wallet);
+        if (address != NULL) {
+            int number_of_utxos = 0;
+            printf("balance:     %ld\n", dogecoin_get_balance(address, number_of_utxos));
+            printf("balance str: %s\n", dogecoin_get_balance_str(address, number_of_utxos));
+            vector* utxos = vector_new(1, free);
+            dogecoin_get_utxo_vector(address, utxos);
+            printf("utxos:       %ld\n", utxos->len);
+            printf("txid:      %s\n", dogecoin_get_utxo_txid_str(address, 1));
+            printf("txid:      %s\n", dogecoin_get_utxo_txid_str(address, 2));
+            vector_free(utxos, true);
+        }
 #endif
     } else {
         printf("Invalid command (use -?)\n");

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -290,7 +290,6 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, char* a
     dogecoin_wallet_addr* waddr;
 
     if (address != NULL) {
-        int init_size = strlen(address);
         char delim[] = " ";
 
         char *ptr = strtok(address, delim);

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -26,7 +26,12 @@
 
 */
 
+#ifndef WIN32
+#include <sys/stat.h>
+#include <syslog.h>
+#include <fcntl.h>
 #include <assert.h>
+#endif
 
 #ifndef _MSC_VER
 #include <getopt.h>
@@ -62,6 +67,101 @@
 #include <dogecoin/utils.h>
 #include <dogecoin/wallet.h>
 
+#ifndef WIN32
+#define BD_NO_CHDIR          01 /* Don't chdir ("/") */
+#define BD_NO_CLOSE_FILES    02 /* Don't close all open files */
+#define BD_NO_REOPEN_STD_FDS 04 /* Don't reopen stdin, stdout, and stderr
+                                   to /dev/null */
+#define BD_NO_UMASK0        010 /* Don't do a umask(0) */
+#define BD_MAX_CLOSE       8192 /* Max file descriptors to close if
+                                   sysconf(_SC_OPEN_MAX) is indeterminate */
+
+int // returns 0 on success -1 on error
+become_daemon(int flags)
+{
+  int maxfd, fd;
+
+  /* The first fork will change our pid
+   * but the sid and pgid will be the
+   * calling process.
+   */
+  switch(fork())                    // become background process
+  {
+    case -1: return -1;
+    case 0: break;                  // child falls through
+    default: _exit(EXIT_SUCCESS);   // parent terminates
+  }
+
+  /*
+   * Run the process in a new session without a controlling
+   * terminal. The process group ID will be the process ID
+   * and thus, the process will be the process group leader.
+   * After this call the process will be in a new session,
+   * and it will be the progress group leader in a new
+   * process group.
+   */
+  if(setsid() == -1)                // become leader of new session
+    return -1;
+
+  /*
+   * We will fork again, also known as a
+   * double fork. This second fork will orphan
+   * our process because the parent will exit.
+   * When the parent process exits the child
+   * process will be adopted by the init process
+   * with process ID 1.
+   * The result of this second fork is a process
+   * with the parent as the init process with an ID
+   * of 1. The process will be in it's own session
+   * and process group and will have no controlling
+   * terminal. Furthermore, the process will not
+   * be the process group leader and thus, cannot
+   * have the controlling terminal if there was one.
+   */
+  switch(fork())
+  {
+    case -1: return -1;
+    case 0: break;                  // child breaks out of case
+    default: _exit(EXIT_SUCCESS);   // parent process will exit
+  }
+
+  if(!(flags & BD_NO_UMASK0))
+    umask(0);                       // clear file creation mode mask
+
+//   if(!(flags & BD_NO_CHDIR))
+//     chdir("/");                     // change to root directory
+
+  if(!(flags & BD_NO_CLOSE_FILES))  // close all open files
+  {
+    maxfd = sysconf(_SC_OPEN_MAX);
+    if(maxfd == -1)
+      maxfd = BD_MAX_CLOSE;         // if we don't know then guess
+    for(fd = 0; fd < maxfd; fd++)
+      close(fd);
+  }
+
+  if(!(flags & BD_NO_REOPEN_STD_FDS))
+  {
+    /* now time to go "dark"!
+     * we'll close stdin
+     * then we'll point stdout and stderr
+     * to /dev/null
+     */
+    close(STDIN_FILENO);
+
+    fd = open("/dev/null", O_RDWR);
+    if(fd != STDIN_FILENO)
+      return -1;
+    if(dup2(STDIN_FILENO, STDOUT_FILENO) != STDOUT_FILENO)
+      return -2;
+    if(dup2(STDIN_FILENO, STDERR_FILENO) != STDERR_FILENO)
+      return -3;
+  }
+
+  return 0;
+}
+#endif
+
 /* This is a list of all the options that can be used with the program. */
 static struct option long_options[] = {
         {"testnet", no_argument, NULL, 't'},
@@ -75,7 +175,7 @@ static struct option long_options[] = {
         {"address", no_argument, NULL, 'a'},
         {"full_sync", no_argument, NULL, 'b'},
         {"checkpoint", no_argument, NULL, 'p'},
-        {"wallet_cmd", no_argument, NULL, 'w'},
+        {"daemon", no_argument, NULL, 'z'},
         {NULL, 0, NULL, 0} };
 
 /**
@@ -260,6 +360,7 @@ int main(int argc, char* argv[]) {
     dogecoin_bool use_checkpoint = false;
     char* mnemonic_in = 0;
     dogecoin_bool full_sync = false;
+    dogecoin_bool have_decl_daemon = false;
 
     if (argc <= 1 || strlen(argv[argc - 1]) == 0 || argv[argc - 1][0] == '-') {
         /* exit if no command was provided */
@@ -269,7 +370,7 @@ int main(int argc, char* argv[]) {
     data = argv[argc - 1];
 
     /* get arguments */
-    while ((opt = getopt_long_only(argc, argv, "i:ctrds:m:n:f:a:bp:", long_options, &long_index)) != -1) {
+    while ((opt = getopt_long_only(argc, argv, "i:ctrds:m:n:f:a:bpz:", long_options, &long_index)) != -1) {
         switch (opt) {
                 case 'c':
                     quit_when_synced = false;
@@ -300,6 +401,9 @@ int main(int argc, char* argv[]) {
                     break;
                 case 'p':
                     use_checkpoint = true;
+                    break;
+                case 'z':
+                    have_decl_daemon = true;
                     break;
                 case 'v':
                     print_version();
@@ -332,6 +436,37 @@ int main(int argc, char* argv[]) {
             printf("Could not load or create headers database...aborting\n");
             ret = EXIT_FAILURE;
         } else {
+            if (have_decl_daemon) {
+#if defined(HAVE_DECL_DAEMON) && !defined(WIN32)
+                const char *LOGNAME = "libdogecoin-spvnode";
+
+                // turn this process into a daemon
+                ret = become_daemon(0);
+                if(ret)
+                {
+                    syslog(LOG_USER | LOG_ERR, "error starting");
+                    closelog();
+                    return EXIT_FAILURE;
+                }
+
+                // we are now a daemon!
+                // printf now will go to /dev/null
+
+                // open up the system log
+                openlog(LOGNAME, LOG_PID, LOG_USER);
+                syslog(LOG_USER | LOG_INFO, "starting");
+
+                // run forever in the background
+                while(1)
+                {
+                    sleep(60);
+                    syslog(LOG_USER | LOG_INFO, "running");
+                }
+#else
+            fprintf(stderr, "Error: -z | --daemon is not supported on this operating system\n");
+            return false;
+#endif
+            }
             printf("done\n");
             printf("Discover peers...\n");
             dogecoin_spv_client_discover_peers(client, ips);

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -489,18 +489,18 @@ int main(int argc, char* argv[]) {
     } else if (strcmp(data, "wallet") == 0) {
 #if WITH_WALLET
         if (address != NULL) {
-            printf("balance:        %ld\n", dogecoin_get_balance(address));
-            printf("balance str:    %s\n", dogecoin_get_balance_str(address));
-            vector* utxos = vector_new(1, free);
-            dogecoin_get_utxo_vector(address, utxos);
-            unsigned int utxo_count = dogecoin_get_utxos_length(address);
-            printf("utxo count:     %d\n", utxo_count);
-            uint8_t* byte_array = dogecoin_get_utxos(address);
-            size_t byte_array_length = strlen((const char*)byte_array);
-            printf("byte_array:     %s\n", utils_uint8_to_hex(byte_array, byte_array_length));
-            printf("txid:           %s\n", dogecoin_get_utxo_txid_str(address, 1));
-            printf("txid:           %s\n", dogecoin_get_utxo_txid_str(address, 2));
-            vector_free(utxos, true);
+            uint64_t amount = dogecoin_get_balance(address);
+            if (amount > 0) {
+                printf("amount:         %s\n", dogecoin_get_balance_str(address));
+                unsigned int utxo_count = dogecoin_get_utxos_length(address);
+                if (utxo_count) {
+                    printf("utxo count:     %d\n", utxo_count);
+                    unsigned int i = 1;
+                    for (; i <= utxo_count; i++) {
+                        printf("txid:           %s\n", dogecoin_get_utxo_txid_str(address, i));
+                    }
+                }
+            }
         }
 #endif
     } else {

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -481,6 +481,9 @@ int main(int argc, char* argv[]) {
             dogecoin_spv_client_runloop(client);
             dogecoin_spv_client_free(client);
             ret = EXIT_SUCCESS;
+#if WITH_WALLET
+            dogecoin_wallet_free(wallet);
+#endif
             }
         dogecoin_ecc_stop();
     } else if (strcmp(data, "wallet") == 0) {

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -340,7 +340,7 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, char* a
             printf("txid:           %s\n", utils_uint8_to_hex(utxo->txid, sizeof utxo->txid));
             printf("vout:           %d\n", utxo->vout);
             printf("address:        %s\n", utxo->address);
-            printf("script_pubkey:  %s\n", utils_uint8_to_hex((uint8_t*)utxo->script_pubkey->str, utxo->script_pubkey->len));
+            printf("script_pubkey:  %s\n", utxo->script_pubkey);
             printf("amount:         %s\n", utxo->amount);
             debug_print("confirmations:  %d\n", utxo->confirmations);
             printf("spendable:      %d\n", utxo->spendable);

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -344,19 +344,17 @@ int main(int argc, char* argv[]) {
     } else if (strcmp(data, "wallet") == 0) {
 #if WITH_WALLET
         if (address != NULL) {
-            printf("balance:     %ld\n", dogecoin_get_balance(address));
-            printf("balance str: %s\n", dogecoin_get_balance_str(address));
+            printf("balance:        %ld\n", dogecoin_get_balance(address));
+            printf("balance str:    %s\n", dogecoin_get_balance_str(address));
             vector* utxos = vector_new(1, free);
             dogecoin_get_utxo_vector(address, utxos);
             unsigned int utxo_count = dogecoin_get_utxos_length(address);
-            printf("%d\n", utxo_count);
-            uint8_t* byte_array = (uint8_t*)dogecoin_malloc(utxo_count * 54);
-            dogecoin_get_utxos(address, byte_array);
-            printf("byte_array: %s\n", utils_uint8_to_hex(byte_array, strlen(byte_array)));
-            printf("byte_array length: %ld\n", strlen(byte_array));
-            printf("txid:      %s\n", dogecoin_get_utxo_txid_str(address, 1));
-            printf("txid:      %s\n", dogecoin_get_utxo_txid_str(address, 2));
-            dogecoin_free(byte_array);
+            printf("utxo count:     %d\n", utxo_count);
+            uint8_t* byte_array = dogecoin_get_utxos(address);
+            size_t byte_array_length = strlen((const char*)byte_array);
+            printf("byte_array:     %s\n", utils_uint8_to_hex(byte_array, byte_array_length));
+            printf("txid:           %s\n", dogecoin_get_utxo_txid_str(address, 1));
+            printf("txid:           %s\n", dogecoin_get_utxo_txid_str(address, 2));
             vector_free(utxos, true);
         }
 #endif

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -344,14 +344,19 @@ int main(int argc, char* argv[]) {
     } else if (strcmp(data, "wallet") == 0) {
 #if WITH_WALLET
         if (address != NULL) {
-            int number_of_utxos = 0;
-            printf("balance:     %ld\n", dogecoin_get_balance(address, number_of_utxos));
-            printf("balance str: %s\n", dogecoin_get_balance_str(address, number_of_utxos));
+            printf("balance:     %ld\n", dogecoin_get_balance(address));
+            printf("balance str: %s\n", dogecoin_get_balance_str(address));
             vector* utxos = vector_new(1, free);
             dogecoin_get_utxo_vector(address, utxos);
-            printf("utxos:       %ld\n", utxos->len);
+            unsigned int utxo_count = dogecoin_get_utxos_length(address);
+            printf("%d\n", utxo_count);
+            uint8_t* byte_array = (uint8_t*)dogecoin_malloc(utxo_count * 54);
+            dogecoin_get_utxos(address, byte_array);
+            printf("byte_array: %s\n", utils_uint8_to_hex(byte_array, strlen(byte_array)));
+            printf("byte_array length: %ld\n", strlen(byte_array));
             printf("txid:      %s\n", dogecoin_get_utxo_txid_str(address, 1));
             printf("txid:      %s\n", dogecoin_get_utxo_txid_str(address, 2));
+            dogecoin_free(byte_array);
             vector_free(utxos, true);
         }
 #endif

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -346,12 +346,11 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, char* a
             printf("spendable:      %d\n", utxo->spendable);
             printf("solvable:       %d\n", utxo->solvable);
             wallet_total_u64 += coins_to_koinu_str(utxo->amount);
-            dogecoin_wallet_utxo_free(utxo);
         }
         koinu_to_coins_str(wallet_total_u64, wallet_total);
         printf("Balance: %s\n", wallet_total);
     }
-    dogecoin_free(unspent);
+    vector_free(unspent, true);
     return wallet;
 }
 

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -290,9 +290,18 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, char* a
     dogecoin_wallet_addr* waddr;
 
     if (address != NULL) {
-        waddr = dogecoin_wallet_addr_new();
-        if (!dogecoin_p2pkh_address_to_wallet_pubkeyhash(address, waddr, wallet)) {
-            exit(EXIT_FAILURE);
+        int init_size = strlen(address);
+        char delim[] = " ";
+
+        char *ptr = strtok(address, delim);
+
+        while(ptr != NULL)
+        {
+            waddr = dogecoin_wallet_addr_new();
+            if (!dogecoin_p2pkh_address_to_wallet_pubkeyhash(ptr, waddr, wallet)) {
+                exit(EXIT_FAILURE);
+            }
+            ptr = strtok(NULL, delim);
         }
     } 
 #ifdef USE_UNISTRING  

--- a/src/utils.c
+++ b/src/utils.c
@@ -685,3 +685,12 @@ unsigned int base64_decode(const unsigned char* in, unsigned int in_len, unsigne
 
 	return k;
 }
+
+int integer_length(int x) {
+    int count = 0;
+    while (x > 0) {
+        x /= 10;
+        count++;
+    }
+    return count > 0 ? count : 1;
+}

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -226,8 +226,6 @@ dogecoin_utxo* dogecoin_wallet_utxo_new() {
 }
 
 void dogecoin_wallet_utxo_free(dogecoin_utxo* utxo) {
-    cstr_free(utxo->script_pubkey, true);
-    dogecoin_free(utxo->amount);
     dogecoin_free(utxo);
 }
 
@@ -400,10 +398,7 @@ void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
                     char* hexbuf = utils_uint8_to_hex((const uint8_t*)utxo->txid, DOGECOIN_HASH_LENGTH);
                     utils_reverse_hex(hexbuf, DOGECOIN_HASH_LENGTH*2);
                     memcpy_safe(utxo->txid, utils_hex_to_uint8(hexbuf), 64);
-                    utxo->script_pubkey = cstr_new_sz(tx_out->script_pubkey->len);
-                    cstr_append_buf(utxo->script_pubkey,
-                                    tx_out->script_pubkey->str,
-                                    tx_out->script_pubkey->len);
+                    memcpy_safe(utxo->script_pubkey, utils_uint8_to_hex((const uint8_t*)tx_out->script_pubkey->str, tx_out->script_pubkey->len), SCRIPT_PUBKEY_STRINGLEN);
                     utxo->vout = j;
                     memcpy_safe(utxo->address, p2pkh_from_script_pubkey, P2PKH_ADDR_STRINGLEN);
                     koinu_to_coins_str(tx_out->value, utxo->amount);


### PR DESCRIPTION
This PR introduces introduces possibility to add multiple watch addresses during spvnode initialization:

```
./spvnode -c -a "address address address" -b -p scan
```
It also has beginnings of daemon process (-z || --daemon) on linux/unix and rudimentary utxo byte array for transit via wire among other semi useful functions for radio use.

Big change is in how we convert script pubkeys to p2pkh addresses which now properly ser/deser.

That said there are still a number of memory leaks that have prevented any additional commits from being included as they are under heavy development and caused issues during sync. (I've successfully synced and scraped multiple addresses using this commit so am going to "call it" so to speak while I work on including some of the back logged stuff.)