### PR TITLE
wallet: fix dogecoin_wallet_unregister_watch_address_with_node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,9 +208,9 @@ jobs:
           make -j"$(getconf _NPROCESSORS_ONLN)" SPEED=slow V=1
           mkdir -p $build_dir/bin $build_dir/docs $build_dir/examples $build_dir/include $build_dir/lib
           if ([ "${{ matrix.name }}" == "x86_64-win" ] || [ "${{ matrix.name }}" == "i686-win" ]); then
-              cp such.exe sendtx.exe $build_dir/bin/
+              cp spvnode.exe such.exe sendtx.exe $build_dir/bin/
           else
-              cp such sendtx $build_dir/bin/
+              cp spvnode such sendtx $build_dir/bin/
           fi
           cp doc/*.md $build_dir/docs/
           cp contrib/examples/example.c $build_dir/examples/

--- a/include/dogecoin/utils.h
+++ b/include/dogecoin/utils.h
@@ -62,6 +62,7 @@ LIBDOGECOIN_API void utils_uint256_sethex(char* psz, uint8_t* out);
 LIBDOGECOIN_API uint256* uint256S(const char *str);
 LIBDOGECOIN_API unsigned char* parse_hex(const char* psz);
 LIBDOGECOIN_API void swap_bytes(uint8_t *buf, int buf_size);
+LIBDOGECOIN_API const char *find_needle(const char *haystack, size_t haystack_length, const char *needle, size_t needle_length);
 LIBDOGECOIN_API void* safe_malloc(size_t size);
 LIBDOGECOIN_API void dogecoin_cheap_random_bytes(uint8_t* buf, size_t len);
 LIBDOGECOIN_API void dogecoin_get_default_datadir(cstring* path_out);

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -136,6 +136,9 @@ LIBDOGECOIN_API void dogecoin_wallet_free(dogecoin_wallet* wallet);
 /** load the wallet, sets masterkey, sets next_childindex */
 LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_path, int *error, dogecoin_bool *created);
 
+/** load the wallet and replace a record */
+LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_replace(dogecoin_wallet* wallet, const char* file_path, cstring* record, uint8_t record_type, int *error);
+
 /** writes the wallet state to disk */
 LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_flush(dogecoin_wallet* wallet);
 

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -96,6 +96,7 @@ typedef struct dogecoin_wallet_addr_{
     uint160 pubkeyhash;
     uint8_t type;
     uint32_t childindex;
+    dogecoin_bool ignore;
 } dogecoin_wallet_addr;
 
 typedef struct dogecoin_output_ {

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -33,17 +33,27 @@
 
 LIBDOGECOIN_BEGIN_DECL
 
+#include <dogecoin/base58.h>
 #include <dogecoin/blockchain.h>
 #include <dogecoin/bip32.h>
+#include <dogecoin/bip39.h>
+#include <dogecoin/bip44.h>
 #include <dogecoin/buffer.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/common.h>
 #include <dogecoin/constants.h>
+#include <dogecoin/koinu.h>
+#include <dogecoin/random.h>
+#include <dogecoin/serialize.h>
 #include <dogecoin/tx.h>
+#include <dogecoin/utils.h>
 
 #include <stdint.h>
 #include <stddef.h>
 
 /** single key/value record */
 typedef struct dogecoin_wallet_ {
+    const char* filename;
     FILE *dbfile;
     dogecoin_hdnode* masterkey;
     uint32_t next_childindex; //cached next child index
@@ -118,6 +128,7 @@ LIBDOGECOIN_API void dogecoin_wallet_output_free(dogecoin_output* output);
 /** ------------------------------------ */
 
 LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_new(const dogecoin_chainparams *params);
+LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const char* address, const char* mnemonic_in, const char* name);
 LIBDOGECOIN_API void dogecoin_wallet_free(dogecoin_wallet* wallet);
 
 /** load the wallet, sets masterkey, sets next_childindex */

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -130,6 +130,7 @@ LIBDOGECOIN_API void dogecoin_wallet_output_free(dogecoin_output* output);
 
 LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_new(const dogecoin_chainparams *params);
 LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const char* address, const char* mnemonic_in, const char* name);
