### PR TITLE
bip44: updated key derivation

### DIFF
--- a/include/dogecoin/bip32.h
+++ b/include/dogecoin/bip32.h
@@ -69,6 +69,8 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const
 //if you use pub child key derivation, pass usepubckd=true
 LIBDOGECOIN_API dogecoin_bool dogecoin_hd_generate_key(dogecoin_hdnode* node, const char* keypath, const uint8_t* keymaster, const uint8_t* chaincode, dogecoin_bool usepubckd);
 
+LIBDOGECOIN_API dogecoin_bool dogecoin_hd_generate_key_from_parent(dogecoin_hdnode* node, const char* keypath, const dogecoin_hdnode* parent, dogecoin_bool usepubckd);
+
 //!checks if a node has the according private key (or if its a pubkey only node)
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_has_privkey(dogecoin_hdnode* node);
 

--- a/include/dogecoin/bip44.h
+++ b/include/dogecoin/bip44.h
@@ -17,13 +17,14 @@ LIBDOGECOIN_BEGIN_DECL
  */
 
 /* BIP 44 string constants */
+#define BIP44_MASTER_KEY "m"     /* Master key for key derivation according to BIP 44 */
 #define BIP44_PURPOSE "44"       /* Purpose for key derivation according to BIP 44 */
 #define BIP44_COIN_TYPE "3"      /* Coin type for Dogecoin (3, SLIP 44) */
 #define BIP44_COIN_TYPE_TEST "1" /* Coin type for Testnet (1, SLIP44) */
 #define BIP44_CHANGE_EXTERNAL "0"     /* Change level for external addresses */
 #define BIP44_CHANGE_INTERNAL "1"     /* Change level for internal addresses */
 #define BIP44_CHANGE_LEVEL_SIZE 1 + 1 /* Change level size with a null terminator */
-#define SLIP44_KEY_PATH "m/" BIP44_PURPOSE "'/" /* Key path to derive keys */
+#define SLIP44_KEY_PATH BIP44_MASTER_KEY "/" BIP44_PURPOSE /* Key path to derive keys */
 
 /* BIP 44 literal constants */
 #define BIP44_MAX_ADDRESS 2^31 - 1    /* Maximum address is 2^31 - 1 */
