### PR TITLE
bug-fix: python wrapper missing unistring

### DIFF
--- a/wrappers/python/libdogecoin/setup.py
+++ b/wrappers/python/libdogecoin/setup.py
@@ -10,7 +10,7 @@ libdoge_extension = [Extension(
                         "include",
                         "include/dogecoin",
                         "secp256k1/include"],
-    libraries =         ["event", "event_core", "pthread", "m"],
+    libraries =         ["event", "event_core", "pthread", "m", "unistring"],
     extra_objects=      [".libs/libdogecoin.a", 
                         "src/secp256k1/.libs/libsecp256k1.a", 
                         "src/secp256k1/.libs/libsecp256k1_precomputed.a"]


### PR DESCRIPTION
import libdogecoin false: 
ImportError: .....build/lib.linux-x86_64-3.9/libdogecoin.cpython-39-x86_64-linux-gnu.so: undefined symbol: uninorm_nfkd


fix it