+LIBDOGECOIN_API void print_utxos(dogecoin_wallet* wallet);
 LIBDOGECOIN_API void dogecoin_wallet_free(dogecoin_wallet* wallet);
 
 /** load the wallet, sets masterkey, sets next_childindex */

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -407,21 +407,15 @@ int main(int argc, char* argv[]) {
         dogecoin_ecc_stop();
     } else if (strcmp(data, "wallet") == 0) {
 #if WITH_WALLET
-#endif
     dogecoin_ecc_start();
     dogecoin_wallet_addr* waddr;
-
     if (address != NULL) {
         char delim[] = " ";
         // copy address into a new string, strtok modifies the string
         char* address_copy = strdup(address);
-
         char *ptr = strtok(address_copy, delim);
-
         while(ptr != NULL)
         {
-
-            
             dogecoin_wallet* wallet = dogecoin_wallet_read(ptr);
             waddr = dogecoin_wallet_addr_new();
             
@@ -444,29 +438,14 @@ int main(int argc, char* argv[]) {
                     }
                 }
             }
-            res = dogecoin_unregister_watch_address_with_node(ptr);
-            printf("unregistered:   %s\n", res ? "true" : "false");
-            // shouldn't run:
-            amount = dogecoin_get_balance(ptr);
-            if (amount > 0) {
-                printf("amount:         %s\n", dogecoin_get_balance_str(ptr));
-                unsigned int utxo_count = dogecoin_get_utxos_length(ptr);
-                if (utxo_count) {
-                    printf("utxo count:     %d\n", utxo_count);
-                    unsigned int i = 1;
-                    for (; i <= utxo_count; i++) {
-                        printf("txid:           %s\n", dogecoin_get_utxo_txid_str(ptr, i));
-                        printf("vout:           %d\n", dogecoin_get_utxo_vout(ptr, i));
-                        printf("amount:         %s\n\n", dogecoin_get_utxo_amount(ptr, i));
-                    }
-                }
-            }
-
             ptr = strtok(NULL, delim);
         }
+
+        int res = dogecoin_unregister_watch_address_with_node(address);
+        printf("unregistered:   %s\n", res ? "true" : "false");
     }
-    
     dogecoin_ecc_stop();
