### PR TITLE
qa/spv: shorten block duration on ibd and switch to testnet for spv_test

### DIFF
--- a/src/spv.c
+++ b/src/spv.c
@@ -56,7 +56,7 @@
 static const unsigned int HEADERS_MAX_RESPONSE_TIME = 60;
 static const unsigned int MIN_TIME_DELTA_FOR_STATE_CHECK = 5;
 static const unsigned int BLOCK_GAP_TO_DEDUCT_TO_START_SCAN_FROM = 5;
-static const unsigned int BLOCKS_DELTA_IN_S = 36000; // roughly 2 days minus 5 minutes (oldest_item_of_interest)
+static const unsigned int BLOCKS_DELTA_IN_S = 900;
 static const unsigned int COMPLETED_WHEN_NUM_NODES_AT_SAME_HEIGHT = 2;
 
 static dogecoin_bool dogecoin_net_spv_node_timer_callback(dogecoin_node *node, uint64_t *now);

--- a/test/spv_tests.c
+++ b/test/spv_tests.c
@@ -56,7 +56,7 @@ dogecoin_bool test_spv_header_message_processed(struct dogecoin_spv_client_ *cli
 void test_spv()
 {
     // set chain:
-    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_test;
 
     // concatenate chain to prefix of headers database:
     char* header_suffix = "_headers.db";


### PR DESCRIPTION
the following significantly expedites the time it's taking to run tests on ci. changes include:

-shorten the duration of downloading blocks near the tip
-switch spv_test back to testnet on account of resolution to testseed.jrn.me.uk