### PR TITLE
Proposal: fixed a few missing error-checks on return values

### DIFF
--- a/contrib/examples/example.c
+++ b/contrib/examples/example.c
@@ -261,6 +261,7 @@ int main() {
         // key 1:
         int key_id = start_key(false);
         eckey* key = find_eckey(key_id);
+		assert(key != NULL);
         char* msg = "This is a test message";
         char* sig = sign_message(key->private_key_wif, msg);
         if (verify_message(sig, msg, key->address)) {
@@ -275,6 +276,7 @@ int main() {
         // key 2:
         int key_id2 = start_key(true);
         eckey* key2 = find_eckey(key_id2);
+		assert(key2 != NULL);
         char* msg2 = "This is a test message";
         char* sig2 = sign_message(key2->private_key_wif, msg2);
         if (verify_message(sig2, msg2, key2->address)) {

--- a/doc/address.md
+++ b/doc/address.md
@@ -118,6 +118,8 @@ int main() {
 
 This function will populate provided string variables (privkey, pubkey) with freshly generated respective private and public keys for a hierarchical deterministic wallet, specifically for either mainnet or testnet as specified through the network flag (is_testnet). The function returns 1 on success and 0 on failure.
 
+The resulting wif_privkey_master is also known as the "extended master key" or "masterkey".
+
 _C usage:_
 
 ```C
@@ -148,6 +150,9 @@ int main() {
 
 This function takes a given HD master private key (wif_privkey_master) and loads it into the provided pointer for the resulting derived public key (p2pkh_pubkey). This private key input should come from the result of generateHDMasterPubKeypair(). The function returns 1 on success and 0 on failure.
 
+This function also works with any extended HD public address (e.g. dgub, tpub) from getDerivedHDAddress
+or getDerivedHDAddressByPath, to get the corresponding public P2PKH Address (Dogecoin Address)
+
 _C usage:_
 
 ```C
@@ -170,6 +175,44 @@ int main() {
   printf("master private key: %s\n", masterPrivKey);
   printf("master public key: %s\n", masterPubKey);
   printf("derived child key: %s\n", childPubKey);
+}
+```
+
+---
+
+### **generateDerivedHDPrivKeyWIF**
+
+`int generateDerivedHDPrivKeyWIF(const char* extended_private, char* out_privkey_wif)`
+
+This function converts an extended HD private address (e.g. dgpv, tprv) to a WIF-encoded private key.
+
+It works with any extended HD private address from getDerivedHDAddress or getDerivedHDAddressByPath,
+to get the corresponding WIF-encoded private key for the child address.
+
+You will need a WIF-encoded private key to sign transactions.
+
+_C usage:_
+
+```C
+#include "libdogecoin.h"
+#include <stdio.h>
+
+int main() {
+  char masterPrivKey[HD_MASTERKEY_STRINGLEN]; 
+  char masterPubKey[P2PKH_ADDR_STRINGLEN];
+  char childHDPrivate[HD_MASTERKEY_STRINGLEN];
+  char privkeyWIF[WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN];
+
+  dogecoin_ecc_start();
+  generateHDMasterPubKeypair(masterPrivKey, masterPubKey, false);
+  getDerivedHDAddress(masterPrivKey, 0, false, 1, childHDPrivate, true);
+  generateDerivedHDPrivKeyWIF(childHDPrivate, privkeyWIF);
+  dogecoin_ecc_stop();
+
+  printf("master private key: %s\n", masterPrivKey);
+  printf("master public key: %s\n", masterPubKey);
+  printf("derived child key: %s\n", childHDPrivate);
+  printf("derived privkey WIF: %s\n", privkeyWIF);
 }
 ```
 
@@ -281,7 +324,7 @@ int main() {
 
 `int getDerivedHDAddress(const char* masterkey, uint32_t account, bool ischange, uint32_t addressindex, char* outaddress, bool outprivkey)`
 
-This function derives a hierarchical deterministic address by way of providing the extended master key, account, ischange and addressindex.
+This function derives a hierarchical deterministic address (extended HD address) by way of providing the extended master key, account, ischange and addressindex.
 It will return 1 if the function is successful and 0 if not.
 
 _C usage:_

--- a/doc/eckey.md
+++ b/doc/eckey.md
@@ -91,7 +91,7 @@ eckey* new_eckey(dogecoin_bool is_testnet) {
     dogecoin_privkey_gen(&key->private_key);
     assert(dogecoin_privkey_is_valid(&key->private_key)==1);
     dogecoin_pubkey_init(&key->public_key);
-    dogecoin_pubkey_from_key(&key->private_key, &key->public_key);
+    assert(dogecoin_pubkey_from_key(&key->private_key, &key->public_key) == 1);
     assert(dogecoin_pubkey_is_valid(&key->public_key) == 1);
     strcpy(key->public_key_hex, utils_uint8_to_hex((const uint8_t *)&key->public_key, 33));
     uint8_t pkeybase58c[34];
@@ -107,6 +107,9 @@ eckey* new_eckey(dogecoin_bool is_testnet) {
 ```
 
 This function instantiates a new working key, but does not add it to the hash table.
+
+Note: the actual implementation returns NULL if not able to generate a new key,
+rather than failing an assert.
 
 _C usage:_
 ```c
@@ -125,7 +128,7 @@ eckey* new_eckey_from_privkey(char* private_key) {
     if (!dogecoin_privkey_decode_wif(private_key, chain, &key->private_key)) return false;
     assert(dogecoin_privkey_is_valid(&key->private_key)==1);
     dogecoin_pubkey_init(&key->public_key);
-    dogecoin_pubkey_from_key(&key->private_key, &key->public_key);
+    assert(dogecoin_pubkey_from_key(&key->private_key, &key->public_key) == 1);
     assert(dogecoin_pubkey_is_valid(&key->public_key) == 1);
     strcpy(key->public_key_hex, utils_uint8_to_hex((const uint8_t *)&key->public_key, 33));
     uint8_t pkeybase58c[34];
@@ -140,6 +143,9 @@ eckey* new_eckey_from_privkey(char* private_key) {
 ```
 
 This function instantiates a new working key from a `private_key` in WIF format, but does not add it to the hash table.
+
+Note: the actual implementation returns NULL if the provided private_key was not valid,
+rather than failing an assert.
 
 _C usage:_
 ```c
@@ -208,6 +214,8 @@ eckey* find_eckey(int idx) {
 ```
 
 This function takes an index and returns the working eckey associated with that index in the hash table.
+
+Note: can return NULL if there's no key at idx.
 
 _C usage:_
 ```c

--- a/include/dogecoin/address.h
+++ b/include/dogecoin/address.h
@@ -42,6 +42,9 @@ LIBDOGECOIN_API int generateHDMasterPubKeypair(char* wif_privkey_master, char* p
 /* generate an extended public key */
 LIBDOGECOIN_API int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey);
 
+/* converts an extended HD private address (dgpv, tprv) to a WIF-encoded private key */
+LIBDOGECOIN_API int generateDerivedHDPrivKeyWIF(const char* extended_private, char* out_privkey_wif);
+
 /* verify private and public keys are valid and associated with each other*/
 LIBDOGECOIN_API int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet);
 

--- a/include/dogecoin/address.h
+++ b/include/dogecoin/address.h
@@ -39,11 +39,14 @@ LIBDOGECOIN_API int generatePrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey
 /* generate HD master key and WIF public key */
 LIBDOGECOIN_API int generateHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
 
-/* generate an extended public key */
-LIBDOGECOIN_API int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey);
+/* converts an HD masterkey or HD child address (public or private) to P2PKH Dogecoin Address */
+LIBDOGECOIN_API int convertHDKeyToP2PKH(const char* extended_key, char* out_p2pkh_pubkey);
 
-/* converts an extended HD private address (dgpv, tprv) to a WIF-encoded private key */
-LIBDOGECOIN_API int generateDerivedHDPrivKeyWIF(const char* extended_private, char* out_privkey_wif);
+/* converts an HD private key (e.g. dgpv, tprv) to a WIF-encoded EC private key. */
+LIBDOGECOIN_API int convertHDKeyToECPrivKey(const char* extended_private, char* out_ec_privkey);
+
+/* deprecated: renamed to convertHDKeyToP2PKH */
+LIBDOGECOIN_API int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey);
 
 /* verify private and public keys are valid and associated with each other*/
 LIBDOGECOIN_API int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet);

--- a/include/dogecoin/bip32.h
+++ b/include/dogecoin/bip32.h
@@ -56,7 +56,7 @@ LIBDOGECOIN_API void dogecoin_hdnode_clear(dogecoin_hdnode* node);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_public_ckd(dogecoin_hdnode* inout, uint32_t i);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_from_seed(const uint8_t* seed, int seed_len, dogecoin_hdnode* out);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_private_ckd(dogecoin_hdnode* inout, uint32_t i);
-LIBDOGECOIN_API void dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node);
+LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node);
 LIBDOGECOIN_API void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 LIBDOGECOIN_API void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 

--- a/include/dogecoin/bip32.h
+++ b/include/dogecoin/bip32.h
@@ -52,12 +52,14 @@ typedef struct
 LIBDOGECOIN_API dogecoin_hdnode* dogecoin_hdnode_new();
 LIBDOGECOIN_API dogecoin_hdnode* dogecoin_hdnode_copy(const dogecoin_hdnode* hdnode);
 LIBDOGECOIN_API void dogecoin_hdnode_free(dogecoin_hdnode* node);
+LIBDOGECOIN_API void dogecoin_hdnode_clear(dogecoin_hdnode* node);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_public_ckd(dogecoin_hdnode* inout, uint32_t i);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_from_seed(const uint8_t* seed, int seed_len, dogecoin_hdnode* out);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_private_ckd(dogecoin_hdnode* inout, uint32_t i);
 LIBDOGECOIN_API void dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node);
 LIBDOGECOIN_API void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 LIBDOGECOIN_API void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
+LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_serialize_privkey_wif(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* outstr, size_t* strsize);
 
 /* gives out the raw sha256/ripemd160 hash */
 LIBDOGECOIN_API void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_out);
@@ -70,7 +72,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const
 LIBDOGECOIN_API dogecoin_bool dogecoin_hd_generate_key(dogecoin_hdnode* node, const char* keypath, const uint8_t* keymaster, const uint8_t* chaincode, dogecoin_bool usepubckd);
 
 //!checks if a node has the according private key (or if its a pubkey only node)
-LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_has_privkey(dogecoin_hdnode* node);
+LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_has_privkey(const dogecoin_hdnode* node);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/bip32.h
+++ b/include/dogecoin/bip32.h
@@ -59,7 +59,6 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_private_ckd(dogecoin_hdnode* inout
 LIBDOGECOIN_API void dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node);
 LIBDOGECOIN_API void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 LIBDOGECOIN_API void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
-LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_serialize_privkey_wif(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* outstr, size_t* strsize);
 
 /* gives out the raw sha256/ripemd160 hash */
 LIBDOGECOIN_API void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_out);

--- a/include/dogecoin/chainparams.h
+++ b/include/dogecoin/chainparams.h
@@ -68,6 +68,7 @@ extern const dogecoin_checkpoint dogecoin_testnet_checkpoint_array[18];
 
 LIBDOGECOIN_API const dogecoin_chainparams* chain_from_b58_prefix(const char* address);
 LIBDOGECOIN_API int chain_from_b58_prefix_bool(char* address);
+LIBDOGECOIN_API const dogecoin_chainparams* chain_from_bip32_prefix(const char* bip32extkey);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/ecc.h
+++ b/include/dogecoin/ecc.h
@@ -42,7 +42,7 @@ LIBDOGECOIN_API void dogecoin_ecc_start(void);
 LIBDOGECOIN_API void dogecoin_ecc_stop(void);
 
 //!get public key from given private key
-LIBDOGECOIN_API void dogecoin_ecc_get_pubkey(const uint8_t* private_key, uint8_t* public_key, size_t* public_key_len, dogecoin_bool compressed);
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_get_pubkey(const uint8_t* private_key, uint8_t* public_key, size_t* public_key_len, dogecoin_bool compressed);
 
 //!ec mul tweak on given private key
 LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_private_key_tweak_add(uint8_t* private_key, const uint8_t* tweak);

--- a/include/dogecoin/key.h
+++ b/include/dogecoin/key.h
@@ -61,7 +61,7 @@ LIBDOGECOIN_API unsigned int dogecoin_pubkey_get_length(unsigned char ch_header)
 
 LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_is_valid(const dogecoin_pubkey* pubkey);
 LIBDOGECOIN_API void dogecoin_pubkey_cleanse(dogecoin_pubkey* pubkey);
-LIBDOGECOIN_API void dogecoin_pubkey_from_key(const dogecoin_key* privkey, dogecoin_pubkey* pubkey_inout);
+LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_from_key(const dogecoin_key* privkey, dogecoin_pubkey* pubkey_inout);
 
 // get the hash160 (single SHA256 + RIPEMD160)
 LIBDOGECOIN_API void dogecoin_pubkey_get_hash160(const dogecoin_pubkey* pubkey, uint160 hash160);

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -122,7 +122,6 @@ dogecoin_bool pubkey_from_privatekey(const dogecoin_chainparams* chain, const ch
 dogecoin_bool gen_privatekey(const dogecoin_chainparams* chain, char* privkey_wif, size_t strsize_wif, char* privkey_hex);
 
 /* p2pkh utilities */
-int dogecoin_tx_out_pubkey_hash_to_p2pkh_address(dogecoin_tx_out* txout, char* p2pkh, int is_mainnet);
 dogecoin_bool dogecoin_pubkey_hash_to_p2pkh_address(char* script_pubkey_hex, size_t script_pubkey_hex_length, char* p2pkh, const dogecoin_chainparams* chain);
 dogecoin_bool dogecoin_p2pkh_address_to_pubkey_hash(char* p2pkh, char* scripthash);
 char* dogecoin_address_to_pubkey_hash(char* p2pkh);

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -94,6 +94,9 @@ int generateHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_mast
 /* generates a new dogecoin address from a HD master key */
 int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey);
 
+/* converts an extended HD private address (dgpv, tprv) to a WIF-encoded private key */
+int generateDerivedHDPrivKeyWIF(const char* extended_private, char* out_privkey_wif);
+
 /* verify that a private key and dogecoin address match */
 int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet);
 

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -85,17 +85,20 @@ void dogecoin_ecc_start(void);
 //!destroys the static ecc context
 void dogecoin_ecc_stop(void);
 
-/* generates a private and public keypair (a wallet import format private key and a p2pkh ready-to-use corresponding dogecoin address)*/
+/* generates a private and public keypair (a wallet import format EC private key and a p2pkh ready-to-use corresponding dogecoin address)*/
 int generatePrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet);
 
-/* generates a hybrid deterministic WIF master key and p2pkh ready-to-use corresponding dogecoin address. */
+/* generates a hybrid deterministic (HD) WIF master key and p2pkh ready-to-use corresponding dogecoin address. */
 int generateHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
 
-/* generates a new dogecoin address from a HD master key */
-int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey);
+/* converts an HD masterkey or HD child address (public or private) to P2PKH Dogecoin Address */
+int convertHDKeyToP2PKH(const char* extended_key, char* out_p2pkh_pubkey);
 
-/* converts an extended HD private address (dgpv, tprv) to a WIF-encoded private key */
-int generateDerivedHDPrivKeyWIF(const char* extended_private, char* out_privkey_wif);
+/* converts an HD private key (e.g. dgpv, tprv) to a WIF-encoded EC private key. */
+int convertHDKeyToECPrivKey(const char* extended_private, char* out_ec_privkey);
+
+/* deprecated: renamed to convertHDKeyToP2PKH */
+int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey);
 
 /* verify that a private key and dogecoin address match */
 int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet);

--- a/include/dogecoin/tool.h
+++ b/include/dogecoin/tool.h
@@ -46,9 +46,6 @@ LIBDOGECOIN_API dogecoin_bool hd_gen_master(const dogecoin_chainparams* chain, c
 LIBDOGECOIN_API dogecoin_bool hd_print_node(const dogecoin_chainparams* chain, const char* nodeser);
 LIBDOGECOIN_API dogecoin_bool hd_derive(const dogecoin_chainparams* chain, const char* masterkey, const char* keypath, char* extkeyout, size_t extkeyout_size);
 
-/* convert a BIP32 extended private key (e.g. dgpv, tprv) to a WIF private key */
-LIBDOGECOIN_API dogecoin_bool hd_privkey_wif(const char* hd_privkey, char* out_privkey_wif, size_t *inout_size);
-
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_TOOL_H__

--- a/include/dogecoin/tool.h
+++ b/include/dogecoin/tool.h
@@ -46,6 +46,9 @@ LIBDOGECOIN_API dogecoin_bool hd_gen_master(const dogecoin_chainparams* chain, c
 LIBDOGECOIN_API dogecoin_bool hd_print_node(const dogecoin_chainparams* chain, const char* nodeser);
 LIBDOGECOIN_API dogecoin_bool hd_derive(const dogecoin_chainparams* chain, const char* masterkey, const char* keypath, char* extkeyout, size_t extkeyout_size);
 
+/* convert a BIP32 extended private key (e.g. dgpv, tprv) to a WIF private key */
+LIBDOGECOIN_API dogecoin_bool hd_privkey_wif(const char* hd_privkey, char* out_privkey_wif, size_t *inout_size);
+
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_TOOL_H__

--- a/src/address.c
+++ b/src/address.c
@@ -206,6 +206,32 @@ int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey)
 }
 
 /**
+ * @brief This function converts an HD extended private address
+ *        (e.g. dgpv, tprv) to a WIF-encoded private key.
+ * 
+ * @param extended_private The extended HD private key (e.g. dgpv, tprv)
+ * @param out_privkey_wif output buffer for the WIF-encoded private key,
+ *                        at least WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN chars
+ * 
+ * @return dogecoin_bool (uint8_t)
+ */
+int generateDerivedHDPrivKeyWIF(const char* extended_private, char* out_privkey_wif)
+{
+    const dogecoin_chainparams* chain = chain_from_bip32_prefix(extended_private);
+    if (!chain) {
+        return false;
+    }
+    dogecoin_hdnode node;
+    if (!dogecoin_hdnode_deserialize(extended_private, chain, &node)) {
+        return false;
+    }
+    size_t out_size = WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN;
+    dogecoin_bool result = dogecoin_hdnode_serialize_privkey_wif(&node, chain, out_privkey_wif, &out_size);
+    dogecoin_hdnode_clear(&node);
+    return result;
+}
+
+/**
  * @brief This function verifies that a given private key
  * matches a given public key and that both are valid on
  * the specified network.

--- a/src/address.c
+++ b/src/address.c
@@ -226,9 +226,12 @@ int generateDerivedHDPrivKeyWIF(const char* extended_private, char* out_privkey_
         return false;
     }
     size_t out_size = WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN;
-    dogecoin_bool result = dogecoin_hdnode_serialize_privkey_wif(&node, chain, out_privkey_wif, &out_size);
+    dogecoin_key key;
+    memcpy_safe(key.privkey, node.private_key, sizeof(key.privkey));
+    dogecoin_privkey_encode_wif(&key, chain, out_privkey_wif, &out_size);
+    dogecoin_privkey_cleanse(&key);
     dogecoin_hdnode_clear(&node);
-    return result;
+    return true;
 }
 
 /**

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -369,38 +369,6 @@ void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogeco
 
 
 /**
- * @brief This function serializes the private key from
- * the HD node as a WIF private key string.
- * 
- * @param node The HD node containing the private key.
- * @param outstr The output buffer to contain the encoded private key.
- * @param strsize The size of the output buffer; returns the size written (including '\0')
- * 
- * @return true on success, false on error.
- */
-dogecoin_bool dogecoin_hdnode_serialize_privkey_wif(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* outstr, size_t* strsize)
-{
-    if (!node || !chain || !outstr || !strsize) {
-        return false;
-    }
-    if (*strsize < WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN) {
-        return false;
-    }
-    if (!dogecoin_hdnode_has_privkey(node)) {
-        return false;
-    }
-
-    uint8_t pkeybase58c[34];
-    pkeybase58c[0] = chain->b58prefix_secret_address;
-    pkeybase58c[33] = 1; /* always use compressed keys */
-    memcpy_safe(&pkeybase58c[1], node->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    *strsize = dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), outstr, *strsize);
-
-    return (*strsize != 0);
-}
-
-
-/**
  * @brief This function applies the sha256 and rmd160 hash
  * functions to public key and loads variable hash160_out
  * with result.

--- a/src/chainparams.c
+++ b/src/chainparams.c
@@ -154,3 +154,24 @@ int chain_from_b58_prefix_bool(char* address) {
     }
     return false;
 }
+
+#define DOGE_FOURCC(A,B,C,D) (((A)<<24)|((B)<<16)|((C)<<8)|(D))
+
+const dogecoin_chainparams* chain_from_bip32_prefix(const char* bip32extkey) {
+    /* determine chainparams from BIP32 extended private or public key */
+    size_t min_len = strnlen(bip32extkey, 5);
+    if (min_len < 4) {
+        return NULL;
+    }
+    uint32_t prefix = DOGE_FOURCC(bip32extkey[0],bip32extkey[1],bip32extkey[2],bip32extkey[3]);
+    switch (prefix) {
+        case DOGE_FOURCC('d','g','p','v'):
+        case DOGE_FOURCC('d','g','u','b'):
+            return &dogecoin_chainparams_main;
+        case DOGE_FOURCC('t','p','r','v'):
+        case DOGE_FOURCC('t','p','u','b'):
+            return &dogecoin_chainparams_test;
+        default:
+            return NULL;
+    }
+}

--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -1070,6 +1070,7 @@ int main(int argc, char* argv[])
             }
 
         eckey* key = new_eckey_from_privkey(pkey);
+        if (!key) return showError("invalid pkey\n");
         char* sig = sign_message(key->private_key_wif, txhex);
         printf("message: %s\n", txhex);
         printf("content: %s\n", sig);

--- a/src/cli/tool.c
+++ b/src/cli/tool.c
@@ -220,28 +220,3 @@ dogecoin_bool hd_derive(const dogecoin_chainparams* chain, const char* masterkey
         dogecoin_hdnode_serialize_private(&nodenew, chain, extkeyout, extkeyout_size);
     return true;
 }
-
-/**
- * @brief Convert a BIP32 extended private key to WIF format
- * 
- * @param hd_privkey The serialized extended private key (e.g. dgpv, tprv)
- * @param out_privkey_wif output buffer for the private key in WIF format
- * @param inout_size the size of the buffer (at least WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN)
- *                   on return, contains the length written (including '\0')
- * 
- * @return dogecoin_bool (uint8_t)
- */
-dogecoin_bool hd_privkey_wif(const char* hd_privkey, char* out_privkey_wif, size_t *inout_size)
-{
-    const dogecoin_chainparams* chain = chain_from_bip32_prefix(hd_privkey);
-    if (!chain) {
-        return false;
-    }
-    dogecoin_hdnode node;
-    if (!dogecoin_hdnode_deserialize(hd_privkey, chain, &node)) {
-        return false;
-    }
-    dogecoin_bool result = dogecoin_hdnode_serialize_privkey_wif(&node, chain, out_privkey_wif, inout_size);
-    dogecoin_hdnode_clear(&node);
-    return result;
-}

--- a/src/cli/tool.c
+++ b/src/cli/tool.c
@@ -38,6 +38,7 @@
 
 #include <dogecoin/bip32.h>
 #include <dogecoin/base58.h>
+#include <dogecoin/chainparams.h>
 #include <dogecoin/ecc.h>
 #include <dogecoin/key.h>
 #include <dogecoin/random.h>
@@ -218,4 +219,29 @@ dogecoin_bool hd_derive(const dogecoin_chainparams* chain, const char* masterkey
     else
         dogecoin_hdnode_serialize_private(&nodenew, chain, extkeyout, extkeyout_size);
     return true;
+}
+
+/**
+ * @brief Convert a BIP32 extended private key to WIF format
+ * 
+ * @param hd_privkey The serialized extended private key (e.g. dgpv, tprv)
+ * @param out_privkey_wif output buffer for the private key in WIF format
+ * @param inout_size the size of the buffer (at least WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN)
+ *                   on return, contains the length written (including '\0')
+ * 
+ * @return dogecoin_bool (uint8_t)
+ */
+dogecoin_bool hd_privkey_wif(const char* hd_privkey, char* out_privkey_wif, size_t *inout_size)
+{
+    const dogecoin_chainparams* chain = chain_from_bip32_prefix(hd_privkey);
+    if (!chain) {
+        return false;
+    }
+    dogecoin_hdnode node;
+    if (!dogecoin_hdnode_deserialize(hd_privkey, chain, &node)) {
+        return false;
+    }
+    dogecoin_bool result = dogecoin_hdnode_serialize_privkey_wif(&node, chain, out_privkey_wif, inout_size);
+    dogecoin_hdnode_clear(&node);
+    return result;
 }

--- a/src/cli/tool.c
+++ b/src/cli/tool.c
@@ -38,7 +38,6 @@
 
 #include <dogecoin/bip32.h>
 #include <dogecoin/base58.h>
-#include <dogecoin/chainparams.h>
 #include <dogecoin/ecc.h>
 #include <dogecoin/key.h>
 #include <dogecoin/random.h>

--- a/src/cli/tool.c
+++ b/src/cli/tool.c
@@ -89,8 +89,8 @@ dogecoin_bool pubkey_from_privatekey(const dogecoin_chainparams* chain, const ch
     dogecoin_pubkey pubkey;
     dogecoin_pubkey_init(&pubkey);
     assert(dogecoin_pubkey_is_valid(&pubkey) == 0);
-    dogecoin_pubkey_from_key(&key, &pubkey);
-    assert(dogecoin_pubkey_is_valid(&pubkey) == 1);
+    if (!dogecoin_pubkey_from_key(&key, &pubkey)) return false;
+    if (!dogecoin_pubkey_is_valid(&pubkey)) return false;
     dogecoin_privkey_cleanse(&key);
     dogecoin_pubkey_get_hex(&pubkey, pubkey_hex, sizeout);
     dogecoin_pubkey_cleanse(&pubkey);

--- a/src/ecc.c
+++ b/src/ecc.c
@@ -36,17 +36,17 @@ void dogecoin_ecc_stop(void)
         secp256k1_context_destroy(ctx);
 }
 
-void dogecoin_ecc_get_pubkey(const uint8_t* private_key, uint8_t* public_key, size_t* in_outlen, dogecoin_bool compressed)
+dogecoin_bool dogecoin_ecc_get_pubkey(const uint8_t* private_key, uint8_t* public_key, size_t* in_outlen, dogecoin_bool compressed)
 {
     secp256k1_pubkey pubkey;
     assert(secp256k1_ctx);
     assert((int)*in_outlen == (compressed ? 33 : 65));
     dogecoin_mem_zero(public_key, *in_outlen);
     if (!secp256k1_ec_pubkey_create(secp256k1_ctx, &pubkey, (const unsigned char*)private_key))
-        return;
+        return false;
     if (!secp256k1_ec_pubkey_serialize(secp256k1_ctx, public_key, in_outlen, &pubkey, compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED))
-        return;
-    return;
+        return false;
+    return true;
 }
 
 dogecoin_bool dogecoin_ecc_private_key_tweak_add(uint8_t* private_key, const uint8_t* tweak)

--- a/test/address_tests.c
+++ b/test/address_tests.c
@@ -10,6 +10,7 @@
 
 #include <dogecoin/address.h>
 #include <dogecoin/chainparams.h>
+#include <dogecoin/constants.h>
 #include <dogecoin/dogecoin.h>
 #include <dogecoin/utils.h>
 
@@ -173,6 +174,12 @@ void test_address()
     res = getDerivedHDAddressFromMnemonic(0, 0, BIP44_CHANGE_EXTERNAL, seedphrase, NULL, p2pkh_pubkey_main, false);
     u_assert_str_eq(p2pkh_pubkey_main, "DTdKu8YgcxoXyjFCDtCeKimaZzsK27rcwT");
 #endif
+
+    /* generateDerivedHDPrivKeyWIF */
+    const char* ext_hd_private = "tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK";
+    char privkey_wif_out[WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN];
+    u_assert_int_eq(generateDerivedHDPrivKeyWIF(ext_hd_private, privkey_wif_out), true);
+    u_assert_str_eq(privkey_wif_out, "chq4gQqR1C5erpniafsiu581zFCrctDiUMPTHiMWD3h6H9WWrMzu");
 
     /*free up VLAs*/
     free(masterkey_main);

--- a/test/address_tests.c
+++ b/test/address_tests.c
@@ -175,11 +175,16 @@ void test_address()
     u_assert_str_eq(p2pkh_pubkey_main, "DTdKu8YgcxoXyjFCDtCeKimaZzsK27rcwT");
 #endif
 
-    /* generateDerivedHDPrivKeyWIF */
-    const char* ext_hd_private = "tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK";
-    char privkey_wif_out[WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN];
-    u_assert_int_eq(generateDerivedHDPrivKeyWIF(ext_hd_private, privkey_wif_out), true);
-    u_assert_str_eq(privkey_wif_out, "chq4gQqR1C5erpniafsiu581zFCrctDiUMPTHiMWD3h6H9WWrMzu");
+    /* convertHDKeyToP2PKH */
+    u_assert_int_eq(convertHDKeyToP2PKH("dgpv51eADS3spNJhA6LG5QycrFmQQtxg7ztFJQuamYiytZ4x4FUC7pG5B7fUTHBDB7g6oGaCVwuGF2i75r1DQKyFSauAHUGBAi89NaggpdUP3yK", str), true)
+    u_assert_str_eq("DEByFfUQ3AxcFFet9afr8wxxedQysRduWN", str);
+    u_assert_int_eq(convertHDKeyToP2PKH("dgub8uxGyZKCxRo2buadqKBPGR5MMDrbk8RABK8EcnBv5GrdS8u1Lw2ifRSifsT3wuVRsK45b9kugWkd2cREzkJLiGvwbY5txG2dKfsY3bndC93", str), true)
+    u_assert_str_eq("D91jVi3CVGhRmyt83fhMdL4UJWtDuiTZET", str);
+
+    /* convertHDKeyToECPrivKey */
+    char privkey[WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN];
+    u_assert_int_eq(convertHDKeyToECPrivKey("tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK", privkey), true);
+    u_assert_str_eq("chq4gQqR1C5erpniafsiu581zFCrctDiUMPTHiMWD3h6H9WWrMzu", privkey);
 
     /*free up VLAs*/
     free(masterkey_main);

--- a/test/bip32_tests.c
+++ b/test/bip32_tests.c
@@ -248,12 +248,4 @@ void test_bip32()
 
         dogecoin_hdnode_free(nodeheap);
     dogecoin_hdnode_free(nodeheap_copy);
-
-    /* dogecoin_hdnode_serialize_privkey_wif */
-    const char* str_tgpv_wif_test = "tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK";
-    size_t wif_size = WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN;
-    u_assert_int_eq(dogecoin_hdnode_deserialize(str_tgpv_wif_test, &dogecoin_chainparams_test, &node), true);
-    u_assert_int_eq(dogecoin_hdnode_serialize_privkey_wif(&node, &dogecoin_chainparams_test, str, &wif_size), true);
-    u_assert_int_eq(wif_size, 53); // includes terminator!
-    u_assert_str_eq(str, "chq4gQqR1C5erpniafsiu581zFCrctDiUMPTHiMWD3h6H9WWrMzu");
 }

--- a/test/bip32_tests.c
+++ b/test/bip32_tests.c
@@ -9,6 +9,7 @@
 #include <test/utest.h>
 
 #include <dogecoin/bip32.h>
+#include <dogecoin/constants.h>
 #include <dogecoin/utils.h>
 #include <dogecoin/mem.h>
 
@@ -247,4 +248,12 @@ void test_bip32()
 
         dogecoin_hdnode_free(nodeheap);
     dogecoin_hdnode_free(nodeheap_copy);
+
+    /* dogecoin_hdnode_serialize_privkey_wif */
+    const char* str_tgpv_wif_test = "tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK";
+    size_t wif_size = WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN;
+    u_assert_int_eq(dogecoin_hdnode_deserialize(str_tgpv_wif_test, &dogecoin_chainparams_test, &node), true);
+    u_assert_int_eq(dogecoin_hdnode_serialize_privkey_wif(&node, &dogecoin_chainparams_test, str, &wif_size), true);
+    u_assert_int_eq(wif_size, 53); // includes terminator!
+    u_assert_str_eq(str, "chq4gQqR1C5erpniafsiu581zFCrctDiUMPTHiMWD3h6H9WWrMzu");
 }

--- a/test/key_tests.c
+++ b/test/key_tests.c
@@ -42,7 +42,7 @@ void test_key()
     dogecoin_pubkey pubkey;
     dogecoin_pubkey_init(&pubkey);
     assert(dogecoin_pubkey_is_valid(&pubkey) == 0);
-    dogecoin_pubkey_from_key(&key, &pubkey);
+    assert(dogecoin_pubkey_from_key(&key, &pubkey) == 1);
     assert(dogecoin_pubkey_is_valid(&pubkey) == 1);
     assert(dogecoin_privkey_verify_pubkey(&key, &pubkey) == 1);
     unsigned int i;

--- a/test/signmsg_tests.c
+++ b/test/signmsg_tests.c
@@ -30,6 +30,7 @@ void test_signmsg_ext() {
     for (int i = 0; i < 10; i++) {
         int key_id = start_key(false);
         eckey* key = find_eckey(key_id);
+        u_assert_true(key != NULL);
         char* msg = "This is a test message";
         char* sig = sign_message(key->private_key_wif, msg);
         u_assert_int_eq(verify_message(sig, msg, key->address), 1);
@@ -38,6 +39,7 @@ void test_signmsg_ext() {
 
         int key_id2 = start_key(false);
         eckey* key2 = find_eckey(key_id2);
+        u_assert_true(key2 != NULL);
         char* msg2 = "This is a test message";
         char* sig2 = sign_message(key2->private_key_wif, msg2);
         u_assert_int_eq(verify_message(sig2, msg2, key2->address), 1);
@@ -48,6 +50,7 @@ void test_signmsg_ext() {
 
         int key_id3 = start_key(true);
         eckey* testnet_key = find_eckey(key_id3);
+        u_assert_true(testnet_key != NULL);
         char* testnet_msg = "bleh";
         char* testnet_sig = sign_message(testnet_key->private_key_wif, testnet_msg);
         u_assert_int_eq(verify_message(testnet_sig, testnet_msg, testnet_key->address), 1);
@@ -57,6 +60,7 @@ void test_signmsg_ext() {
 
     char* privkey = "QUtnMFjt3JFk1NfeMe6Dj5u4p25DHZA54FsvEFAiQxcNP4bZkPu2";
     eckey* key = new_eckey_from_privkey(privkey);
+    u_assert_true(key != NULL);
     char* msg = "This is a test message";
     char* sig = sign_message(key->private_key_wif, msg);
     u_assert_int_eq(verify_message(sig, msg, key->address), 1);

--- a/test/tool_tests.c
+++ b/test/tool_tests.c
@@ -9,7 +9,6 @@
 #include <test/utest.h>
 
 #include <dogecoin/chainparams.h>
-#include <dogecoin/constants.h>
 #include <dogecoin/base58.h>
 #include <dogecoin/tool.h>
 #include <dogecoin/utils.h>

--- a/test/tool_tests.c
+++ b/test/tool_tests.c
@@ -9,6 +9,7 @@
 #include <test/utest.h>
 
 #include <dogecoin/chainparams.h>
+#include <dogecoin/constants.h>
 #include <dogecoin/base58.h>
 #include <dogecoin/tool.h>
 #include <dogecoin/utils.h>
@@ -60,4 +61,12 @@ void test_tool()
     u_assert_int_eq(hd_derive(&dogecoin_chainparams_main, "dgpv51eADS3spNJh9gCpE1AyQ9NpMGkGh6MJKxM84Tf87KVLNeodEW76V2nJJRPorYLGnvZGJKTgEgvqGCtf9VS9RqhfJaTxV7iqm86VpMUNi5G", "m/3", extout, extoutsize), true);
 
     free(extout);
+
+    /* hd_privkey_wif */
+    const char* tprv_wif_test = "tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK";
+    char privkey_wif_out[WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN];
+    size_t wif_size = WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN;
+    u_assert_int_eq(hd_privkey_wif(tprv_wif_test, privkey_wif_out, &wif_size), true);
+    u_assert_int_eq(wif_size, 53); // includes terminator!
+    u_assert_str_eq(privkey_wif_out, "chq4gQqR1C5erpniafsiu581zFCrctDiUMPTHiMWD3h6H9WWrMzu");
 }

--- a/test/tool_tests.c
+++ b/test/tool_tests.c
@@ -61,12 +61,4 @@ void test_tool()
     u_assert_int_eq(hd_derive(&dogecoin_chainparams_main, "dgpv51eADS3spNJh9gCpE1AyQ9NpMGkGh6MJKxM84Tf87KVLNeodEW76V2nJJRPorYLGnvZGJKTgEgvqGCtf9VS9RqhfJaTxV7iqm86VpMUNi5G", "m/3", extout, extoutsize), true);
 
     free(extout);
-
-    /* hd_privkey_wif */
-    const char* tprv_wif_test = "tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK";
-    char privkey_wif_out[WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN];
-    size_t wif_size = WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN;
-    u_assert_int_eq(hd_privkey_wif(tprv_wif_test, privkey_wif_out, &wif_size), true);
-    u_assert_int_eq(wif_size, 53); // includes terminator!
-    u_assert_str_eq(privkey_wif_out, "chq4gQqR1C5erpniafsiu581zFCrctDiUMPTHiMWD3h6H9WWrMzu");
 }

--- a/test/tx_tests.c
+++ b/test/tx_tests.c
@@ -972,7 +972,7 @@ void test_script_parse()
 
         dogecoin_pubkey* pubkey = dogecoin_malloc(sizeof(dogecoin_pubkey));
         dogecoin_pubkey_init(pubkey);
-        dogecoin_pubkey_from_key(&key, pubkey);
+        assert(dogecoin_pubkey_from_key(&key, pubkey) == 1);
         assert(dogecoin_pubkey_is_valid(pubkey) == 1);
 
         vector_add(pubkeys, pubkey);
@@ -1095,7 +1095,7 @@ void test_script_parse()
 
     dogecoin_pubkey pubkeytx_rev;
     dogecoin_pubkey_init(&pubkeytx_rev);
-    dogecoin_pubkey_from_key(&key, &pubkeytx_rev);
+    assert(dogecoin_pubkey_from_key(&key, &pubkeytx_rev) == 1);
 
     tx = dogecoin_tx_new();
     dogecoin_tx_add_data_out(tx, 100000, sigcmp, outlencmp); //0.001 DOGECOIN


### PR DESCRIPTION
* dogecoin_hdnode_private_ckd always returned true! (oops)
* dogecoin_hdnode_public_ckd had an incorrect "failed = false;" assignment
* dogecoin_hdnode_fill_public_key did not return anything, despite being possible to fail (in dogecoin_ecc_get_pubkey)
* dogecoin_ecc_get_pubkey did not return a result, despite testing for errors

dogecoin_ecc_get_pubkey can strictly speaking fail, although I think only if the privkey is invalid (zero or causes an overflow, there's also an infinity check in the serialize function!)

My concern is if we don't check the result of these calls, we could generate an **invalid P2PKH Address**.

In particular, if dogecoin_ecc_get_pubkey exited early because of an error and didn't populate node->public_key, then later,
**dogecoin_hdnode_get_p2pkh_address isn't going to detect any problem**, it will just hash160 and base58 encode whatever bytes are there!

All tests still pass (except test_net_flag_defined which was already failing when I `make check`!)

Note: this branch is based on my https://github.com/dogecoinfoundation/libdogecoin/tree/rc-hd-convert-fns branch, but I can cherry-pick out the error-checks commit into a new PR if necessary.