+#endif
     } else {
         printf("Invalid command (use -?)\n");
         ret = EXIT_FAILURE;

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -208,17 +208,6 @@ static void print_usage() {
     printf("> spvnode -d -c -w \"./wallets/main_wallet.db\" -h \"./headers/main_headers.db\" scan\n\n");
     }
 
-/**
- * Prints an error message to the screen
- *
- * @param er The error message to display.
- *
- * @return Nothing.
- */
-static bool showError(const char* er) {
-    printf("Error: %s\n", er);
-    return 1;
-    }
 
 /**
  * When a new block is added to the blockchain, this function is called
@@ -252,157 +241,6 @@ void spv_sync_completed(dogecoin_spv_client* client) {
     } else {
         printf("Waiting for new blocks or relevant transactions...\n");
     }
-}
-
-dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const char* address, const char* mnemonic_in, const char* name) {
-    dogecoin_wallet* wallet = dogecoin_wallet_new(chain);
-    int error;
-    dogecoin_bool created;
-    char* wallet_suffix = "_wallet.db";
-    char* wallet_prefix = (char*)chain->chainname;
-    char* walletfile = NULL;
-    dogecoin_bool res = false;
-    if (mnemonic_in) {
-        char* wallet_type = "_mnemonic";
-        char* wallet_type_prefix = concat(wallet_prefix, wallet_type);
-        walletfile = concat(wallet_type_prefix, wallet_suffix);
-        dogecoin_free(wallet_type_prefix);
-        if (name) {
-            // Override wallet file name with name:
-            res = dogecoin_wallet_load(wallet, name, &error, &created);
-        }
-        else {
-            res = dogecoin_wallet_load(wallet, walletfile, &error, &created);
-        }
-    }
-    // else if name is set, use name for wallet file name:
-    else if (name) {
-        res = dogecoin_wallet_load(wallet, name, &error, &created);
-    }
-    else {
-        // prefix chain to wallet file name:
-        walletfile = concat(wallet_prefix, wallet_suffix);
-        res = dogecoin_wallet_load(wallet, walletfile, &error, &created);
-    }
-    dogecoin_free(walletfile);
-    if (!res) {
-        showError("Loading wallet failed\n");
-        exit(EXIT_FAILURE);
-    }
-    if (created) {
-        // create a new key
-        dogecoin_hdnode node;
-#ifdef WITH_UNISTRING
-        SEED seed;
-#else
-        uint8_t seed[64];
-#endif
-        if (mnemonic_in) {
-            // generate seed from mnemonic
-            dogecoin_seed_from_mnemonic(mnemonic_in, NULL, seed);
-        } else {
-            res = dogecoin_random_bytes(seed, sizeof(seed), true);
-            if (!res) {
-                showError("Generating random bytes failed\n");
-                exit(EXIT_FAILURE);
-            }
-        }
-        dogecoin_hdnode_from_seed(seed, sizeof(seed), &node);
-        dogecoin_wallet_set_master_key_copy(wallet, &node);
-    } else {
-        // ensure we have a key
-        // TODO
-    }
-
-    dogecoin_wallet_addr* waddr;
-
-    if (address != NULL) {
-        char delim[] = " ";
-        // copy address into a new string, strtok modifies the string
-        char* address_copy = strdup(address);
-
-        char *ptr = strtok(address_copy, delim);
-
-        while(ptr != NULL)
-        {
-            waddr = dogecoin_wallet_addr_new();
-
-            if (!dogecoin_p2pkh_address_to_wallet_pubkeyhash(ptr, waddr, wallet)) {
-                exit(EXIT_FAILURE);
-            }
-
-            ptr = strtok(NULL, delim);
-        }
-    }
-#ifdef USE_UNISTRING
-    else if (wallet->waddr_vector->len == 0) {
-        int i=0;
-        for(;i<20;i++) {
-            waddr = dogecoin_wallet_next_bip44_addr(wallet);
-        }
-        char str[P2PKH_ADDR_STRINGLEN];
-        dogecoin_p2pkh_addr_from_hash160(waddr->pubkeyhash, wallet->chain, str, P2PKH_ADDR_STRINGLEN);
-        printf("Wallet addr: %s (child %d)\n", str, waddr->childindex);
-    }
-#else
-    else if (wallet->waddr_vector->len == 0) {
-        waddr = dogecoin_wallet_next_addr(wallet);
-    }
-#endif
-
-    /* Creating a vector of addresses and storing them in the wallet. */
-    vector* addrs = vector_new(1, free);
-    dogecoin_wallet_get_addresses(wallet, addrs);
-    unsigned int i;
-    for (i = 0; i < addrs->len; i++) {
-        char* addr = vector_idx(addrs, i);
-        printf("Address: %s\n", addr);
-        }
-    vector_free(addrs, true);
-
-    if (wallet->spends->len) {
-        char wallet_total[21];
-        uint64_t wallet_total_u64 = 0;
-        unsigned int g = 0;
-        for (; g < wallet->spends->len; g++) {
-            dogecoin_utxo* utxo = vector_idx(wallet->spends, g);
-            printf("%s\n", "----------------------");
-            printf("txid:           %s\n", utils_uint8_to_hex(utxo->txid, sizeof utxo->txid));
-            printf("vout:           %d\n", utxo->vout);
-            printf("address:        %s\n", utxo->address);
-            printf("script_pubkey:  %s\n", utxo->script_pubkey);
-            printf("amount:         %s\n", utxo->amount);
-            debug_print("confirmations:  %d\n", utxo->confirmations);
-            printf("spendable:      %d\n", utxo->spendable);
-            printf("solvable:       %d\n", utxo->solvable);
-            wallet_total_u64 += coins_to_koinu_str(utxo->amount);
-        }
-        koinu_to_coins_str(wallet_total_u64, wallet_total);
-        printf("Spent Balance: %s\n", wallet_total);
-    }
-    vector* unspent = vector_new(1, free);
-    dogecoin_wallet_get_unspent(wallet, unspent);
-    if (unspent->len) {
-        char wallet_total[21];
-        uint64_t wallet_total_u64 = 0;
-        for (i = 0; i < unspent->len; i++) {
-            dogecoin_utxo* utxo = vector_idx(unspent, i);
-            printf("%s\n", "----------------------");
-            printf("txid:           %s\n", utils_uint8_to_hex(utxo->txid, sizeof utxo->txid));
-            printf("vout:           %d\n", utxo->vout);
-            printf("address:        %s\n", utxo->address);
-            printf("script_pubkey:  %s\n", utxo->script_pubkey);
-            printf("amount:         %s\n", utxo->amount);
-            debug_print("confirmations:  %d\n", utxo->confirmations);
-            printf("spendable:      %d\n", utxo->spendable);
-            printf("solvable:       %d\n", utxo->solvable);
-            wallet_total_u64 += coins_to_koinu_str(utxo->amount);
-        }
-        koinu_to_coins_str(wallet_total_u64, wallet_total);
-        printf("Unspent Balance: %s\n", wallet_total);
-    }
-    vector_free(unspent, true);
-    return wallet;
 }
 
 int main(int argc, char* argv[]) {
@@ -569,22 +407,45 @@ int main(int argc, char* argv[]) {
         dogecoin_ecc_stop();
     } else if (strcmp(data, "wallet") == 0) {
 #if WITH_WALLET
-        if (address != NULL) {
-            uint64_t amount = dogecoin_get_balance(address);
-            if (amount > 0) {
-                printf("amount:         %s\n", dogecoin_get_balance_str(address));
-                unsigned int utxo_count = dogecoin_get_utxos_length(address);
-                if (utxo_count) {
-                    printf("utxo count:     %d\n", utxo_count);
-                    unsigned int i = 1;
-                    for (; i <= utxo_count; i++) {
-                        printf("txid:           %s\n", dogecoin_get_utxo_txid_str(address, i));
-                        printf("vout:           %d\n", dogecoin_get_utxo_vout(address, i));
-                        printf("amount:         %s\n", dogecoin_get_utxo_amount(address, i));
-                    }
+    dogecoin_ecc_start();
+    int res = dogecoin_register_watch_address_with_node(address);
+    printf("registered:     %d %s\n", res, address);
+    if (address != NULL) {
+        uint64_t amount = dogecoin_get_balance(address);
+        if (amount > 0) {
+            printf("amount:         %s\n", dogecoin_get_balance_str(address));
+            unsigned int utxo_count = dogecoin_get_utxos_length(address);
+            if (utxo_count) {
+                printf("utxo count:     %d\n", utxo_count);
+                unsigned int i = 1;
+                for (; i <= utxo_count; i++) {
+                    printf("txid:           %s\n", dogecoin_get_utxo_txid_str(address, i));
+                    printf("vout:           %d\n", dogecoin_get_utxo_vout(address, i));
+                    printf("amount:         %s\n", dogecoin_get_utxo_amount(address, i));
                 }
             }
         }
+    }
+    res = dogecoin_unregister_watch_address_with_node(address);
+    printf("unregistered:   %s\n", res ? "true" : "false");
+    // shouldn't run:
+    if (address != NULL) {
+        uint64_t amount = dogecoin_get_balance(address);
+        if (amount > 0) {
+            printf("amount:         %s\n", dogecoin_get_balance_str(address));
+            unsigned int utxo_count = dogecoin_get_utxos_length(address);
+            if (utxo_count) {
+                printf("utxo count:     %d\n", utxo_count);
+                unsigned int i = 1;
+                for (; i <= utxo_count; i++) {
+                    printf("txid:           %s\n", dogecoin_get_utxo_txid_str(address, i));
+                    printf("vout:           %d\n", dogecoin_get_utxo_vout(address, i));
+                    printf("amount:         %s\n\n", dogecoin_get_utxo_amount(address, i));
+                }
+            }
+        }
+    }
+    dogecoin_ecc_stop();
 #endif
     } else {
         printf("Invalid command (use -?)\n");

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -416,12 +416,6 @@ int main(int argc, char* argv[]) {
         char *ptr = strtok(address_copy, delim);
         while(ptr != NULL)
         {
-            dogecoin_wallet* wallet = dogecoin_wallet_read(ptr);
-            waddr = dogecoin_wallet_addr_new();
-            
-            if (!dogecoin_p2pkh_address_to_wallet_pubkeyhash(ptr, waddr, wallet)) {
-                exit(EXIT_FAILURE);
-            }
             int res = dogecoin_register_watch_address_with_node(ptr);
             printf("registered:     %d %s\n", res, ptr);
             uint64_t amount = dogecoin_get_balance(ptr);

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -327,6 +327,7 @@ int main(int argc, char* argv[]) {
 
 #if WITH_WALLET
         dogecoin_wallet* wallet = dogecoin_wallet_init(chain, address, mnemonic_in, name);
+        print_utxos(wallet);
         client->sync_transaction = dogecoin_wallet_check_transaction;
         client->sync_transaction_ctx = wallet;
 #endif
@@ -408,34 +409,24 @@ int main(int argc, char* argv[]) {
     } else if (strcmp(data, "wallet") == 0) {
 #if WITH_WALLET
     dogecoin_ecc_start();
-    dogecoin_wallet_addr* waddr;
     if (address != NULL) {
-        char delim[] = " ";
-        // copy address into a new string, strtok modifies the string
-        char* address_copy = strdup(address);
-        char *ptr = strtok(address_copy, delim);
-        while(ptr != NULL)
-        {
-            int res = dogecoin_register_watch_address_with_node(ptr);
-            printf("registered:     %d %s\n", res, ptr);
-            uint64_t amount = dogecoin_get_balance(ptr);
-            if (amount > 0) {
-                printf("amount:         %s\n", dogecoin_get_balance_str(ptr));
-                unsigned int utxo_count = dogecoin_get_utxos_length(ptr);
-                if (utxo_count) {
-                    printf("utxo count:     %d\n", utxo_count);
-                    unsigned int i = 1;
-                    for (; i <= utxo_count; i++) {
-                        printf("txid:           %s\n", dogecoin_get_utxo_txid_str(ptr, i));
-                        printf("vout:           %d\n", dogecoin_get_utxo_vout(ptr, i));
-                        printf("amount:         %s\n", dogecoin_get_utxo_amount(ptr, i));
-                    }
+        int res = dogecoin_register_watch_address_with_node(address);
+        printf("registered:     %d %s\n", res, address);
+        uint64_t amount = dogecoin_get_balance(address);
+        if (amount > 0) {
+            printf("amount:         %s\n", dogecoin_get_balance_str(address));
+            unsigned int utxo_count = dogecoin_get_utxos_length(address);
+            if (utxo_count) {
+                printf("utxo count:     %d\n", utxo_count);
+                unsigned int i = 1;
+                for (; i <= utxo_count; i++) {
+                    printf("txid:           %s\n", dogecoin_get_utxo_txid_str(address, i));
+                    printf("vout:           %d\n", dogecoin_get_utxo_vout(address, i));
+                    printf("amount:         %s\n", dogecoin_get_utxo_amount(address, i));
                 }
             }
-            ptr = strtok(NULL, delim);
         }
-
-        int res = dogecoin_unregister_watch_address_with_node(address);
+        res = dogecoin_unregister_watch_address_with_node(address);
         printf("unregistered:   %s\n", res ? "true" : "false");
     }
     dogecoin_ecc_stop();

--- a/src/utils.c
+++ b/src/utils.c
@@ -369,6 +369,31 @@ void swap_bytes(uint8_t *buf, int buf_size) {
     }
 }
 
+const char *find_needle(const char *haystack, size_t haystack_length, const char *needle, size_t needle_length) {
+    size_t haystack_index = 0;
+    for (; haystack_index < haystack_length; haystack_index++) {
+
+        bool needle_found = true;
+        size_t needle_index = 0;
+        for (; needle_index < needle_length; needle_index++) {
+            const auto haystack_character = haystack[haystack_index + needle_index];
+            const auto needle_character = needle[needle_index];
+            if (haystack_character == needle_character) {
+                continue;
+            } else {
+                needle_found = false;
+                break;
+            }
+        }
+
+        if (needle_found) {
+            return &haystack[haystack_index];
+        }
+    }
+
+    return NULL;
+}
+
 /**
  * @brief This function executes malloc() but exits the
  * program if unsuccessful.

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -39,7 +39,6 @@
 
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS
-#include <stdio.h>
 #include <win/winunistd.h>
 #else
 #include <unistd.h>
@@ -1489,7 +1488,6 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
             }
 
             dogecoin_wallet_flush(wallet);
-            _fcloseall();
             dogecoin_wallet_free(wallet);
             dogecoin_wallet_flush(wallet_new);
             dogecoin_free(wallet_new);
@@ -1497,6 +1495,7 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
                 /* Attempt to rename file: */
 #ifdef WIN32
 #include <winbase.h>
+                _fcloseall();
                 LPVOID message;
                 int result = DeleteFile(newname);
                 if (!result) {

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -1300,7 +1300,6 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
             dogecoin_mem_zero(addresses, strlen(address));
             for (; i < wallet->waddr_vector->len; i++) {
                 char* address_inner = vector_idx(wallet->waddr_vector, i);
-                size_t address_length = strlen(address_inner);
                 char p2pkh_tmp[35];
                 dogecoin_p2pkh_addr_from_hash160((const uint8_t*)address_inner, wallet->chain, p2pkh_tmp, 35);
                 if (strcmp(ptr, p2pkh_tmp)==0) {
@@ -1431,7 +1430,9 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
             if (found) {
                 rename("temp.bin", wallet->filename);
             } else remove("temp.bin");
+            dogecoin_wallet_flush(wallet);
             dogecoin_wallet_free(wallet);
+            dogecoin_wallet_free(wallet_new);
             ptr = strtok(NULL, delim);
         }
     } else return false;

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -1489,6 +1489,7 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
             }
 
             dogecoin_wallet_flush(wallet);
+            _fcloseall();
             dogecoin_wallet_free(wallet);
             dogecoin_wallet_flush(wallet_new);
             dogecoin_free(wallet_new);
@@ -1496,9 +1497,14 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
                 /* Attempt to rename file: */
 #ifdef WIN32
 #include <winbase.h>
-                int result = DeleteFile(oldname);
-                if (result != 0) printf("DeleteFile failed: %d\n", result);
-                result = MoveFile(oldname, newname);
+                LPVOID message;
+                int result = DeleteFile(newname);
+                if (!result) {
+                    error = GetLastError();
+                    FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&message, 0, NULL);
+                    printf("ERROR: %s\n", message);
+                }
+                result = rename( oldname, newname );
 #else
                 int result = rename( oldname, newname );
 #endif

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -644,7 +644,7 @@ dogecoin_bool dogecoin_wallet_create(dogecoin_wallet* wallet, const char* file_p
     }
 
     wallet->filename = file_path;
-    wallet->dbfile = fopen(file_path, "w+b");
+    wallet->dbfile = fopen(file_path, "a+b");
 
     // write file-header-magic
     if (fwrite(file_hdr_magic, 4, 1, wallet->dbfile) != 1) return false;
@@ -769,7 +769,7 @@ dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_pat
     *created = true;
     if (stat(file_path, &buffer) == 0) *created = false;
 
-    wallet->dbfile = fopen(file_path, *created ? "w+b" : "r+b");
+    wallet->dbfile = fopen(file_path, *created ? "a+b" : "r+b");
 
     if (*created) {
         if (!dogecoin_wallet_create(wallet, file_path, error)) {
@@ -1452,13 +1452,10 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
                     dogecoin_p2pkh_addr_from_hash160(waddr->pubkeyhash, wallet->chain, p2pkh_check, 35);
                     if (memcmp(record->str, buf, record->len)==0) {
                         found = 1;
-                        dogecoin_btree_tdelete(waddr, &wallet_new->waddr_rbtree, dogecoin_wallet_addr_compare);
                     } else {
                         const char* addr_match = find_needle(ptr, strlen(ptr), p2pkh_check, 35);
                         if (!addr_match) {
                             if (!dogecoin_p2pkh_address_to_wallet_pubkeyhash(p2pkh_check, waddr, wallet_new)) return false;
-                            // add the node to the binary tree
-                            dogecoin_btree_tsearch(waddr, &wallet_new->waddr_rbtree, dogecoin_wallet_addr_compare);
                         }
                     }
                 } else if (rectype == WALLET_DB_REC_TYPE_TX) {

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -1475,10 +1475,12 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
                         dogecoin_p2pkh_addr_from_hash160(addr_check->pubkeyhash, wallet->chain, p2pkh_check, 35);
                         const char* match = find_needle(address, strlen(address), p2pkh_check, strlen(p2pkh_check));
                         if (!match) {
-                            dogecoin_wallet_scrape_utxos(wallet_new, wtx);
-                            dogecoin_wallet_add_wtx_move(wallet_new, wtx); // hands memory management over to the binary tree
+                            goto copy;
                         }
                     }
+copy:                    
+                    dogecoin_wallet_scrape_utxos(wallet_new, wtx);
+                    dogecoin_wallet_add_wtx_move(wallet_new, wtx); // hands memory management over to the binary tree
                 } else {
                     fseek(wallet->dbfile, reclen, SEEK_CUR);
                 }

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -1459,8 +1459,6 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
                             if (!dogecoin_p2pkh_address_to_wallet_pubkeyhash(p2pkh_check, waddr, wallet_new)) return false;
                             // add the node to the binary tree
                             dogecoin_btree_tsearch(waddr, &wallet_new->waddr_rbtree, dogecoin_wallet_addr_compare);
-                            vector_add(wallet_new->waddr_vector, waddr);
-                            wallet_new->next_childindex = waddr->childindex+1;
                         }
                     }
                 } else if (rectype == WALLET_DB_REC_TYPE_TX) {

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -1469,9 +1469,9 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
                     dogecoin_wallet_wtx_deserialize(wtx, &cbuf);
                     // loop through existing wallet and omit wtx's with matching address:
                     unsigned int i = 0;
-                    for (; i < wallet_new->waddr_vector->len; i++) {
+                    for (; i < wallet->waddr_vector->len; i++) {
                         char p2pkh_check[35];
-                        dogecoin_wallet_addr* addr_check = vector_idx(wallet_new->waddr_vector, i);
+                        dogecoin_wallet_addr* addr_check = vector_idx(wallet->waddr_vector, i);
                         dogecoin_p2pkh_addr_from_hash160(addr_check->pubkeyhash, wallet->chain, p2pkh_check, 35);
                         const char* match = find_needle(address, strlen(address), p2pkh_check, strlen(p2pkh_check));
                         if (!match) {


### PR DESCRIPTION
-this PR fixes dogecoin_wallet_unregister_watch_address_with_node and allows multiple watch addresses to be removed at a time.
-testing can be achieved by dl the new main_wallet_jul1.db and main_headers_jun29.db and walking through the steps found here:
https://gist.github.com/xanimo/96f753bcc635dc30285ca72e3b6d3e44