### PR TITLE
depends: Add support for Android

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -53,6 +53,11 @@ full_host_os:=$(subst $(host_arch)-$(host_vendor)-,,$(canonical_host))
 host_os:=$(findstring linux,$(full_host_os))
 host_os+=$(findstring darwin,$(full_host_os))
 host_os+=$(findstring mingw32,$(full_host_os))
+
+ifeq (android,$(findstring android,$(full_host_os)))
+host_os:=android
+endif
+
 host_os:=$(strip $(host_os))
 ifeq ($(host_os),)
 host_os=$(full_host_os)

--- a/depends/README.md
+++ b/depends/README.md
@@ -26,6 +26,9 @@ Common `host-platform-triplets` for cross compilation are:
 - `arm-linux-gnueabihf` for Linux ARM 32 bit
 - `aarch64-linux-gnu` for Linux ARM 64 bit
 - `x86_64-linux-gnu` for Linux 64 bit
+- `armv7a-linux-android` for Android ARM 32 bit
+- `aarch64-linux-android` for Android ARM 64 bit
+- `x86_64-linux-android` for Android x86 64 bit
 
 No other options are needed, the paths are automatically configured.
 
@@ -34,7 +37,9 @@ The following can be set when running make: make FOO=bar
 
     SOURCES_PATH: downloaded sources will be placed here
     BASE_CACHE: built packages will be placed here
-    SDK_PATH: Path where sdk's can be found (used by OSX)
+    SDK_PATH: Path where sdk's can be found (used by OSX and Android)
+    ANDROID_TOOLCHAIN_BIN: Path to Android toolchain if installed via Android SDK Manager
+    ANDROID_API_LEVEL: API level corresponding to the Android version targeted
     FALLBACK_DOWNLOAD_PATH: If a source file can't be fetched, try here before giving up
     DEBUG: disable some optimizations and enable more runtime checking
     HOST_ID_SALT: Optional salt to use when generating host package ids

--- a/depends/hosts/android.mk
+++ b/depends/hosts/android.mk
@@ -1,0 +1,18 @@
+ANDROID_API_LEVEL=21
+ANDROID_NDK_VERSION=android-ndk-r25c
+
+ANDROID_NDK=$(SDK_PATH)/$(ANDROID_NDK_VERSION)
+ANDROID_TOOLCHAIN_BIN=$(ANDROID_NDK)/toolchains/llvm/prebuilt/linux-x86_64/bin
+
+ifeq ($(HOST),armv7a-linux-android)
+android_CXX=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)eabi$(ANDROID_API_LEVEL)-clang++
+android_CC=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)eabi$(ANDROID_API_LEVEL)-clang
+else
+android_CXX=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)$(ANDROID_API_LEVEL)-clang++
+android_CC=$(ANDROID_TOOLCHAIN_BIN)/$(HOST)$(ANDROID_API_LEVEL)-clang
+endif
+
+android_AR=$(ANDROID_TOOLCHAIN_BIN)/llvm-ar
+android_RANLIB=$(ANDROID_TOOLCHAIN_BIN)/llvm-ranlib
+
+android_cmake_system=Android

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -9,6 +9,7 @@ define $(package)_set_vars
   $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
+  $(package)_config_opts_android=--with-pic
   $(package)_cppflags_mingw32=-D_WIN32_WINNT=0x0601
 endef
 

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -158,10 +158,13 @@ Congratulations, you have just built an executable program that implements Libdo
 There may be times when you would like to build the library for a different operating system than you are currently running. You can do this relatively easily with `depends`, included in the Libdogecoin repo! The available operating systems you can choose from are the following:
 
 - arm-linux-gnueabihf
+- armv7a-linux-android
 - aarch64-linux-gnu
+- aarch64-linux-android
 - x86_64-pc-linux-gnu
 - x86_64-apple-darwin
 - x86_64-w64-mingw32
+- x86_64-linux-android
 - i686-w64-mingw32
 - i686-pc-linux-gnu
 


### PR DESCRIPTION
This PR adds Android support (`aarch64-linux-android`) to the depends system through the Android SDK+NDK. 

![libdoge_android_2](https://github.com/dogecoinfoundation/libdogecoin/assets/36016500/72023d6c-d528-4b5d-992e-0dcbcb26b991)
