### PR TITLE
ci: update mac osx sdk checksum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             goal: install
             sdk: 12.2
             sdk-build: 12B45b
-            sdk-shasum: "66c4d0756e3f5c6303643410c99821db8ec91b600f423b29788d1d7b9f35e2c1"
+            sdk-shasum: "df75d30ecafc429e905134333aeae56ac65fac67cb4182622398fd717df77619"
           # - name: arm64-macos
           #   host: arm64-apple-darwin
           #   os: macos-latest
@@ -78,7 +78,7 @@ jobs:
           #   goal: install
           #   sdk: 12.2
           #   sdk-build: 12B45b
-          #   sdk-shasum: "66c4d0756e3f5c6303643410c99821db8ec91b600f423b29788d1d7b9f35e2c1"
+          #   sdk-shasum: "df75d30ecafc429e905134333aeae56ac65fac67cb4182622398fd717df77619"
           - name: x86_64-win
             host: x86_64-w64-mingw32
             arch: i386

--- a/contrib/scripts/sdk.sh
+++ b/contrib/scripts/sdk.sh
@@ -7,7 +7,7 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel 2> /dev/null)
 $PROJECT_ROOT/contrib/scripts/check_dir.sh
 
 SDK_URL=https://bitcoincore.org/depends-sources/sdks
-SDK_SHASUM="66c4d0756e3f5c6303643410c99821db8ec91b600f423b29788d1d7b9f35e2c1"
+SDK_SHASUM="df75d30ecafc429e905134333aeae56ac65fac67cb4182622398fd717df77619"
 SDK_VERSION=12.2
 SDK_BUILD="12B45b"
 SDK_FILENAME=Xcode-$SDK_VERSION-$SDK_BUILD-extracted-SDK-with-libcxx-headers.tar.gz


### PR DESCRIPTION
-bitcoin core updated their hosted version of Xcode-12.2-12B45b-extracted-SDK-with-libcxx-headers.tar.gz which broke our checksum validation. i wrote security@bitcoincore.org and received confirmation from fanquake that it was updated to reflect the checksum found here: https://github.com/bitcoin/bitcoin/tree/master/contrib/macdeploy#step-2-generating-xcode-122-12b45b-extracted-sdk-with-libcxx-headerstargz-from-xcodeapp