### PR TITLE
wallet: fix rehydration of waddr_rbtree and route wtx to proper vector

### DIFF
--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -329,6 +329,26 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, char* a
         }
     vector_free(addrs, true);
 
+    if (wallet->spends->len) {
+        char wallet_total[21];
+        uint64_t wallet_total_u64 = 0;
+        unsigned int g = 0;
+        for (; g < wallet->spends->len; g++) {
+            dogecoin_utxo* utxo = vector_idx(wallet->spends, g);
+            printf("%s\n", "----------------------");
+            printf("txid:           %s\n", utils_uint8_to_hex(utxo->txid, sizeof utxo->txid));
+            printf("vout:           %d\n", utxo->vout);
+            printf("address:        %s\n", utxo->address);
+            printf("script_pubkey:  %s\n", utxo->script_pubkey);
+            printf("amount:         %s\n", utxo->amount);
+            debug_print("confirmations:  %d\n", utxo->confirmations);
+            printf("spendable:      %d\n", utxo->spendable);
+            printf("solvable:       %d\n", utxo->solvable);
+            wallet_total_u64 += coins_to_koinu_str(utxo->amount);
+        }
+        koinu_to_coins_str(wallet_total_u64, wallet_total);
+        printf("Spent Balance: %s\n", wallet_total);
+    }
     vector* unspent = vector_new(1, free);
     dogecoin_wallet_get_unspent(wallet, unspent);
     if (unspent->len) {
@@ -348,7 +368,7 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, char* a
             wallet_total_u64 += coins_to_koinu_str(utxo->amount);
         }
         koinu_to_coins_str(wallet_total_u64, wallet_total);
-        printf("Balance: %s\n", wallet_total);
+        printf("Unspent Balance: %s\n", wallet_total);
     }
     vector_free(unspent, true);
     return wallet;

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -404,6 +404,27 @@ void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
                     koinu_to_coins_str(tx_out->value, utxo->amount);
                     dogecoin_btree_tfind(utxo, &wallet->unspent_rbtree, dogecoin_utxo_compare);
                     vector_add(wallet->unspent, utxo);
+                    unsigned int z = 0;
+                    for (; z < wallet->vec_wtxes->len; z++) {
+                        dogecoin_wtx* existing_wtx = vector_idx(wallet->vec_wtxes, z);
+                        unsigned int y = 0;
+                        for (; y < wallet->unspent->len; y++) {
+                            dogecoin_utxo* utxo = vector_idx(wallet->unspent, y);
+                            unsigned int x = 0;
+                            for (; x < existing_wtx->tx->vin->len; x++) {
+                                dogecoin_tx_in* tx_in = vector_idx(existing_wtx->tx->vin, x);
+                                char* prevout_hash = utils_uint8_to_hex(tx_in->prevout.hash, 32);
+                                utils_reverse_hex(prevout_hash, 64);
+                                uint8_t* prevout_hash_bytes = utils_hex_to_uint8(prevout_hash);
+                                if (memcmp(prevout_hash_bytes, utxo->txid, 32)==0) {
+                                    utxo->spendable = 0;
+                                    utxo->solvable = 0;
+                                    vector_add(wallet->spends, utxo);
+                                    vector_remove_idx(wallet->unspent, y);
+                                }
+                            }
+                        }
+                    }
                 }
             }
             vector_free(addrs, true);
@@ -531,27 +552,6 @@ dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_pat
                 dogecoin_wallet_wtx_deserialize(wtx, &cbuf);
                 dogecoin_wallet_scrape_utxos(wallet, wtx);
                 dogecoin_wallet_add_wtx_intern_move(wallet, wtx); // hands memory management over to the binary tree
-                unsigned int z = 0;
-                for (; z < wallet->vec_wtxes->len; z++) {
-                    dogecoin_wtx* wtx = vector_idx(wallet->vec_wtxes, z);
-                    unsigned int y = 0;
-                    for (; y < wallet->unspent->len; y++) {
-                        dogecoin_utxo* utxo = vector_idx(wallet->unspent, y);
-                        unsigned int x = 0;
-                        for (; x < wtx->tx->vin->len; x++) {
-                            dogecoin_tx_in* tx_in = vector_idx(wtx->tx->vin, x);
-                            char* prevout_hash = utils_uint8_to_hex(tx_in->prevout.hash, 32);
-                            utils_reverse_hex(prevout_hash, 64);
-                            uint8_t* prevout_hash_bytes = utils_hex_to_uint8(prevout_hash);
-                            if (memcmp(prevout_hash_bytes, utxo->txid, 32)==0) {
-                                utxo->spendable = 0;
-                                utxo->solvable = 0;
-                                vector_add(wallet->spends, utxo);
-                                vector_remove_idx(wallet->unspent, y);
-                            }
-                        }
-                    }
-                }
             } else {
                 fseek(wallet->dbfile , reclen, SEEK_CUR);
             }

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -517,7 +517,7 @@ dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_pat
 
                 dogecoin_wallet_addr_deserialize(waddr, wallet->chain, &cbuf);
                 // add the node to the binary tree
-                dogecoin_btree_tfind(waddr, &wallet->waddr_rbtree, dogecoin_wallet_addr_compare);
+                dogecoin_btree_tsearch(waddr, &wallet->waddr_rbtree, dogecoin_wallet_addr_compare);
                 vector_add(wallet->waddr_vector, waddr);
                 wallet->next_childindex = waddr->childindex+1;
             } else if (rectype == WALLET_DB_REC_TYPE_TX) {
@@ -531,6 +531,27 @@ dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_pat
                 dogecoin_wallet_wtx_deserialize(wtx, &cbuf);
                 dogecoin_wallet_scrape_utxos(wallet, wtx);
                 dogecoin_wallet_add_wtx_intern_move(wallet, wtx); // hands memory management over to the binary tree
+                unsigned int z = 0;
+                for (; z < wallet->vec_wtxes->len; z++) {
+                    dogecoin_wtx* wtx = vector_idx(wallet->vec_wtxes, z);
+                    unsigned int y = 0;
+                    for (; y < wallet->unspent->len; y++) {
+                        dogecoin_utxo* utxo = vector_idx(wallet->unspent, y);
+                        unsigned int x = 0;
+                        for (; x < wtx->tx->vin->len; x++) {
+                            dogecoin_tx_in* tx_in = vector_idx(wtx->tx->vin, x);
+                            char* prevout_hash = utils_uint8_to_hex(tx_in->prevout.hash, 32);
+                            utils_reverse_hex(prevout_hash, 64);
+                            uint8_t* prevout_hash_bytes = utils_hex_to_uint8(prevout_hash);
+                            if (memcmp(prevout_hash_bytes, utxo->txid, 32)==0) {
+                                utxo->spendable = 0;
+                                utxo->solvable = 0;
+                                vector_add(wallet->spends, utxo);
+                                vector_remove_idx(wallet->unspent, y);
+                            }
+                        }
+                    }
+                }
             } else {
                 fseek(wallet->dbfile , reclen, SEEK_CUR);
             }


### PR DESCRIPTION
i'm going to make the previous pr more map centric and atomic. this one fixes issues found in successive starts to spvnode wiping out the wallet->waddr_rbtree and routes wtx's to proper vector on init.