@@ -63,11 +64,10 @@ int derive_bip44_extended_private_key(const dogecoin_hdnode *master_key, const u
 /* Derived address index, set to NULL to get an extended key */
 /* Change level ("0" for external or "1" for internal addresses */
 /* Custom path string (optional, account and change_level ignored) */
-/* Test net flag */
 /* Key path string generated */
 /* BIP 44 extended public key generated */
 /* return 0 (success), -1 (fail) */
-int derive_bip44_extended_public_key(const dogecoin_hdnode *master_key, const uint32_t account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key);
+int derive_bip44_extended_public_key(const dogecoin_hdnode *master_key, const uint32_t account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH path, KEY_PATH keypath, dogecoin_hdnode *bip44_key);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -206,11 +206,10 @@ int derive_bip44_extended_private_key(const dogecoin_hdnode *master_key, const u
 /* Derived address index, set to NULL to get an extended key */
 /* Change level ("0" for external or "1" for internal addresses */
 /* Custom path string (optional, account and change_level ignored) */
-/* Test net flag */
 /* Key path string generated */
 /* BIP 44 extended public key generated */
 /* return 0 (success), -1 (fail) */
-int derive_bip44_extended_public_key(const dogecoin_hdnode *master_key, const uint32_t account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key);
+int derive_bip44_extended_public_key(const dogecoin_hdnode *master_key, const uint32_t account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH path, KEY_PATH keypath, dogecoin_hdnode *bip44_key);
 
 /* utilities */
 uint8_t* utils_hex_to_uint8(const char* str);

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -43,10 +43,10 @@
 
 /**
  * @brief This function writes 4 big endian bytes.
- * 
+ *
  * @param data The buffer being written to.
  * @param x The 4 bytes to be written, bundled as int.
- * 
+ *
  * @return Nothing.
  */
 static void write_be(uint8_t* data, uint32_t x)
@@ -60,9 +60,9 @@ static void write_be(uint8_t* data, uint32_t x)
 
 /**
  * @brief This function reads 4 big endian bytes.
- * 
+ *
  * @param data The bytes to be read.
- * 
+ *
  * @return The data buffer in int format.
  */
 static uint32_t read_be(const uint8_t* data)
@@ -75,9 +75,9 @@ static uint32_t read_be(const uint8_t* data)
 
 
 /**
- * @brief This function allocates memory for a new 
+ * @brief This function allocates memory for a new
  * HD node object and returns a pointer to it.
- * 
+ *
  * @return The pointer to the new HD node object.
  */
 dogecoin_hdnode* dogecoin_hdnode_new()
@@ -89,11 +89,11 @@ dogecoin_hdnode* dogecoin_hdnode_new()
 
 
 /**
- * @brief The function creates a new HD node object 
+ * @brief The function creates a new HD node object
  * and copies all information from the old to the new.
- * 
+ *
  * @param hdnode The HD node to be copied.
- * 
+ *
  * @return The pointer to the new node.
  */
 dogecoin_hdnode* dogecoin_hdnode_copy(const dogecoin_hdnode* hdnode)
@@ -113,9 +113,9 @@ dogecoin_hdnode* dogecoin_hdnode_copy(const dogecoin_hdnode* hdnode)
 
 /**
  * @brief This function frees an HD node object in memory.
- * 
+ *
  * @param hdnode The HD node to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_free(dogecoin_hdnode* hdnode)
@@ -129,14 +129,14 @@ void dogecoin_hdnode_free(dogecoin_hdnode* hdnode)
 
 /**
  * @brief This function generates a private and public
- * keypair along with chain_code for a hierarchical 
- * deterministic wallet. This is derived from a seed 
+ * keypair along with chain_code for a hierarchical
+ * deterministic wallet. This is derived from a seed
  * which usually consists of 12 random mnemonic words.
- * 
+ *
  * @param seed The byte string containing the seed phrase.
  * @param seed_len The length of the phrase in characters.
  * @param out The master node which stores the generated data.
- * 
+ *
  * @return Nothing.
  */
 dogecoin_bool dogecoin_hdnode_from_seed(const uint8_t* seed, int seed_len, dogecoin_hdnode* out)
@@ -164,11 +164,11 @@ dogecoin_bool dogecoin_hdnode_from_seed(const uint8_t* seed, int seed_len, dogec
 /**
  * @brief This function derives a child key from the
  * public key of the specified master HD node.
- * 
+ *
  * @param inout The node to derive the child key from.
  * @param i The index of the child key, specified in derivation path.
- * 
- * @return Nothing. 
+ *
+ * @return Nothing.
  */
 dogecoin_bool dogecoin_hdnode_public_ckd(dogecoin_hdnode* inout, uint32_t i)
 {
@@ -214,11 +214,11 @@ dogecoin_bool dogecoin_hdnode_public_ckd(dogecoin_hdnode* inout, uint32_t i)
 /**
  * @brief This function derives a child key from the
  * private key of the specified master HD node.
- * 
+ *
  * @param inout The node to derive the child key from.
  * @param i The index of the child key, specified in derivation path.
- * 
- * @return Nothing. 
+ *
+ * @return Nothing.
  */
 dogecoin_bool dogecoin_hdnode_private_ckd(dogecoin_hdnode* inout, uint32_t i)
 {
@@ -273,11 +273,11 @@ dogecoin_bool dogecoin_hdnode_private_ckd(dogecoin_hdnode* inout, uint32_t i)
 
 
 /**
- * @brief This function derives a public key from a private 
+ * @brief This function derives a public key from a private
  * key taken from the HD node provided.
- * 
+ *
  * @param node The HD node which contains the private key.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node)
@@ -288,16 +288,16 @@ void dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node)
 
 
 /**
- * @brief This function serializes the information inside an 
+ * @brief This function serializes the information inside an
  * HD node and loads it into string variable str using WIF-
  * encoding to represent the public or private key.
- * 
+ *
  * @param node The HD node containing the key.
  * @param version The version byte.
  * @param use_public Whether to use public or private key.
  * @param str The string to contain the encoded output.
  * @param strsize The size of the string that will be returned.
- * 
+ *
  * @return Nothing.
  */
 static void dogecoin_hdnode_serialize(const dogecoin_hdnode* node, uint32_t version, char use_public, char* str, size_t strsize)
@@ -319,14 +319,14 @@ static void dogecoin_hdnode_serialize(const dogecoin_hdnode* node, uint32_t vers
 
 
 /**
- * @brief This function serializes the HD node information 
+ * @brief This function serializes the HD node information
  * into a string using the public key.
- * 
+ *
  * @param node The HD node containing the key.
  * @param chain The preset chain parameters to use.
  * @param str The string to contain the encoded public key.
  * @param strsize The size of the string to be returned.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize)
@@ -338,12 +338,12 @@ void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoi
 /**
  * @brief This function serializes the HD node information
  * into a string using the private key.
- * 
+ *
  * @param node The HD node containing the key.
  * @param chain The chain parameters to use.
  * @param str The string to contain the encoded private key.
  * @param strsize The size of the string to be returned.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize)
@@ -356,10 +356,10 @@ void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogeco
  * @brief This function applies the sha256 and rmd160 hash
  * functions to public key and loads variable hash160_out
  * with result.
- * 
+ *
  * @param node The node containing the public key and its chain code.
  * @param hash160_out The hash160 of the public key.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_out)
@@ -372,14 +372,14 @@ void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_ou
 
 /**
  * @brief This function produces a dogecoin pay-to-
- * public-key-hash (p2pkh) address from the public 
+ * public-key-hash (p2pkh) address from the public
  * key of the given node.
- * 
+ *
  * @param node The HD node containing the public key.
  * @param chain The chain parameters to use.
  * @param str The string containing the p2pkh address.
  * @param strsize The size of the string to be returned.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize)
@@ -394,11 +394,11 @@ void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogeco
 /**
  * @brief This function converts a public key from binary
  * to hexadecimal string format.
- * 
+ *
  * @param node The HD node containing the public key.
  * @param str The hexadecimal string to be returned.
  * @param strsize The size of the string to be returned.
- * 
+ *
  * @return Nothing.
  */
 dogecoin_bool dogecoin_hdnode_get_pub_hex(const dogecoin_hdnode* node, char* str, size_t* strsize)
@@ -414,13 +414,13 @@ dogecoin_bool dogecoin_hdnode_get_pub_hex(const dogecoin_hdnode* node, char* str
 /**
  * @brief This function takes a string buffer containing HD
  * node data and loads an HD node object with that data. The
- * function will copy either a private key or a public key, 
+ * function will copy either a private key or a public key,
  * depending on the prefix of the given buffer.
- * 
+ *
  * @param str The buffer containing the node information.
  * @param chain The chain parameters to use.
  * @param node The HD node to be filled.
- * 
+ *
  * @return Nothing.
  */
 dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const dogecoin_chainparams* chain, dogecoin_hdnode* node)
@@ -459,13 +459,13 @@ dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const dogecoin_chainp
 /**
  * @brief This function generates a child key from a given
  * master key and loads it into an HD node.
- * 
+ *
  * @param node The HD node to be filled with the derived key.
  * @param keypath The derivation path of the desired key (e.g. "m/0h/0/0")
  * @param keymaster The master key to derive the child from.
  * @param chaincode A 32-byte value that is used to generate the child key.
  * @param usepubckd Whether to use public or private key derivation function.
- * 
+ *
  * @return Nothing.
  */
 dogecoin_bool dogecoin_hd_generate_key(dogecoin_hdnode* node, const char* keypath, const uint8_t* keymaster, const uint8_t* chaincode, dogecoin_bool usepubckd)
@@ -543,12 +543,87 @@ err:
     return false;
 }
 
+dogecoin_bool dogecoin_hd_generate_key_from_parent(dogecoin_hdnode* node, const char* keypath, const dogecoin_hdnode* parent, dogecoin_bool usepubckd)
+{
+    static char delim[] = "/";
+    static char prime[] = "phH'";
+    static char digits[] = "0123456789";
+    uint64_t idx = 0;
+    assert(strlen(keypath) < 1024);
+    char *pch, *kp = dogecoin_malloc(strlen(keypath) + 1);
+    char *saveptr; /* for strtok_r calls - fix for concurrent calls error*/
+
+    if (!kp) {
+        return false;
+    }
+
+    if (strlen(keypath) < strlen("m/")) {
+        goto err;
+    }
+
+    memset(kp, 0, strlen(keypath) + 1);
+    memcpy_safe(kp, keypath, strlen(keypath));
+
+    if (kp[0] != 'm' || kp[1] != '/') {
+        goto err;
+    }
+
+    node->depth = parent->depth; // Set depth from the parent node
+    node->child_num = 0;
+    node->fingerprint = 0;
+    memcpy_safe(node->chain_code, parent->chain_code, DOGECOIN_BIP32_CHAINCODE_SIZE);
+
+    if (usepubckd == true) {
+        memcpy_safe(node->public_key, parent->public_key, DOGECOIN_ECKEY_COMPRESSED_LENGTH);
+    } else {
+        memcpy_safe(node->private_key, parent->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
+        dogecoin_hdnode_fill_public_key(node);
+    }
+
+    pch = strtok_r(kp + 2, delim, &saveptr);
+    while (pch != NULL) {
+        size_t i = 0;
+        int prm = 0;
+        for (; i < strlen(pch); i++) {
+            if (strchr(prime, pch[i])) {
+                if ((i != strlen(pch) - 1) || usepubckd == true) {
+                    goto err;
+                }
+                prm = 1;
+            } else if (!strchr(digits, pch[i])) {
+                goto err;
+            }
+        }
+
+        idx = strtoull(pch, NULL, 10);
+        if (idx > UINT32_MAX) {
+            goto err;
+        }
+
+        if (prm) {
+            if (dogecoin_hdnode_private_ckd_prime(node, idx) != true) {
+                goto err;
+            }
+        } else {
+            if ((usepubckd == true ? dogecoin_hdnode_public_ckd(node, idx) : dogecoin_hdnode_private_ckd(node, idx)) != true) {
+                goto err;
+            }
+        }
+        pch = strtok_r(NULL, delim, &saveptr);
+    }
+    dogecoin_free(kp);
+    return true;
+
+err:
+    dogecoin_free(kp);
+    return false;
+}
 
 /**
  * @brief This function checks if the HD node has a private key.
- * 
+ *
  * @param node The HD node to check.
- * 
+ *
  * @return A boolean value, true if node has a private key.
  */
 dogecoin_bool dogecoin_hdnode_has_privkey(dogecoin_hdnode* node)


### PR DESCRIPTION
address, wallet, example, lib, test: updated to derive_bip44_extended_key