### PR TITLE
lib: added key string constants, chainparams and bip32/44 wrappers

### DIFF
--- a/contrib/examples/example.c
+++ b/contrib/examples/example.c
@@ -245,6 +245,28 @@ int main() {
 		printf("Address: %s\n", str);
 	}
 
+	// EXTENDED PUBLIC KEY DERIVATION EXAMPLE
+	printf("\n\nBEGIN EXTENDED PUBLIC KEY DERIVATION:\n\n");
+
+	// Generate the Master key from a seed
+	char masterkey[HDKEYLEN];
+	getHDRootKeyFromSeed(utils_hex_to_uint8("5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4"), MAX_SEED_SIZE, false, masterkey);
+	printf("Master key: %s\n", masterkey);
+
+	// Serialize and print the Master public key
+	char master_public_key[HDKEYLEN] = {0};
+	getHDPubKey(masterkey, false, master_public_key);
+	printf("Master public key: %s\n", master_public_key);
+
+	// Derive an extended normal (non-hardened) public key
+	char extkeypath[KEYPATHMAXLEN] = "m/0/0/0/0/0";
+	char extpubkey[HDKEYLEN] = {0};
+	getHDNodeAndExtKeyByPath(master_public_key, extkeypath, extpubkey, false);
+	printf("Keypath: %s\nExtended public key: %s\n", extkeypath, extpubkey);
+	if (strcmp(extpubkey, "dgub8wcWPRxhthgZYftisbirNJ5Ae3navJCCEfd6SzyL5SK44GC4tok3BGkNWbhrM4KeJ8o9ZAkXiVdLTnUyzz89ah1izJjWTo5pv7eboGtzktJ") != 0) {
+			printf("extpubkey does not match!\n");
+	}
+
 	// BASIC TRANSACTION FORMATION EXAMPLE
 	printf("\n\nBEGIN TRANSACTION FORMATION AND SIGNING:\n\n");
 	// declare keys and previous hashes

--- a/doc/address.md
+++ b/doc/address.md
@@ -315,7 +315,7 @@ int main() {
 
 `dogecoin_hdnode* getHDNodeAndExtKeyByPath(const char* masterkey, const char* derived_path, char* outaddress, bool outprivkey)`
 
-This function derives a hierarchical deterministic child key by way of providing the extended master key, derived_path, outaddress and outprivkey.
+This function derives a hierarchical deterministic child key by way of providing the extended master key, derived_path, outaddress and outprivkey.  The masterkey can be either a private or public key, but if it is a public key, the outprivkey flag must be set to false and the derived_path must be a public derivation path.
 It will return the dogecoin_hdnode if successful and exits if the proper arguments are not provided.
 
 _C usage:_
@@ -338,6 +338,29 @@ int main() {
   dogecoin_ecc_stop();
   dogecoin_hdnode_free(hdnode);
   free(extout);
+}
+```
+
+```C
+#include "libdogecoin.h"
+#include <assert.h>
+#include <stdio.h>
+
+int main() {
+  char masterkey[HDKEYLEN] = {0};
+  char master_public_key[HDKEYLEN] = {0};
+  char extkeypath[KEYPATHMAXLEN] = "m/0/0/0/0/0";
+  char extpubkey[HDKEYLEN] = {0};
+  dogecoin_ecc_start();
+
+  // Generate a master key pair from the seed, and then get the master public key
+  getHDRootKeyFromSeed(utils_hex_to_uint8("5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4"), MAX_SEED_SIZE, false, masterkey);
+  getHDPubKey(masterkey, false, master_public_key);
+
+  // Derive an extended normal (non-hardened) public key from the master public key
+  getHDNodeAndExtKeyByPath(master_public_key, extkeypath, extpubkey, false);
+  dogecoin_ecc_stop();
+  printf("%s\n", extpubkey);
 }
 ```
 

--- a/include/dogecoin/bip32.h
+++ b/include/dogecoin/bip32.h
@@ -67,10 +67,16 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const
 
 //!derive dogecoin_hdnode from extended private or extended public key orkey
 //if you use pub child key derivation, pass usepubckd=true
-LIBDOGECOIN_API dogecoin_bool dogecoin_hd_generate_key(dogecoin_hdnode* node, const char* keypath, const uint8_t* keymaster, const uint8_t* chaincode, dogecoin_bool usepubckd);
+LIBDOGECOIN_API dogecoin_bool dogecoin_hd_generate_key(dogecoin_hdnode* node, const char* keypath, const uint8_t* keymaster, const uint32_t depth, const uint8_t* chaincode, dogecoin_bool usepubckd);
 
 //!checks if a node has the according private key (or if its a pubkey only node)
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_has_privkey(dogecoin_hdnode* node);
+
+// wrappers for bip32 key derivation functions
+LIBDOGECOIN_API dogecoin_bool getHDRootKeyFromSeed(const SEED seed, const int seed_len, const dogecoin_bool is_testnet, char masterkey[HDKEYLEN]);
+LIBDOGECOIN_API dogecoin_bool getHDPubKey(const char hdkey[HDKEYLEN], const dogecoin_bool is_testnet, char hdpubkey[HDKEYLEN]);
+LIBDOGECOIN_API dogecoin_bool deriveExtKeyFromHDKey(const char extkey[HDKEYLEN], const char keypath[KEYPATHMAXLEN], const dogecoin_bool is_testnet, char key[HDKEYLEN]);
+LIBDOGECOIN_API dogecoin_bool deriveExtPubKeyFromHDKey(const char extpubkey[HDKEYLEN], const char keypath[KEYPATHMAXLEN], const dogecoin_bool is_testnet, char pubkey[HDKEYLEN]);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/bip39.h
+++ b/include/dogecoin/bip39.h
@@ -54,9 +54,6 @@ LIBDOGECOIN_API
 /* Maximum size of a passphrase string in bytes */
 #define MAX_PASSPHRASE_STRING_SIZE (MAX_CHARS_IN_PASSPHRASE * HEX_CHARS_PER_BYTE) + 1
 
-/* Maximum size of a seed in bytes */
-#define MAX_SEED_SIZE 64
-
 /* Specifies the number of decimal characters needed to represent entropy size */
 #define ENTROPY_SIZE_STRING_SIZE 3
 
@@ -135,10 +132,6 @@ typedef char PASSPHRASE[MAX_PASSPHRASE_STRING_SIZE];
 /* A string representation of a BIP39 mnemonic phrase, used as a seed to generate private and public keys */
 /* The mnemonic should be a space-separated string with a maximum size of MAX_MNEMONIC_STRING_SIZE */
 typedef char MNEMONIC[MAX_MNEMONIC_STRING_SIZE];
-
-/* A binary representation of the BIP39 seed, used to generate private and public keys */
-/* The seed should be an unsigned integer with a maximum size of MAX_SEED_SIZE */
-typedef uint8_t SEED[MAX_SEED_SIZE];
 
 /* A string representation of the entropy size to generate a BIP39 mnemonic */
 /* The entropy size should be a decimal string with a size of ENTROPY_SIZE_STRING_SIZE */

--- a/include/dogecoin/bip44.h
+++ b/include/dogecoin/bip44.h
@@ -45,29 +45,51 @@ typedef char CHANGE_LEVEL [BIP44_CHANGE_LEVEL_SIZE];
 /* The key path should be a string with a maximum size of BIP44_KEY_PATH_MAX_SIZE */
 typedef char KEY_PATH [BIP44_KEY_PATH_MAX_SIZE];
 
-/* Derives a BIP 44 extended private key from a master private key. */
-/* Master private key to derive from */
-/* Account index (literal) */
+/* Derives a BIP 44 extended key from a master key. */
+/* Master key to derive from */
+/* Account index */
 /* Derived address index, set to NULL to get an extended key */
-/* Change level ("0" for external or "1" for internal addresses */
+/* Change level ("0" for external or "1" for internal addresses), set to NULL to get an extended key */
 /* Custom path string (optional, account and change_level ignored) */
 /* Test net flag */
 /* Key path string generated */
-/* BIP 44 extended private key generated */
+/* BIP 44 extended key generated */
 /* return 0 (success), -1 (fail) */
-int derive_bip44_extended_private_key(const dogecoin_hdnode *master_key, const uint32_t account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key);
+int derive_bip44_extended_key(const dogecoin_hdnode *master_key, const uint32_t *account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key);
 
-/* Derives a BIP 44 extended public key from a master public key. */
-/* Master public key to derive from */
-/* Account index (literal) */
-/* Derived address index, set to NULL to get an extended key */
-/* Change level ("0" for external or "1" for internal addresses */
+/* Derives a BIP 44 extended private key from a master key. */
+/* Master key to derive from */
+/* Account index */
+/* Change level ("0" for external or "1" for internal addresses) */
+/* Derived address index */
 /* Custom path string (optional, account and change_level ignored) */
-/* Test net flag */
+/* Extended private key generated */
 /* Key path string generated */
-/* BIP 44 extended public key generated */
-/* return 0 (success), -1 (fail) */
-int derive_bip44_extended_public_key(const dogecoin_hdnode *master_key, const uint32_t account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key);
+dogecoin_bool deriveBIP44ExtendedKey(
+    const char wif_privkey_master[HDKEYLEN],
+    const uint32_t* account,
+    const CHANGE_LEVEL change_level,
+    const uint32_t* address_index,
+    const KEY_PATH path,
+    char extkeyout[HDKEYLEN],
+    KEY_PATH keypath);
+
+/* Derives a BIP 44 extended public key from a master key. */
+/* Master key to derive from */
+/* Account index */
+/* Change level ("0" for external or "1" for internal addresses) */
+/* Derived address index */
+/* Custom path string (optional, account and change_level ignored) */
+/* Extended public key generated */
+/* Key path string generated */
+dogecoin_bool deriveBIP44ExtendedPublicKey(
+    const char wif_privkey_master[HDKEYLEN],
+    const uint32_t* account,
+    const CHANGE_LEVEL change_level,
+    const uint32_t* address_index,
+    const KEY_PATH path,
+    char extkeyout[HDKEYLEN],
+    KEY_PATH keypath);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/chainparams.h
+++ b/include/dogecoin/chainparams.h
@@ -69,6 +69,10 @@ extern const dogecoin_checkpoint dogecoin_testnet_checkpoint_array[18];
 LIBDOGECOIN_API const dogecoin_chainparams* chain_from_b58_prefix(const char* address);
 LIBDOGECOIN_API int chain_from_b58_prefix_bool(char* address);
 
+// check if the given prefix is a testnet or mainnet prefix
+LIBDOGECOIN_API dogecoin_bool isTestnetFromB58Prefix(const char address[PUBKEYLEN]);
+LIBDOGECOIN_API dogecoin_bool isMainnetFromB58Prefix(const char address[PUBKEYLEN]);
+
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_CHAINPARAMS_H__

--- a/include/dogecoin/dogecoin.h
+++ b/include/dogecoin/dogecoin.h
@@ -74,7 +74,7 @@ typedef uint8_t dogecoin_bool; //!serialize, c/c++ save bool
 
 #if defined(_MSC_VER)
     #define DISABLE_WARNING_PUSH           __pragma(warning( push ))
-    #define DISABLE_WARNING_POP            __pragma(warning( pop )) 
+    #define DISABLE_WARNING_POP            __pragma(warning( pop ))
     #define DISABLE_WARNING(warningNumber) __pragma(warning( disable : warningNumber ))
 
     #define DISABLE_WARNING_UNREFERENCED_FORMAL_PARAMETER    DISABLE_WARNING(4100)
@@ -83,7 +83,7 @@ typedef uint8_t dogecoin_bool; //!serialize, c/c++ save bool
     #include <BaseTsd.h>
     typedef SSIZE_T ssize_t;
 
-    //MLUMIN:MSVC - need winsock for msvc 
+    //MLUMIN:MSVC - need winsock for msvc
     #pragma comment(lib, "Ws2_32.lib")
     #pragma comment(lib, "wsock32.lib")
     //MLUMIN:MSVC - need Iphlpapi.lib for __imp_f_nametoindex in msvc
@@ -95,13 +95,13 @@ typedef uint8_t dogecoin_bool; //!serialize, c/c++ save bool
 #elif defined(__GNUC__) || defined(__clang__)
     #define DO_PRAGMA(X) _Pragma(#X)
     #define DISABLE_WARNING_PUSH           DO_PRAGMA(GCC diagnostic push)
-    #define DISABLE_WARNING_POP            DO_PRAGMA(GCC diagnostic pop) 
+    #define DISABLE_WARNING_POP            DO_PRAGMA(GCC diagnostic pop)
     #define DISABLE_WARNING(warningName)   DO_PRAGMA(GCC diagnostic ignored #warningName)
-    
+
     #define DISABLE_WARNING_UNREFERENCED_FORMAL_PARAMETER    DISABLE_WARNING(-Wunused-parameter)
     #define DISABLE_WARNING_UNREFERENCED_FUNCTION            DISABLE_WARNING(-Wunused-function)
-   // other warnings you want to deactivate... 
-    
+   // other warnings you want to deactivate...
+
 #else
     #define DISABLE_WARNING_PUSH
     #define DISABLE_WARNING_POP
@@ -120,18 +120,34 @@ typedef uint8_t dogecoin_bool; //!serialize, c/c++ save bool
                                 __LINE__, __func__, __VA_ARGS__); } while (0)
 #endif
 
+/* Constants for ECC */
 #define DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH 65
 #define DOGECOIN_ECKEY_COMPRESSED_LENGTH 33
 #define DOGECOIN_ECKEY_PKEY_LENGTH 32
 #define DOGECOIN_HASH_LENGTH 32
+
+/* Constants for BIP32 */
+#define MAX_SEED_SIZE 64
+#define HDKEYLEN 112
+#define PRIVKEYWIFLEN 53
+#define PUBKEYLEN 35
+#define PUBKEYHEXLEN 67
+#define PUBKEYHASHLEN 41
+#define KEYPATHMAXLEN 256
+
+/* Constants for transaction */
+#define SCRIPT_PUBKEY_LENGTH 25
+#define MAX_SERIALIZE_SIZE 2048
 
 #define DOGECOIN_MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define DOGECOIN_MAX(a, b) (((a) > (b)) ? (a) : (b))
 
 LIBDOGECOIN_BEGIN_DECL
 
+/* Data array types */
 typedef uint8_t uint256[32];
 typedef uint8_t uint160[20];
+typedef uint8_t SEED[MAX_SEED_SIZE];
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/key.h
+++ b/include/dogecoin/key.h
@@ -97,6 +97,12 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_getaddr_p2pkh(const dogecoin_pubke
 // initializes an eckey pair
 LIBDOGECOIN_API dogecoin_bool init_keypair(char* privkeywif, dogecoin_key* key, dogecoin_pubkey* pubkey);
 
+// wrapper for wif encoding
+LIBDOGECOIN_API void getWifEncodedPrivKey(const uint8_t privkey[DOGECOIN_ECKEY_PKEY_LENGTH], const dogecoin_bool is_testnet, char privkey_wif[PRIVKEYWIFLEN], size_t* strsize_wif);
+
+// wrapper for wif decoding
+LIBDOGECOIN_API int getDecodedPrivKeyWif(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_bool is_testnet, uint8_t privkey[DOGECOIN_ECKEY_PKEY_LENGTH]);
+
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_KEY_H__

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -85,55 +85,93 @@ void dogecoin_ecc_start(void);
 //!destroys the static ecc context
 void dogecoin_ecc_stop(void);
 
+//#define PRIVKEYWIFLEN 51 //WIF length for uncompressed keys is 51 and should start with Q. This can be 52 also for compressed keys. 53 internally to lib (+stringterm)
+#define PRIVKEYWIFLEN 53 //Function takes 53 but needs to be fixed to take 51.
+
+//#define HDKEYLEN 111 //should be chaincode + privkey; starts with dgpv51eADS3spNJh8 or dgpv51eADS3spNJh9 (112 internally including stringterm? often 128. check this.)
+#define HDKEYLEN 112 // Function expects 128 but needs to be fixed to take 111.
+
+//#define PUBKEYLEN 34 //our mainnet addresses are 34 chars if p2pkh and start with D.  Internally this is cited as 35 for strings that represent it because +stringterm.
+#define PUBKEYLEN 35 // Function expects 35, but needs to be fixed to take 34.
+
+//#define PUBKEYHEXLEN 67 //should be 66 for hex pubkey.  Internally this is cited as 67 for strings that represent it because +stringterm.
+#define PUBKEYHEXLEN 67
+
+//#define PUBKEYHASHLEN 40 //should be 40 for pubkeyhash.  Internally this is cited as 41 for strings that represent it because +stringterm.
+#define PUBKEYHASHLEN 41
+
+//#define KEYPATHMAXLEN 255 // Maximum length of key path string.  Internally this is cited as 256 for strings that represent it because +stringterm.
+#define KEYPATHMAXLEN 256
+
+/* check if a given address is a testnet address */
+dogecoin_bool isTestnetFromB58Prefix(const char address[PUBKEYLEN]);
+
+/* check if a given address is a mainnet address */
+dogecoin_bool isMainnetFromB58Prefix(const char address[PUBKEYLEN]);
+
 /* generates a private and public keypair (a wallet import format private key and a p2pkh ready-to-use corresponding dogecoin address)*/
-int generatePrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet);
+int generatePrivPubKeypair(char wif_privkey[PRIVKEYWIFLEN], char p2pkh_pubkey[PUBKEYLEN], dogecoin_bool is_testnet);
 
 /* generates a hybrid deterministic WIF master key and p2pkh ready-to-use corresponding dogecoin address. */
-int generateHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
+int generateHDMasterPubKeypair(char wif_privkey_master[HDKEYLEN], char p2pkh_pubkey_master[PUBKEYLEN], dogecoin_bool is_testnet);
 
 /* generates a new dogecoin address from a HD master key */
-int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey);
+int generateDerivedHDPubkey(const char wif_privkey_master[HDKEYLEN], char p2pkh_pubkey[PUBKEYLEN]);
 
 /* verify that a private key and dogecoin address match */
-int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet);
+int verifyPrivPubKeypair(char wif_privkey[PRIVKEYWIFLEN], char p2pkh_pubkey[PUBKEYLEN], dogecoin_bool is_testnet);
 
 /* verify that a HD Master key and a dogecoin address matches */
-int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
+int verifyHDMasterPubKeypair(char wif_privkey_master[HDKEYLEN], char p2pkh_pubkey_master[PUBKEYLEN], dogecoin_bool is_testnet);
 
 /* verify that a dogecoin address is valid. */
-int verifyP2pkhAddress(char* p2pkh_pubkey, size_t len);
+int verifyP2pkhAddress(char p2pkh_pubkey[PUBKEYLEN], size_t len);
 
 /* get derived hd address */
-int getDerivedHDAddress(const char* masterkey, uint32_t account, bool ischange, uint32_t addressindex, char* outaddress, bool outprivkey);
+int getDerivedHDAddress(const char masterkey[HDKEYLEN], uint32_t account, dogecoin_bool ischange, uint32_t addressindex, char outaddress[PUBKEYLEN], dogecoin_bool outprivkey);
 
 /* get derived hd address by custom path */
-int getDerivedHDAddressByPath(const char* masterkey, const char* derived_path, char* outaddress, bool outprivkey);
+int getDerivedHDAddressByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[PUBKEYLEN], dogecoin_bool outprivkey);
 
 /* generate the p2pkh address from a given hex pubkey */
-dogecoin_bool addresses_from_pubkey(const dogecoin_chainparams* chain, const char* pubkey_hex, char* p2pkh_address);
+dogecoin_bool addresses_from_pubkey(const dogecoin_chainparams* chain, const char pubkey_hex[PUBKEYHEXLEN], char p2pkh_address[PUBKEYLEN]);
+int getAddressFromPubkey(const char pubkey_hex[PUBKEYHEXLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]);
 
 /* generate the hex publickey from a given hex private key */
-dogecoin_bool pubkey_from_privatekey(const dogecoin_chainparams* chain, const char* privkey_hex, char* pubkey_hex, size_t* sizeout);
+dogecoin_bool pubkey_from_privatekey(const dogecoin_chainparams* chain, const char privkey_hex[PRIVKEYWIFLEN], char pubkey_hex[PUBKEYHEXLEN], size_t* sizeout);
+int getPubkeyFromPrivkey(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_bool is_testnet, char pubkey_hex[PUBKEYHEXLEN], size_t* sizeout);
 
 /* generate a new private key (hex) */
-dogecoin_bool gen_privatekey(const dogecoin_chainparams* chain, char* privkey_wif, size_t strsize_wif, char* privkey_hex);
+dogecoin_bool gen_privatekey(const dogecoin_chainparams* chain, char privkey_wif[PUBKEYHEXLEN], size_t strsize_wif, char privkey_hex[PRIVKEYWIFLEN]);
+int genPrivkey(const dogecoin_bool is_testnet, char privkey_wif[PUBKEYHEXLEN], size_t strsize_wif, char privkey_hex[PRIVKEYWIFLEN]);
 
 /* p2pkh utilities */
-dogecoin_bool dogecoin_pubkey_hash_to_p2pkh_address(char* script_pubkey_hex, size_t script_pubkey_hex_length, char* p2pkh, const dogecoin_chainparams* chain);
-dogecoin_bool dogecoin_p2pkh_address_to_pubkey_hash(char* p2pkh, char* scripthash);
-char* dogecoin_address_to_pubkey_hash(char* p2pkh);
-char* dogecoin_private_key_wif_to_pubkey_hash(char* private_key_wif);
+dogecoin_bool dogecoin_pubkey_hash_to_p2pkh_address(char script_pubkey_hex[PUBKEYHEXLEN], size_t script_pubkey_hex_length, char p2pkh[PUBKEYLEN], const dogecoin_chainparams* chain);
+dogecoin_bool dogecoin_p2pkh_address_to_pubkey_hash(char p2pkh[PUBKEYLEN], char scripthash[PUBKEYHASHLEN]);
+char* dogecoin_address_to_pubkey_hash(char p2pkh[PUBKEYHEXLEN]);
+char* dogecoin_private_key_wif_to_pubkey_hash(char private_key_wif[PRIVKEYWIFLEN]);
+
+/* generate the p2pkh address from a given pubkey hash */
+int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]);
 
 /* privkey utilities */
 typedef struct dogecoin_key_ {
     uint8_t privkey[DOGECOIN_ECKEY_PKEY_LENGTH];
 } dogecoin_key;
 
-void dogecoin_privkey_encode_wif(const dogecoin_key* privkey, const dogecoin_chainparams* chain, char* privkey_wif, size_t* strsize_inout);
-dogecoin_bool dogecoin_privkey_decode_wif(const char* privkey_wif, const dogecoin_chainparams* chain, dogecoin_key* privkey);
+void dogecoin_privkey_encode_wif(const dogecoin_key* privkey, const dogecoin_chainparams* chain, char privkey_wif[PRIVKEYWIFLEN], size_t* strsize_inout);
+dogecoin_bool dogecoin_privkey_decode_wif(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_chainparams* chain, dogecoin_key* privkey);
+
+/* wrappers for wif encoding/decoding */
+void getWifEncodedPrivKey(const char privkey[DOGECOIN_ECKEY_PKEY_LENGTH], const dogecoin_bool is_testnet, char privkey_wif[PRIVKEYWIFLEN], size_t* strsize_wif);
+int getDecodedPrivKeyWif(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_bool is_testnet, char privkey_hex[DOGECOIN_ECKEY_PKEY_LENGTH]);
 
 /* bip32 utilities */
 #define DOGECOIN_BIP32_CHAINCODE_SIZE 32
+
+/* BIP 32 512-bit seed */
+#define MAX_SEED_SIZE 64
+typedef uint8_t SEED [MAX_SEED_SIZE];
 
 typedef struct
 {
@@ -160,20 +198,33 @@ void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogeco
 dogecoin_bool dogecoin_hdnode_get_pub_hex(const dogecoin_hdnode* node, char* str, size_t* strsize);
 dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const dogecoin_chainparams* chain, dogecoin_hdnode* node);
 
-/* get derived hd extended child key and corresponding private key in WIF format */
-char* getHDNodePrivateKeyWIFByPath(const char* masterkey, const char* derived_path, char* outaddress, bool outprivkey);
-/* get derived hd extended address and compendium hdnode */
-dogecoin_hdnode* getHDNodeAndExtKeyByPath(const char* masterkey, const char* derived_path, char* outaddress, bool outprivkey);
+/* bip32 wrappers for key derivation */
+dogecoin_bool getHDRootKeyFromSeed(const SEED seed, const int seed_len, const dogecoin_bool is_testnet, char masterkey[HDKEYLEN]);
+dogecoin_bool getHDPubKey(const char hdkey[HDKEYLEN], const dogecoin_bool is_testnet, char hdpubkey[HDKEYLEN]);
+dogecoin_bool deriveExtKeyFromHDKey(const char extkey[HDKEYLEN], const char keypath[KEYPATHMAXLEN], const dogecoin_bool is_testnet, char key[HDKEYLEN]);
+dogecoin_bool deriveExtPubKeyFromHDKey(const char extpubkey[HDKEYLEN], const char keypath[KEYPATHMAXLEN], const dogecoin_bool is_testnet, char pubkey[HDKEYLEN]);
 
-/* bip44 utilities */
+/* bip32 tools */
+int genHDMaster(const dogecoin_bool is_testnet, char masterkey[HDKEYLEN], size_t strsize);
+int printNode(const dogecoin_bool is_testnet, const char nodeser[HDKEYLEN]);
+int deriveHDExtFromMaster(const dogecoin_bool is_testnet, const char masterkey[HDKEYLEN], const char keypath[KEYPATHMAXLEN], char extkeyout[HDKEYLEN], size_t extkeyout_size);
+
+/* get derived hd extended child key and corresponding private key in WIF format */
+char* getHDNodePrivateKeyWIFByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[PUBKEYLEN], bool outprivkey);
+/* get derived hd extended address and compendium hdnode */
+dogecoin_hdnode* getHDNodeAndExtKeyByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[PUBKEYLEN], bool outprivkey);
+
+/* BIP 44 string constants */
 #define BIP44_PURPOSE "44"       /* Purpose for key derivation according to BIP 44 */
 #define BIP44_COIN_TYPE "3"      /* Coin type for Dogecoin (3, SLIP 44) */
 #define BIP44_COIN_TYPE_TEST "1" /* Coin type for Testnet (1, SLIP44) */
 #define BIP44_CHANGE_EXTERNAL "0"     /* Change level for external addresses */
 #define BIP44_CHANGE_INTERNAL "1"     /* Change level for internal addresses */
 #define BIP44_CHANGE_LEVEL_SIZE 1 + 1 /* Change level size with a null terminator */
+#define SLIP44_KEY_PATH "m/" BIP44_PURPOSE "'/" /* Key path to derive keys */
 
 /* BIP 44 literal constants */
+#define BIP44_MAX_ADDRESS 2^31 - 1    /* Maximum address is 2^31 - 1 */
 #define BIP44_KEY_PATH_MAX_LENGTH 255 /* Maximum length of key path string */
 #define BIP44_KEY_PATH_MAX_SIZE BIP44_KEY_PATH_MAX_LENGTH + 1 /* Key path size with a null terminator */
 #define BIP44_ADDRESS_GAP_LIMIT 20    /* Maximum gap between unused addresses */
@@ -188,29 +239,51 @@ typedef char CHANGE_LEVEL [BIP44_CHANGE_LEVEL_SIZE];
 /* The key path should be a string with a maximum size of BIP44_KEY_PATH_MAX_SIZE */
 typedef char KEY_PATH [BIP44_KEY_PATH_MAX_SIZE];
 
-/* Derives a BIP 44 extended private key from a master private key. */
-/* Master private key to derive from */
-/* Account index (literal) */
+/* Derives a BIP 44 extended key from a master key. */
+/* Master key to derive from */
+/* Account index, set to NULL to get an extended key */
 /* Derived address index, set to NULL to get an extended key */
-/* Change level ("0" for external or "1" for internal addresses */
+/* Change level ("0" for external or "1" for internal addresses), set to NULL to get an extended key */
 /* Custom path string (optional, account and change_level ignored) */
 /* Test net flag */
 /* Key path string generated */
-/* BIP 44 extended private key generated */
+/* BIP 44 extended key generated */
 /* return 0 (success), -1 (fail) */
-int derive_bip44_extended_private_key(const dogecoin_hdnode *master_key, const uint32_t account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key);
+int derive_bip44_extended_key(const dogecoin_hdnode *master_key, const uint32_t* account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key);
 
-/* Derives a BIP 44 extended public key from a master public key. */
-/* Master public key to derive from */
-/* Account index (literal) */
-/* Derived address index, set to NULL to get an extended key */
-/* Change level ("0" for external or "1" for internal addresses */
+/* Derives a BIP 44 extended private key from a master key. */
+/* Master key to derive from */
+/* Account index */
+/* Change level ("0" for external or "1" for internal addresses) */
+/* Derived address index */
 /* Custom path string (optional, account and change_level ignored) */
-/* Test net flag */
+/* Extended private key generated */
 /* Key path string generated */
-/* BIP 44 extended public key generated */
-/* return 0 (success), -1 (fail) */
-int derive_bip44_extended_public_key(const dogecoin_hdnode *master_key, const uint32_t account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key);
+dogecoin_bool deriveBIP44ExtendedKey(
+    const char wif_privkey_master[HDKEYLEN],
+    const uint32_t* account,
+    const CHANGE_LEVEL change_level,
+    const uint32_t* address_index,
+    const KEY_PATH path,
+    char extkeyout[HDKEYLEN],
+    KEY_PATH keypath);
+
+/* Derives a BIP 44 extended public key from a master key. */
+/* Master key to derive from */
+/* Account index */
+/* Change level ("0" for external or "1" for internal addresses) */
+/* Derived address index */
+/* Custom path string (optional, account and change_level ignored) */
+/* Extended public key generated */
+/* Key path string generated */
+dogecoin_bool deriveBIP44ExtendedPublicKey(
+    const char wif_privkey_master[HDKEYLEN],
+    const uint32_t* account,
+    const CHANGE_LEVEL change_level,
+    const uint32_t* address_index,
+    const KEY_PATH path,
+    char extkeyout[HDKEYLEN],
+    KEY_PATH keypath);
 
 /* utilities */
 uint8_t* utils_hex_to_uint8(const char* str);
@@ -235,14 +308,6 @@ typedef char MNEMONIC [MAX_MNEMONIC_SIZE];
 /* BIP 39 passphrase */
 #define MAX_PASS_SIZE 256
 typedef char PASS [MAX_PASS_SIZE];
-
-/* BIP 32 512-bit seed */
-#define MAX_SEED_SIZE 64
-typedef uint8_t SEED [MAX_SEED_SIZE];
-
-/* BIP 32 change level */
-#define CHG_LEVEL_STRING_SIZE 2
-typedef char CHANGE_LEVEL [CHG_LEVEL_STRING_SIZE];
 
 /* Generates an English mnemonic phrase from given hex entropy */
 int generateEnglishMnemonic(const HEX_ENTROPY entropy, const ENTROPY_SIZE size, MNEMONIC mnemonic);

--- a/include/dogecoin/tool.h
+++ b/include/dogecoin/tool.h
@@ -1,6 +1,6 @@
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2016 Jonas Schnelli
  Copyright (c) 2022 bluezr
  Copyright (c) 2022 The Dogecoin Foundation
@@ -45,6 +45,15 @@ LIBDOGECOIN_API dogecoin_bool gen_privatekey(const dogecoin_chainparams* chain, 
 LIBDOGECOIN_API dogecoin_bool hd_gen_master(const dogecoin_chainparams* chain, char* masterkeyhex, size_t strsize);
 LIBDOGECOIN_API dogecoin_bool hd_print_node(const dogecoin_chainparams* chain, const char* nodeser);
 LIBDOGECOIN_API dogecoin_bool hd_derive(const dogecoin_chainparams* chain, const char* masterkey, const char* keypath, char* extkeyout, size_t extkeyout_size);
+
+/* wrappers for the above functions */
+LIBDOGECOIN_API int getAddressFromPubkey(const char pubkey_hex[PUBKEYHEXLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]);
+LIBDOGECOIN_API int getPubkeyFromPrivkey(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_bool is_testnet, char pubkey_hex[PUBKEYHEXLEN], size_t* sizeout);
+LIBDOGECOIN_API int genPrivkey(const dogecoin_bool is_testnet, char privkey_wif[PUBKEYHEXLEN], size_t strsize_wif, char privkey_hex[PRIVKEYWIFLEN]);
+
+LIBDOGECOIN_API int genHDMaster(const dogecoin_bool is_testnet, char masterkeyhex[HDKEYLEN], size_t strsize);
+LIBDOGECOIN_API int printNode(const dogecoin_bool is_testnet, const char nodeser[HDKEYLEN]);
+LIBDOGECOIN_API int deriveHDExtFromMaster(const dogecoin_bool is_testnet, const char masterkey[HDKEYLEN], const char keypath[KEYPATHMAXLEN], char extkeyout[HDKEYLEN], size_t extkeyout_size);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/tx.h
+++ b/include/dogecoin/tx.h
@@ -129,6 +129,9 @@ enum dogecoin_tx_sign_result {
 const char* dogecoin_tx_sign_result_to_str(const enum dogecoin_tx_sign_result result);
 enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, const dogecoin_key* privkey, size_t inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, size_t* sigder_len);
 
+//!wrapper to get the address from a pubkey hash
+LIBDOGECOIN_API int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]);
+
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_TX_H__

--- a/include/dogecoin/vector.h
+++ b/include/dogecoin/vector.h
@@ -54,6 +54,10 @@ LIBDOGECOIN_API dogecoin_bool vector_resize(vector* vec, size_t newsz);
 
 LIBDOGECOIN_API ssize_t vector_find(vector* vec, void* data);
 
+/* serialization functions */
+LIBDOGECOIN_API dogecoin_bool serializeVector(vector* vec, char* out, size_t outlen, size_t* written);
+LIBDOGECOIN_API dogecoin_bool deserializeVector(vector* vec, const char* in, size_t inlen, size_t* read);
+
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_VECTOR_H__

--- a/src/address.c
+++ b/src/address.c
@@ -371,7 +371,7 @@ dogecoin_hdnode* getHDNodeAndExtKeyByPath(const char* masterkey, const char* der
     // dogecoin_hdnode_has_privkey
     bool pubckd = !dogecoin_hdnode_has_privkey(node);
     /* derive child key, use pubckd or privckd */
-    dogecoin_hd_generate_key(nodenew, derived_path, pubckd ? node->public_key : node->private_key, node->chain_code, pubckd);
+    dogecoin_hd_generate_key(nodenew, derived_path, pubckd ? node->public_key : node->private_key, node->depth, node->chain_code, pubckd);
     if (outprivkey) dogecoin_hdnode_serialize_private(nodenew, chain, outaddress, HD_MASTERKEY_STRINGLEN);
     else dogecoin_hdnode_serialize_public(nodenew, chain, outaddress, HD_MASTERKEY_STRINGLEN);
     dogecoin_hdnode_free(node);
@@ -450,7 +450,7 @@ bool getDerivedHDNodeByPath(const char* masterkey, const char* derived_path, dog
     // dogecoin_hdnode_has_privkey
     bool pubckd = !dogecoin_hdnode_has_privkey(&node);
     /* derive child key, use pubckd or privckd */
-    if (!dogecoin_hd_generate_key(nodenew, derived_path, pubckd ? node.public_key : node.private_key, node.chain_code, pubckd)) {
+    if (!dogecoin_hd_generate_key(nodenew, derived_path, pubckd ? node.public_key : node.private_key, node.depth, node.chain_code, pubckd)) {
         ret = false;
     }
 
@@ -528,7 +528,7 @@ int getDerivedHDAddressFromMnemonic(const uint32_t account, const uint32_t index
     dogecoin_hdnode_from_seed(seed, MAX_SEED_SIZE, &node);
 
     /* Derive the child private key at the index */
-    if (derive_bip44_extended_private_key(&node, account, &index, change_level, NULL, is_testnet, keypath, &bip44_key) == -1) {
+    if (derive_bip44_extended_key(&node, &account, &index, change_level, NULL, is_testnet, keypath, &bip44_key) == -1) {
         return -1;
     }
 
@@ -666,7 +666,7 @@ int getDerivedHDAddressFromEncryptedSeed(const uint32_t account, const uint32_t 
     dogecoin_hdnode_from_seed(seed, MAX_SEED_SIZE, &node);
 
     /* Derive the child private key at the index */
-    if (derive_bip44_extended_private_key(&node, account, &index, change_level, NULL, is_testnet, keypath, &bip44_key) == -1) {
+    if (derive_bip44_extended_key(&node, &account, &index, change_level, NULL, is_testnet, keypath, &bip44_key) == -1) {
         return -1;
     }
 
@@ -794,7 +794,7 @@ int getDerivedHDAddressFromEncryptedMnemonic(const uint32_t account, const uint3
     dogecoin_hdnode_from_seed(seed, MAX_SEED_SIZE, &node);
 
     /* Derive the child private key at the index */
-    if (derive_bip44_extended_private_key(&node, account, &index, change_level, NULL, is_testnet, keypath, &bip44_key) == -1) {
+    if (derive_bip44_extended_key(&node, &account, &index, change_level, NULL, is_testnet, keypath, &bip44_key) == -1) {
         return -1;
     }
 
@@ -830,7 +830,7 @@ int getDerivedHDAddressFromEncryptedHDNode(const uint32_t account, const uint32_
     }
 
     /* Derive the child private key at the index */
-    if (derive_bip44_extended_private_key(&node, account, &index, change_level, NULL, is_testnet, keypath, &bip44_key) == -1) {
+    if (derive_bip44_extended_key(&node, &account, &index, change_level, NULL, is_testnet, keypath, &bip44_key) == -1) {
         return -1;
     }
 

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -43,10 +43,10 @@
 
 /**
  * @brief This function writes 4 big endian bytes.
- * 
+ *
  * @param data The buffer being written to.
  * @param x The 4 bytes to be written, bundled as int.
- * 
+ *
  * @return Nothing.
  */
 static void write_be(uint8_t* data, uint32_t x)
@@ -60,9 +60,9 @@ static void write_be(uint8_t* data, uint32_t x)
 
 /**
  * @brief This function reads 4 big endian bytes.
- * 
+ *
  * @param data The bytes to be read.
- * 
+ *
  * @return The data buffer in int format.
  */
 static uint32_t read_be(const uint8_t* data)
@@ -75,9 +75,9 @@ static uint32_t read_be(const uint8_t* data)
 
 
 /**
- * @brief This function allocates memory for a new 
+ * @brief This function allocates memory for a new
  * HD node object and returns a pointer to it.
- * 
+ *
  * @return The pointer to the new HD node object.
  */
 dogecoin_hdnode* dogecoin_hdnode_new()
@@ -89,11 +89,11 @@ dogecoin_hdnode* dogecoin_hdnode_new()
 
 
 /**
- * @brief The function creates a new HD node object 
+ * @brief The function creates a new HD node object
  * and copies all information from the old to the new.
- * 
+ *
  * @param hdnode The HD node to be copied.
- * 
+ *
  * @return The pointer to the new node.
  */
 dogecoin_hdnode* dogecoin_hdnode_copy(const dogecoin_hdnode* hdnode)
@@ -113,9 +113,9 @@ dogecoin_hdnode* dogecoin_hdnode_copy(const dogecoin_hdnode* hdnode)
 
 /**
  * @brief This function frees an HD node object in memory.
- * 
+ *
  * @param hdnode The HD node to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_free(dogecoin_hdnode* hdnode)
@@ -129,14 +129,14 @@ void dogecoin_hdnode_free(dogecoin_hdnode* hdnode)
 
 /**
  * @brief This function generates a private and public
- * keypair along with chain_code for a hierarchical 
- * deterministic wallet. This is derived from a seed 
+ * keypair along with chain_code for a hierarchical
+ * deterministic wallet. This is derived from a seed
  * which usually consists of 12 random mnemonic words.
- * 
+ *
  * @param seed The byte string containing the seed phrase.
  * @param seed_len The length of the phrase in characters.
  * @param out The master node which stores the generated data.
- * 
+ *
  * @return Nothing.
  */
 dogecoin_bool dogecoin_hdnode_from_seed(const uint8_t* seed, int seed_len, dogecoin_hdnode* out)
@@ -164,11 +164,11 @@ dogecoin_bool dogecoin_hdnode_from_seed(const uint8_t* seed, int seed_len, dogec
 /**
  * @brief This function derives a child key from the
  * public key of the specified master HD node.
- * 
+ *
  * @param inout The node to derive the child key from.
  * @param i The index of the child key, specified in derivation path.
- * 
- * @return Nothing. 
+ *
+ * @return Nothing.
  */
 dogecoin_bool dogecoin_hdnode_public_ckd(dogecoin_hdnode* inout, uint32_t i)
 {
@@ -214,11 +214,11 @@ dogecoin_bool dogecoin_hdnode_public_ckd(dogecoin_hdnode* inout, uint32_t i)
 /**
  * @brief This function derives a child key from the
  * private key of the specified master HD node.
- * 
+ *
  * @param inout The node to derive the child key from.
  * @param i The index of the child key, specified in derivation path.
- * 
- * @return Nothing. 
+ *
+ * @return Nothing.
  */
 dogecoin_bool dogecoin_hdnode_private_ckd(dogecoin_hdnode* inout, uint32_t i)
 {
@@ -273,11 +273,11 @@ dogecoin_bool dogecoin_hdnode_private_ckd(dogecoin_hdnode* inout, uint32_t i)
 
 
 /**
- * @brief This function derives a public key from a private 
+ * @brief This function derives a public key from a private
  * key taken from the HD node provided.
- * 
+ *
  * @param node The HD node which contains the private key.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node)
@@ -288,16 +288,16 @@ void dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node)
 
 
 /**
- * @brief This function serializes the information inside an 
+ * @brief This function serializes the information inside an
  * HD node and loads it into string variable str using WIF-
  * encoding to represent the public or private key.
- * 
+ *
  * @param node The HD node containing the key.
  * @param version The version byte.
  * @param use_public Whether to use public or private key.
  * @param str The string to contain the encoded output.
  * @param strsize The size of the string that will be returned.
- * 
+ *
  * @return Nothing.
  */
 static void dogecoin_hdnode_serialize(const dogecoin_hdnode* node, uint32_t version, char use_public, char* str, size_t strsize)
@@ -319,14 +319,14 @@ static void dogecoin_hdnode_serialize(const dogecoin_hdnode* node, uint32_t vers
 
 
 /**
- * @brief This function serializes the HD node information 
+ * @brief This function serializes the HD node information
  * into a string using the public key.
- * 
+ *
  * @param node The HD node containing the key.
  * @param chain The preset chain parameters to use.
  * @param str The string to contain the encoded public key.
  * @param strsize The size of the string to be returned.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize)
@@ -338,12 +338,12 @@ void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoi
 /**
  * @brief This function serializes the HD node information
  * into a string using the private key.
- * 
+ *
  * @param node The HD node containing the key.
  * @param chain The chain parameters to use.
  * @param str The string to contain the encoded private key.
  * @param strsize The size of the string to be returned.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize)
@@ -356,10 +356,10 @@ void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogeco
  * @brief This function applies the sha256 and rmd160 hash
  * functions to public key and loads variable hash160_out
  * with result.
- * 
+ *
  * @param node The node containing the public key and its chain code.
  * @param hash160_out The hash160 of the public key.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_out)
@@ -372,14 +372,14 @@ void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_ou
 
 /**
  * @brief This function produces a dogecoin pay-to-
- * public-key-hash (p2pkh) address from the public 
+ * public-key-hash (p2pkh) address from the public
  * key of the given node.
- * 
+ *
  * @param node The HD node containing the public key.
  * @param chain The chain parameters to use.
  * @param str The string containing the p2pkh address.
  * @param strsize The size of the string to be returned.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize)
@@ -394,11 +394,11 @@ void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogeco
 /**
  * @brief This function converts a public key from binary
  * to hexadecimal string format.
- * 
+ *
  * @param node The HD node containing the public key.
  * @param str The hexadecimal string to be returned.
  * @param strsize The size of the string to be returned.
- * 
+ *
  * @return Nothing.
  */
 dogecoin_bool dogecoin_hdnode_get_pub_hex(const dogecoin_hdnode* node, char* str, size_t* strsize)
@@ -414,13 +414,13 @@ dogecoin_bool dogecoin_hdnode_get_pub_hex(const dogecoin_hdnode* node, char* str
 /**
  * @brief This function takes a string buffer containing HD
  * node data and loads an HD node object with that data. The
- * function will copy either a private key or a public key, 
+ * function will copy either a private key or a public key,
  * depending on the prefix of the given buffer.
- * 
+ *
  * @param str The buffer containing the node information.
  * @param chain The chain parameters to use.
  * @param node The HD node to be filled.
- * 
+ *
  * @return Nothing.
  */
 dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const dogecoin_chainparams* chain, dogecoin_hdnode* node)
@@ -459,16 +459,17 @@ dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const dogecoin_chainp
 /**
  * @brief This function generates a child key from a given
  * master key and loads it into an HD node.
- * 
+ *
  * @param node The HD node to be filled with the derived key.
  * @param keypath The derivation path of the desired key (e.g. "m/0h/0/0")
  * @param keymaster The master key to derive the child from.
+ * @param depth The depth of the master key.
  * @param chaincode A 32-byte value that is used to generate the child key.
  * @param usepubckd Whether to use public or private key derivation function.
- * 
+ *
  * @return Nothing.
  */
-dogecoin_bool dogecoin_hd_generate_key(dogecoin_hdnode* node, const char* keypath, const uint8_t* keymaster, const uint8_t* chaincode, dogecoin_bool usepubckd)
+dogecoin_bool dogecoin_hd_generate_key(dogecoin_hdnode* node, const char* keypath, const uint8_t* keymaster, const uint32_t depth, const uint8_t* chaincode, dogecoin_bool usepubckd)
 {
     static char delim[] = "/";
     static char prime[] = "phH\'";
@@ -493,7 +494,7 @@ dogecoin_bool dogecoin_hd_generate_key(dogecoin_hdnode* node, const char* keypat
         goto err;
     }
 
-    node->depth = 0;
+    node->depth = depth;
     node->child_num = 0;
     node->fingerprint = 0;
     memcpy_safe(node->chain_code, chaincode, DOGECOIN_BIP32_CHAINCODE_SIZE);
@@ -546,9 +547,9 @@ err:
 
 /**
  * @brief This function checks if the HD node has a private key.
- * 
+ *
  * @param node The HD node to check.
- * 
+ *
  * @return A boolean value, true if node has a private key.
  */
 dogecoin_bool dogecoin_hdnode_has_privkey(dogecoin_hdnode* node)
@@ -559,4 +560,77 @@ dogecoin_bool dogecoin_hdnode_has_privkey(dogecoin_hdnode* node)
             return true;
     }
     return false;
+}
+
+/**
+ * @brief This function generates a master key from a given seed.
+ *
+ * @param seed The seed to generate the master key from.
+ * @param seed_len The length of the seed.
+ * @param is_testnet Whether to use testnet or mainnet.
+ * @param masterkey The master key to be returned.
+ *
+ * @return A boolean value, true if the master key was generated.
+ */
+dogecoin_bool getHDRootKeyFromSeed(const SEED seed, const int seed_len, const dogecoin_bool is_testnet, char masterkey[HDKEYLEN]) {
+    dogecoin_hdnode node;
+    size_t masterkey_len = HDKEYLEN;
+    dogecoin_hdnode_from_seed(seed, seed_len, &node);
+    dogecoin_hdnode_serialize_private(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, masterkey, masterkey_len);
+    return true;
+}
+
+/**
+ * @brief This function gets the master public key from a given master key.
+ *
+ * @param hdkey The master key to get the master public key from.
+ * @param is_testnet Whether to use testnet or mainnet.
+ * @param hdpubkey The master public key to be returned.
+ *
+ * @return A boolean value, true if the master public key was generated.
+ */
+dogecoin_bool getHDPubKey(const char hdkey[HDKEYLEN], const dogecoin_bool is_testnet, char hdpubkey[HDKEYLEN]) {
+    dogecoin_hdnode node;
+    size_t masterkey_len = HDKEYLEN;
+    dogecoin_hdnode_deserialize(hdkey, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, &node);
+    dogecoin_hdnode_serialize_public(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, hdpubkey, masterkey_len);
+    return true;
+}
+
+/**
+ * @brief This function derives an extended private key from a parent key and a derivation path.
+ *
+ * @param extkey The parent key to derive the extended private key from.
+ * @param keypath The derivation path to derive the extended private key from.
+ * @param is_testnet Whether to use testnet or mainnet.
+ * @param key The extended private key to be returned.
+ *
+ * @return A boolean value, true if the extended private key was generated.
+ */
+dogecoin_bool deriveExtKeyFromHDKey(const char extkey[HDKEYLEN], const char keypath[KEYPATHMAXLEN], const dogecoin_bool is_testnet, char key[HDKEYLEN]) {
+    dogecoin_hdnode node, parent;
+    size_t key_len = HDKEYLEN;
+    dogecoin_hdnode_deserialize(extkey, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, &parent);
+    dogecoin_hd_generate_key(&node, keypath, parent.private_key, parent.depth, parent.chain_code, false);
+    dogecoin_hdnode_serialize_private(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, key, key_len);
+    return true;
+}
+
+/**
+ * @brief This function derives an extended public key from a parent key and a derivation path.
+ *
+ * @param extpubkey The parent key to derive the extended public key from.
+ * @param keypath The derivation path to derive the extended public key from.
+ * @param is_testnet Whether to use testnet or mainnet.
+ * @param pubkey The extended public key to be returned.
+ *
+ * @return A boolean value, true if the extended public key was generated.
+ */
+dogecoin_bool deriveExtPubKeyFromHDKey(const char extpubkey[HDKEYLEN], const char keypath[KEYPATHMAXLEN], const dogecoin_bool is_testnet, char pubkey[HDKEYLEN]) {
+    dogecoin_hdnode node, parent;
+    size_t key_len = HDKEYLEN;
+    dogecoin_hdnode_deserialize(extpubkey, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, &parent);
+    dogecoin_hd_generate_key(&node, keypath, parent.public_key, parent.depth, parent.chain_code, true);
+    dogecoin_hdnode_serialize_public(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, pubkey, key_len);
+    return true;
 }

--- a/src/bip44.c
+++ b/src/bip44.c
@@ -28,38 +28,44 @@
 #define UINT32_MAX_DIGITS 10  /* The maximum number of digits needed to represent a 32-bit unsigned integer in decimal format */
 
 /**
- * @brief This function derives the BIP 44 extended private key from a master private key.
+ * @brief This function derives the BIP 44 extended key from a master key.
  *
  * BIP 44 is a standard for deterministic wallet generation, which allows for the generation of
- * a hierarchy of keys starting from a single seed. The extended private key is a specific key
+ * a hierarchy of keys starting from a single seed. The extended key is a specific key
  * in this hierarchy that is derived using BIP 44 constants and the input parameters.
  *
- * @param master_key The master private key to derive from.
+ * @param master_key The master key to derive from.
  * @param account The account number to use in the BIP 44 key derivation.
  * @param address_index The address index to use in the BIP 44 key derivation.
  * @param change_level The change level to use in the BIP 44 key derivation, either "external" or "internal".
  * @param custom_path A custom BIP 44 keypath to use for the derivation (optional).
  * @param keypath A string buffer to store the BIP 44 keypath used for the derivation.
- * @param bip44_key The BIP 44 extended private key to be generated.
+ * @param bip44_key The BIP 44 extended key to be generated.
  * @return 0 if the key is derived successfully, -1 otherwise.
  */
-int derive_bip44_extended_private_key(const dogecoin_hdnode *master_key, const uint32_t account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH custom_path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key)
+int derive_bip44_extended_key(const dogecoin_hdnode *master_key, const uint32_t *account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH custom_path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key)
 {
     char addr_idx_str[UINT32_MAX_DIGITS + 1] = "";
+    char acct_str[UINT32_MAX_DIGITS + 1] = "";
 
     /* Validate input parameters */
-    if (master_key == NULL || change_level == NULL || keypath == NULL || bip44_key == NULL) {
+    if (master_key == NULL || keypath == NULL || bip44_key == NULL) {
         fprintf(stderr, "ERROR: invalid input arguments\n");
         return -1;
     }
 
     /* Convert the address index to a string */
+    if (account != NULL) {
+        snprintf(acct_str, UINT32_MAX_DIGITS + 1, "%u", (uint32_t) *account);
+    }
+
+    /* Convert the address index to a string */
     if (address_index != NULL) {
-        snprintf(addr_idx_str, UINT32_MAX_DIGITS + 1, "/%u", (uint32_t) *address_index);
+        snprintf(addr_idx_str, UINT32_MAX_DIGITS + 1, "%u", (uint32_t) *address_index);
     }
 
     /* Validate the change level input */
-    if (strcmp(change_level, BIP44_CHANGE_EXTERNAL) != 0 && strcmp(change_level, BIP44_CHANGE_INTERNAL) != 0) {
+    if (change_level != NULL && strcmp(change_level, BIP44_CHANGE_EXTERNAL) != 0 && strcmp(change_level, BIP44_CHANGE_INTERNAL) != 0) {
         fprintf(stderr, "ERROR: invalid change level\n");
         return -1;
     }
@@ -69,72 +75,106 @@ int derive_bip44_extended_private_key(const dogecoin_hdnode *master_key, const u
         /* Construct the BIP 44 keypath using the custom path */
         snprintf(keypath, BIP44_KEY_PATH_MAX_LENGTH, "%s%s", custom_path, addr_idx_str);
     }
+    else if (account == NULL) {
+        /* Construct the BIP 44 keypath using the input parameters and BIP 44 constants */
+        snprintf(keypath, BIP44_KEY_PATH_MAX_LENGTH, SLIP44_KEY_PATH "%s'", is_testnet ? BIP44_COIN_TYPE_TEST : BIP44_COIN_TYPE);
+    }
+    else if (change_level == NULL) {
+        /* Construct the BIP 44 keypath using the input parameters and BIP 44 constants */
+        snprintf(keypath, BIP44_KEY_PATH_MAX_LENGTH, SLIP44_KEY_PATH "%s'/%s'", is_testnet ? BIP44_COIN_TYPE_TEST : BIP44_COIN_TYPE, acct_str);
+    }
+    else if (address_index == NULL) {
+        /* Construct the BIP 44 keypath using the input parameters and BIP 44 constants */
+        snprintf(keypath, BIP44_KEY_PATH_MAX_LENGTH, SLIP44_KEY_PATH "%s'/%s'/%s", is_testnet ? BIP44_COIN_TYPE_TEST : BIP44_COIN_TYPE, acct_str, change_level);
+    }
     else {
         /* Construct the BIP 44 keypath using the input parameters and BIP 44 constants */
-        snprintf(keypath, BIP44_KEY_PATH_MAX_LENGTH, SLIP44_KEY_PATH "%s'/%u'/%s%s", is_testnet ? BIP44_COIN_TYPE_TEST : BIP44_COIN_TYPE , account, change_level, addr_idx_str);
+        snprintf(keypath, BIP44_KEY_PATH_MAX_LENGTH, SLIP44_KEY_PATH "%s'/%s'/%s/%s", is_testnet ? BIP44_COIN_TYPE_TEST : BIP44_COIN_TYPE, acct_str, change_level, addr_idx_str);
     }
 
-    /* Generate the BIP 44 extended private key using the master key and keypath */
-    if (!dogecoin_hd_generate_key(bip44_key, keypath, master_key->private_key, master_key->chain_code, false)) {
+    /* Generate the BIP 44 extended key using the master key and keypath */
+    if (!dogecoin_hd_generate_key(bip44_key, keypath, master_key->private_key, master_key->depth, master_key->chain_code, false)) {
         return -1;
     }
-    debug_print("Account: %u\n", account);
+    debug_print("Account: %s\n", acct_str);
     debug_print("Derivation path: %s\n", keypath);
     return 0;
 }
 
-/**
- * @brief This function derives the BIP 44 extended public key from a master public key.
+/** @brief This function derives the BIP 44 extended private key from a master private key.
  *
- * BIP 44 is a standard for deterministic wallet generation, which allows for the generation of
- * a hierarchy of keys starting from a single seed. The extended public key is a specific key
- * in this hierarchy that is derived using BIP 44 constants and the input parameters.
- *
- * @param master_key The master public key to derive from.
+ * @param wif_privkey_master The master private key to derive from.
  * @param account The account number to use in the BIP 44 key derivation.
- * @param address_index The address index to use in the BIP 44 key derivation.
  * @param change_level The change level to use in the BIP 44 key derivation, either "external" or "internal".
- * @param custom_path A custom BIP 44 keypath to use for the derivation (optional).
+ * @param address_index The address index to use in the BIP 44 key derivation.
+ * @param path A custom BIP 44 keypath to use for the derivation (optional).
+ * @param extkeyout A string buffer to store the BIP 44 extended private key.
  * @param keypath A string buffer to store the BIP 44 keypath used for the derivation.
- * @param bip44_key The BIP 44 extended public key to be generated.
- * @return 0 if the key is derived successfully, -1 otherwise.
+ *
+ * @return true if the key is derived successfully, false otherwise.
  */
-int derive_bip44_extended_public_key(const dogecoin_hdnode *master_key, const uint32_t account, const uint32_t* address_index, const CHANGE_LEVEL change_level, const KEY_PATH custom_path, const dogecoin_bool is_testnet, KEY_PATH keypath, dogecoin_hdnode *bip44_key)
-{
-    char addr_idx_str[UINT32_MAX_DIGITS + 1] = "";
-
-    /* Validate input parameters */
-    if (master_key == NULL || change_level == NULL || keypath == NULL || bip44_key == NULL) {
+dogecoin_bool deriveBIP44ExtendedKey(
+    const char wif_privkey_master[HDKEYLEN],
+    const uint32_t* account,
+    const CHANGE_LEVEL change_level,
+    const uint32_t* address_index,
+    const KEY_PATH path,
+    char extkeyout[HDKEYLEN],
+    KEY_PATH keypath) {
+    dogecoin_hdnode master_key;
+    dogecoin_hdnode derived_key;
+    dogecoin_bool is_testnet = isTestnetFromB58Prefix(wif_privkey_master);
+    if (wif_privkey_master == NULL || extkeyout == NULL) {
         fprintf(stderr, "ERROR: invalid input arguments\n");
-        return -1;
+        return false;
     }
+    if (!dogecoin_hdnode_deserialize(wif_privkey_master, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, &master_key)) {
+        fprintf(stderr, "ERROR: invalid master key\n");
+        return false;
+    }
+    if (derive_bip44_extended_key(&master_key, account, address_index, change_level, path, is_testnet, keypath, &derived_key) != 0) {
+        fprintf(stderr, "ERROR: failed to derive BIP 44 extended key\n");
+        return false;
+    }
+    dogecoin_hdnode_serialize_private(&derived_key, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, extkeyout, HDKEYLEN);
+    return true;
+}
 
-    /* Convert the address index to a string */
-    if (address_index != NULL) {
-        snprintf(addr_idx_str, UINT32_MAX_DIGITS + 1, "/%u", (uint32_t) *address_index);
+/** @brief This function derives the BIP 44 extended public key from a master private key.
+ *
+ * @param wif_privkey_master The master private key to derive from.
+ * @param account The account number to use in the BIP 44 key derivation.
+ * @param change_level The change level to use in the BIP 44 key derivation, either "external" or "internal".
+ * @param address_index The address index to use in the BIP 44 key derivation.
+ * @param path A custom BIP 44 keypath to use for the derivation (optional).
+ * @param extkeyout A string buffer to store the BIP 44 extended public key.
+ * @param keypath A string buffer to store the BIP 44 keypath used for the derivation.
+ *
+ * @return true if the key is derived successfully, false otherwise.
+ */
+dogecoin_bool deriveBIP44ExtendedPublicKey(
+    const char wif_privkey_master[HDKEYLEN],
+    const uint32_t* account,
+    const CHANGE_LEVEL change_level,
+    const uint32_t* address_index,
+    const KEY_PATH path,
+    char extkeyout[HDKEYLEN],
+    KEY_PATH keypath) {
+    dogecoin_hdnode master_key;
+    dogecoin_hdnode derived_key;
+    dogecoin_bool is_testnet = isTestnetFromB58Prefix(wif_privkey_master);
+    if (wif_privkey_master == NULL || extkeyout == NULL) {
+        fprintf(stderr, "ERROR: invalid input arguments\n");
+        return false;
     }
-
-    /* Validate the change level input */
-    if (strcmp(change_level, BIP44_CHANGE_EXTERNAL) != 0 && strcmp(change_level, BIP44_CHANGE_INTERNAL) != 0) {
-        fprintf(stderr, "ERROR: invalid change level\n");
-        return -1;
+    if (!dogecoin_hdnode_deserialize(wif_privkey_master, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, &master_key)) {
+        fprintf(stderr, "ERROR: invalid master key\n");
+        return false;
     }
-
-    /* Check for custom key path */
-    if (custom_path != NULL) {
-        /* Construct the BIP 44 keypath using the custom path */
-        snprintf(keypath, BIP44_KEY_PATH_MAX_LENGTH, "%s%s", custom_path, addr_idx_str);
+    if (derive_bip44_extended_key(&master_key, account, address_index, change_level, path, is_testnet, keypath, &derived_key) != 0) {
+        fprintf(stderr, "ERROR: failed to derive BIP 44 extended public key\n");
+        return false;
     }
-    else {
-        /* Construct the BIP 44 keypath using the input parameters and BIP 44 constants */
-        snprintf(keypath, BIP44_KEY_PATH_MAX_LENGTH, SLIP44_KEY_PATH "%s'/%u'/%s%s", is_testnet ? BIP44_COIN_TYPE_TEST : BIP44_COIN_TYPE , account, change_level, addr_idx_str);
-    }
-
-    /* Generate the BIP 44 extended public key using the master key and keypath */
-    if (!dogecoin_hd_generate_key(bip44_key, keypath, master_key->public_key, master_key->chain_code, true)) {
-        return -1;
-    }
-    debug_print("Account: %u\n", account);
-    debug_print("Derivation path: %s\n", keypath);
-    return 0;
+    dogecoin_hdnode_serialize_public(&derived_key, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, extkeyout, HDKEYLEN);
+    return true;
 }

--- a/src/chainparams.c
+++ b/src/chainparams.c
@@ -154,3 +154,21 @@ int chain_from_b58_prefix_bool(char* address) {
     }
     return false;
 }
+
+/* check if a given address is a testnet address */
+dogecoin_bool isTestnetFromB58Prefix(const char address[PUBKEYLEN]) {
+    /* Determine address prefix for network chainparams */
+    const dogecoin_chainparams* chainparams = chain_from_b58_prefix(address);
+
+    /* Check if chainparams is testnet */
+    return (chainparams == &dogecoin_chainparams_test);
+}
+
+/* check if a given address is a mainnet address */
+dogecoin_bool isMainnetFromB58Prefix(const char address[PUBKEYLEN]) {
+    /* Determine address prefix for network chainparams */
+    const dogecoin_chainparams* chainparams = chain_from_b58_prefix(address);
+
+    /* Check if chainparams is mainnet */
+    return (chainparams == &dogecoin_chainparams_main);
+}

--- a/src/cli/tool.c
+++ b/src/cli/tool.c
@@ -182,7 +182,7 @@ dogecoin_bool hd_print_node(const dogecoin_chainparams* chain, const char* nodes
         printf("privatekey WIF:      %s\n", privkey_wif);
     }
     printf("depth:               %d\n", node.depth);
-    printf("child index:         %d\n", node.child_num);
+    printf("child index:         %u\n", node.child_num);
     char addr[34 + 1];
     addresses_from_pubkey(&dogecoin_chainparams_main, str, addr);
     printf("p2pkh address:       %s\n", addr);

--- a/src/cli/tool.c
+++ b/src/cli/tool.c
@@ -47,11 +47,11 @@
 
 /**
  * @brief Given a public key, it returns the addresses that correspond to it
- * 
+ *
  * @param chain The chainparams struct for the chain you want to generate addresses for.
  * @param pubkey_hex The hexadecimal representation of the public key.
  * @param p2pkh_address The address in legacy format (DRnwTww6YB2zw1TTjiPfeFkfuabojfyaB8)
- * 
+ *
  * @return dogecoin_bool (uint8_t)
  */
 dogecoin_bool addresses_from_pubkey(const dogecoin_chainparams* chain, const char* pubkey_hex, char* p2pkh_address)
@@ -72,12 +72,12 @@ dogecoin_bool addresses_from_pubkey(const dogecoin_chainparams* chain, const cha
 
 /**
  * @brief Given a private key in WIF format, convert it to a public key and return it in hex format
- * 
+ *
  * @param chain The chainparams structure.
  * @param privkey_wif The private key in WIF format.
  * @param pubkey_hex The public key in hexadecimal format.
  * @param sizeout The size of the output buffer.
- * 
+ *
  * @return dogecoin_bool (uint8_t)
  */
 dogecoin_bool pubkey_from_privatekey(const dogecoin_chainparams* chain, const char* privkey_wif, char* pubkey_hex, size_t* sizeout)
@@ -92,20 +92,20 @@ dogecoin_bool pubkey_from_privatekey(const dogecoin_chainparams* chain, const ch
     dogecoin_pubkey_from_key(&key, &pubkey);
     assert(dogecoin_pubkey_is_valid(&pubkey) == 1);
     dogecoin_privkey_cleanse(&key);
-    dogecoin_pubkey_get_hex(&pubkey, pubkey_hex, sizeout);
+    assert (dogecoin_pubkey_get_hex(&pubkey, pubkey_hex, sizeout) == 1);
     dogecoin_pubkey_cleanse(&pubkey);
     return true;
 }
 
 /**
  * @brief Generate a private key and export it in both WIF and hex format
- * 
+ *
  * @param chain the chain parameters
  * @param privkey_wif the private key in WIF format
  * @param strsize_wif the size of the buffer to hold the WIF key
  * @param privkey_hex_or_null If you pass in a valid pointer, the function will export the private key
  * in hex format.
- * 
+ *
  * @return dogecoin_bool (uint8_t)
  */
 dogecoin_bool gen_privatekey(const dogecoin_chainparams* chain, char* privkey_wif, size_t strsize_wif, char* privkey_hex_or_null)
@@ -128,11 +128,11 @@ dogecoin_bool gen_privatekey(const dogecoin_chainparams* chain, char* privkey_wi
 
 /**
  * @brief Generate a master key from a random seed
- * 
+ *
  * @param chain The chain parameters to use.
  * @param masterkeyhex The master key in hexadecimal format.
  * @param strsize The size of the buffer to be returned.
- * 
+ *
  * @return dogecoin_bool (uint8_t)
  */
 dogecoin_bool hd_gen_master(const dogecoin_chainparams* chain, char* masterkeyhex, size_t strsize)
@@ -149,10 +149,10 @@ dogecoin_bool hd_gen_master(const dogecoin_chainparams* chain, char* masterkeyhe
 
 /**
  * @brief It takes in a serialized extended public key and prints out all the information about it
- * 
+ *
  * @param chain The chain parameters.
  * @param nodeser The serialized extended public key.
- * 
+ *
  * @return dogecoin_bool (uint8_t)
  */
 dogecoin_bool hd_print_node(const dogecoin_chainparams* chain, const char* nodeser)
@@ -192,13 +192,13 @@ dogecoin_bool hd_print_node(const dogecoin_chainparams* chain, const char* nodes
 /**
  * @brief It takes a master key, a path, and an output buffer. It derives the child key at the path and writes
  * it to the output buffer
- * 
+ *
  * @param chain The chain parameters.
  * @param masterkey The master key to derive the child key from.
  * @param derived_path The path to derive the key from.
  * @param extkeyout The output buffer to write the extended key to.
  * @param extkeyout_size The size of the extkeyout buffer.
- * 
+ *
  * @return dogecoin_bool (uint8_t)
  */
 dogecoin_bool hd_derive(const dogecoin_chainparams* chain, const char* masterkey, const char* derived_path, char* extkeyout, size_t extkeyout_size)
@@ -211,11 +211,41 @@ dogecoin_bool hd_derive(const dogecoin_chainparams* chain, const char* masterkey
     //check if we only have the publickey
     bool pubckd = !dogecoin_hdnode_has_privkey(&node);
     //derive child key, use pubckd or privckd
-    if (!dogecoin_hd_generate_key(&nodenew, derived_path, pubckd ? node.public_key : node.private_key, node.chain_code, pubckd))
+    if (!dogecoin_hd_generate_key(&nodenew, derived_path, pubckd ? node.public_key : node.private_key, node.depth, node.chain_code, pubckd))
         return false;
     if (pubckd)
         dogecoin_hdnode_serialize_public(&nodenew, chain, extkeyout, extkeyout_size);
     else
         dogecoin_hdnode_serialize_private(&nodenew, chain, extkeyout, extkeyout_size);
     return true;
+}
+
+int getAddressFromPubkey(const char pubkey_hex[PUBKEYHEXLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]) {
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+    return addresses_from_pubkey(chain, pubkey_hex, p2pkh_address);
+}
+
+int getPubkeyFromPrivkey(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_bool is_testnet, char pubkey_hex[PUBKEYHEXLEN], size_t* sizeout) {
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+    return (pubkey_from_privatekey(chain, privkey_wif, pubkey_hex, sizeout) == true) ? 1 : 0;
+}
+
+int genPrivkey(const dogecoin_bool is_testnet, char privkey_wif[PUBKEYHEXLEN], size_t strsize_wif, char privkey_hex[PRIVKEYWIFLEN]) {
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+    return gen_privatekey(chain, privkey_wif, strsize_wif, privkey_hex);
+}
+
+int genHDMaster(const dogecoin_bool is_testnet, char masterkey[HDKEYLEN], size_t strsize) {
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+    return hd_gen_master(chain, masterkey, strsize);
+}
+
+int printNode(const dogecoin_bool is_testnet, const char nodeser[HDKEYLEN]) {
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+    return hd_print_node(chain, nodeser);
+}
+
+int deriveHDExtFromMaster(const dogecoin_bool is_testnet, const char masterkey[HDKEYLEN], const char keypath[KEYPATHMAXLEN], char extkeyout[HDKEYLEN], size_t extkeyout_size) {
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+    return hd_derive(chain, masterkey, keypath, extkeyout, extkeyout_size);
 }

--- a/src/key.c
+++ b/src/key.c
@@ -23,7 +23,7 @@
  OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE.
- 
+
 */
 
 
@@ -255,4 +255,21 @@ dogecoin_bool dogecoin_pubkey_getaddr_p2pkh(const dogecoin_pubkey* pubkey, const
     dogecoin_pubkey_get_hash160(pubkey, hash160 + 1);
     dogecoin_base58_encode_check(hash160, sizeof(hash160), addrout, 100);
     return true;
+}
+
+void getWifEncodedPrivKey(const uint8_t privkey[DOGECOIN_ECKEY_PKEY_LENGTH], const dogecoin_bool is_testnet, char privkey_wif[PRIVKEYWIFLEN], size_t* strsize_wif) {
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+    dogecoin_key key;
+    memcpy_safe(key.privkey, privkey, DOGECOIN_ECKEY_PKEY_LENGTH);
+    dogecoin_privkey_encode_wif(&key, chain, privkey_wif, strsize_wif);
+}
+
+int getDecodedPrivKeyWif(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_bool is_testnet, uint8_t privkey[DOGECOIN_ECKEY_PKEY_LENGTH]) {
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+    dogecoin_key key;
+    if (!dogecoin_privkey_decode_wif(privkey_wif, chain, &key)) {
+        return 0;
+    }
+    memcpy_safe(privkey, key.privkey, DOGECOIN_ECKEY_PKEY_LENGTH);
+    return 1;
 }

--- a/src/tx.c
+++ b/src/tx.c
@@ -44,9 +44,9 @@
 /**
  * @brief This function frees the memory allocated
  * for a transaction input.
- * 
+ *
  * @param tx_in The pointer to the transaction input to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_in_free(dogecoin_tx_in* tx_in)
@@ -71,9 +71,9 @@ void dogecoin_tx_in_free(dogecoin_tx_in* tx_in)
  * @brief This function casts data from a channel buffer to
  * a transaction input object and then frees it by calling
  * dogecoin_tx_in_free().
- * 
+ *
  * @param data The pointer to the data to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_in_free_cb(void* data)
@@ -90,7 +90,7 @@ void dogecoin_tx_in_free_cb(void* data)
 /**
  * @brief This function creates a new dogecoin transaction
  * input object and initializes it to all zeroes.
- * 
+ *
  * @return A pointer to the new transaction input object.
  */
 dogecoin_tx_in* dogecoin_tx_in_new()
@@ -106,9 +106,9 @@ dogecoin_tx_in* dogecoin_tx_in_new()
 /**
  * @brief This function frees the memory allocated
  * for a transaction output.
- * 
+ *
  * @param tx_in The pointer to the transaction output to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_out_free(dogecoin_tx_out* tx_out)
@@ -132,9 +132,9 @@ void dogecoin_tx_out_free(dogecoin_tx_out* tx_out)
  * @brief This function casts data from a channel buffer to
  * a transaction output object and then frees it by calling
  * dogecoin_tx_out_free().
- * 
+ *
  * @param data The pointer to the data to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_out_free_cb(void* data)
@@ -151,7 +151,7 @@ void dogecoin_tx_out_free_cb(void* data)
 /**
  * @brief This function creates a new dogecoin transaction
  * output object and initializes it to all zeroes.
- * 
+ *
  * @return A pointer to the new transaction output object.
  */
 dogecoin_tx_out* dogecoin_tx_out_new()
@@ -166,9 +166,9 @@ dogecoin_tx_out* dogecoin_tx_out_new()
 /**
  * @brief This function frees the memory allocated
  * for a full transaction.
- * 
+ *
  * @param tx_in The pointer to the transaction to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_free(dogecoin_tx* tx)
@@ -189,12 +189,12 @@ void dogecoin_tx_free(dogecoin_tx* tx)
 
 /**
  * It takes a pointer to a dogecoin_tx_out, copies to a new dogecoin_tx_out
- * converts dogecoin_tx_out->script_pubkey to a p2pkh address, and 
+ * converts dogecoin_tx_out->script_pubkey to a p2pkh address, and
  * frees the copy.
- * 
+ *
  * @param txout The data to be copied which contains the script hash we want.
  * @param p2pkh The variable out we want to contain the converted script hash in.
- * 
+ *
  * @return int
  */
 int dogecoin_tx_out_pubkey_hash_to_p2pkh_address(dogecoin_tx_out* txout, char* p2pkh, int is_mainnet) {
@@ -232,12 +232,12 @@ int dogecoin_tx_out_pubkey_hash_to_p2pkh_address(dogecoin_tx_out* txout, char* p
 
 /**
  * It takes a pointer to a script_pubkey, copies to a new script_pubkey
- * converts script_pubkey to a p2pkh address, and 
+ * converts script_pubkey to a p2pkh address, and
  * frees the copy.
- * 
+ *
  * @param script_pubkey The data to be copied which contains the script hash we want.
  * @param p2pkh The variable out we want to contain the converted script hash in.
- * 
+ *
  * @return int
  */
 dogecoin_bool dogecoin_pubkey_hash_to_p2pkh_address(char* script_pubkey_hex, size_t script_pubkey_hex_length, char* p2pkh, const dogecoin_chainparams* chain) {
@@ -272,17 +272,17 @@ dogecoin_bool dogecoin_pubkey_hash_to_p2pkh_address(char* script_pubkey_hex, siz
 
 /**
  * It takes a p2pkh address and converts it to a compressed public key in
- * hexadecimal format. It then strips the network prefix and checksum and 
+ * hexadecimal format. It then strips the network prefix and checksum and
  * prepends OP_DUP and OP_HASH160 and appends OP_EQUALVERIFY and OP_CHECKSIG.
- * 
+ *
  * @param p2pkh The variable out we want to contain the converted script hash in.
  * @param pubkey_hash The variable that will store the pubkey hash.
- * 
+ *
  * @return int
  */
 dogecoin_bool dogecoin_p2pkh_address_to_pubkey_hash(char* p2pkh, char* pubkey_hash) {
     if (!p2pkh) return false;
- 
+
     // strlen(p2pkh) + 1 = 35
     unsigned char dec[35]; //problem is here, it works if its char**
 
@@ -293,7 +293,7 @@ dogecoin_bool dogecoin_p2pkh_address_to_pubkey_hash(char* p2pkh, char* pubkey_ha
         printf("failed base58 decode\n");
         return false;
     }
-    
+
     //decoded bytes = [1-byte versionbits][20-byte hash][4-byte checksum]
     char* b58_decode_hex = utils_uint8_to_hex((const uint8_t*)dec, decoded_length - 4);
     //concatenate the fields
@@ -304,15 +304,15 @@ dogecoin_bool dogecoin_p2pkh_address_to_pubkey_hash(char* p2pkh, char* pubkey_ha
 /**
  * It takes a p2pkh address and converts it to a compressed public key in
  * hexadecimal format. It then strips the network prefix and checksum
- * 
+ *
  * @param p2pkh The variable out we want to contain the converted script hash in.
  * @param pubkey_hash The variable that will store the pubkey hash.
- * 
+ *
  * @return int
  */
 char* dogecoin_address_to_pubkey_hash(char* p2pkh) {
     if (!p2pkh) return false;
- 
+
     // strlen(p2pkh) + 1 = 35
     unsigned char dec[35]; //problem is here, it works if its char**
 
@@ -323,7 +323,7 @@ char* dogecoin_address_to_pubkey_hash(char* p2pkh) {
         printf("failed base58 decode\n");
         return false;
     }
-    
+
     //decoded bytes = [1-byte versionbits][20-byte hash][4-byte checksum]
     char* b58_decode_hex = utils_uint8_to_hex((const uint8_t*)dec, decoded_length - 4);
     return &b58_decode_hex[2];
@@ -336,9 +336,9 @@ char* dogecoin_address_to_pubkey_hash(char* p2pkh) {
  * public hexadecimal key and generates the corresponding p2pkh address. Finally it converts
  * the p2pkh to a script pubkey hash, frees the previous structs from memory and returns the
  * script pubkey hash.
- * 
+ *
  * @param p2pkh The variable out we want to contain the converted script hash in.
- * 
+ *
  * @return char* The script public key hash.
  */
 char* dogecoin_private_key_wif_to_pubkey_hash(char* private_key_wif) {
@@ -385,7 +385,7 @@ char* dogecoin_private_key_wif_to_pubkey_hash(char* private_key_wif) {
  * @brief This function creates a new dogecoin transaction
  * object and initializes it to all zeroes except for the
  * version, which is set to 1.
- * 
+ *
  * @return A pointer to the new transaction object.
  */
 dogecoin_tx* dogecoin_tx_new()
@@ -403,10 +403,10 @@ dogecoin_tx* dogecoin_tx_new()
 /**
  * @brief This function takes information from a buffer
  * and deserializes it into a transaction input object.
- * 
+ *
  * @param tx_in The pointer to the transaction input to deserialize into.
  * @param buf The pointer to the buffer containing the transaction input information.
- * 
+ *
  * @return 1 if deserialized successfully, 0 otherwise.
  */
 dogecoin_bool dogecoin_tx_in_deserialize(dogecoin_tx_in* tx_in, struct const_buffer* buf)
@@ -428,10 +428,10 @@ dogecoin_bool dogecoin_tx_in_deserialize(dogecoin_tx_in* tx_in, struct const_buf
 /**
  * @brief This function takes information from a buffer
  * and deserializes it into a transaction output object.
- * 
+ *
  * @param tx_in The pointer to the transaction output to deserialize into.
  * @param buf The pointer to the buffer containing the transaction output information.
- * 
+ *
  * @return 1 if deserialized successfully, 0 otherwise.
  */
 dogecoin_bool dogecoin_tx_out_deserialize(dogecoin_tx_out* tx_out, struct const_buffer* buf)
@@ -449,12 +449,12 @@ dogecoin_bool dogecoin_tx_out_deserialize(dogecoin_tx_out* tx_out, struct const_
 /**
  * @brief This function takes information from a string
  * and deserializes it into a full transaction object.
- * 
+ *
  * @param tx_serialized The string containing the transaction information.
  * @param inlen The length of the string to be read.
  * @param tx The pointer to the transaction object to be deserialized into.
  * @param consumed_length The pointer to the total number of characters successfully deserialized.
- * 
+ *
  * @return 1 if deserialized successfully, 0 otherwise.
  */
 int dogecoin_tx_deserialize(const unsigned char* tx_serialized, size_t inlen, dogecoin_tx* tx, size_t* consumed_length)
@@ -512,10 +512,10 @@ int dogecoin_tx_deserialize(const unsigned char* tx_serialized, size_t inlen, do
 
 /**
  * @brief This function serializes a transaction input.
- * 
+ *
  * @param s The pointer to the cstring to serialize the data into.
  * @param tx_in The pointer to the transaction input to serialize.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_in_serialize(cstring* s, const dogecoin_tx_in* tx_in)
@@ -529,10 +529,10 @@ void dogecoin_tx_in_serialize(cstring* s, const dogecoin_tx_in* tx_in)
 
 /**
  * @brief This function serializes a transaction output.
- * 
+ *
  * @param s The pointer to the cstring to serialize the data into.
  * @param tx_out The pointer to the transaction output to serialize.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_out_serialize(cstring* s, const dogecoin_tx_out* tx_out)
@@ -544,10 +544,10 @@ void dogecoin_tx_out_serialize(cstring* s, const dogecoin_tx_out* tx_out)
 
 /**
  * @brief This function serializes a full transaction.
- * 
+ *
  * @param s The pointer to the cstring to serialize the data into.
  * @param tx The pointer to the transaction to serialize.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_serialize(cstring* s, const dogecoin_tx* tx)
@@ -584,10 +584,10 @@ void dogecoin_tx_serialize(cstring* s, const dogecoin_tx* tx)
 /**
  * @brief This function performs a double SHA256 hash
  * on a given transaction.
- * 
+ *
  * @param tx The pointer to the transaction to hash.
  * @param hashout The result of the hashing operation.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_hash(const dogecoin_tx* tx, uint256 hashout)
@@ -603,10 +603,10 @@ void dogecoin_tx_hash(const dogecoin_tx* tx, uint256 hashout)
 /**
  * @brief This function makes a copy of a given transaction
  * input object.
- * 
+ *
  * @param dest The pointer to the copy of the transaction input.
  * @param src The pointer to the original transaction input.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_in_copy(dogecoin_tx_in* dest, const dogecoin_tx_in* src)
@@ -628,10 +628,10 @@ void dogecoin_tx_in_copy(dogecoin_tx_in* dest, const dogecoin_tx_in* src)
 /**
  * @brief This function makes a copy of a given transaction
  * output object.
- * 
+ *
  * @param dest The pointer to the copy of the transaction output.
  * @param src The pointer to the original transaction output.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_out_copy(dogecoin_tx_out* dest, const dogecoin_tx_out* src)
@@ -652,10 +652,10 @@ void dogecoin_tx_out_copy(dogecoin_tx_out* dest, const dogecoin_tx_out* src)
 /**
  * @brief This function makes a copy of a given transaction
  * object.
- * 
+ *
  * @param dest The pointer to the copy of the transaction.
  * @param src The pointer to the original transaction.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_copy(dogecoin_tx* dest, const dogecoin_tx* src)
@@ -708,10 +708,10 @@ void dogecoin_tx_copy(dogecoin_tx* dest, const dogecoin_tx* src)
 /**
  * @brief This function performs a double SHA256 hash
  * on the input data of a given transaction.
- * 
+ *
  * @param tx The pointer to the transaction whose inputs will be hashed.
  * @param hash The result of the hashed inputs.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_prevout_hash(const dogecoin_tx* tx, uint256 hash)
@@ -731,12 +731,12 @@ void dogecoin_tx_prevout_hash(const dogecoin_tx* tx, uint256 hash)
 
 /**
  * @brief This function performs a double SHA256 hash
- * on the sequence numbers of all the transaction's 
+ * on the sequence numbers of all the transaction's
  * inputs
- * 
+ *
  * @param tx The pointer to the transaction whose inputs will be hashed.
  * @param hash The result of the hashed inputs.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_sequence_hash(const dogecoin_tx* tx, uint256 hash)
@@ -756,10 +756,10 @@ void dogecoin_tx_sequence_hash(const dogecoin_tx* tx, uint256 hash)
 /**
  * @brief This function perform a double SHA256 hash
  * on the serialized outputs of a given transaction.
- * 
+ *
  * @param tx The pointer to the transaction whose outputs will be hashed.
  * @param hash The result of the hashed outputs.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_tx_outputs_hash(const dogecoin_tx* tx, uint256 hash)
@@ -781,13 +781,13 @@ void dogecoin_tx_outputs_hash(const dogecoin_tx* tx, uint256 hash)
  * @brief This function takes an existing transaction and
  * generates a signature hash to lock its inputs from being
  * double-spent.
- * 
+ *
  * @param tx_to The pointer to the existing transaction.
  * @param fromPubKey The pointer to the cstring containing the public key of the sender.
  * @param in_num The index of the input being signed.
  * @param hashtype The type of signature hash to perform.
  * @param hash The generated signature hash.
- * 
+ *
  * @return 1 if signature hash is generated successfully, 0 otherwise.
  */
 dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, size_t in_num, int hashtype, uint256 hash)
@@ -800,7 +800,7 @@ dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromP
 
     dogecoin_tx* tx_tmp = dogecoin_tx_new();
     dogecoin_tx_copy(tx_tmp, tx_to);
-    
+
     // standard sighash (SIGVERSION_BASE)
     cstring* new_script = cstr_new_sz(fromPubKey->len);
     dogecoin_script_copy_without_op_codeseperator(fromPubKey, new_script);
@@ -881,13 +881,13 @@ out:
 /**
  * @brief This function adds another transaction output to
  * an existing transaction.
- * 
+ *
  * @param tx The pointer to the transaction which will be updated.
  * @param amount The amount that will be sent to the new destination.
  * @param data The pubkey data to be embedded in the new transaction.
  * @param datalen The length of the pubkey data to be embedded.
- * 
- * @return dogecoin_bool 
+ *
+ * @return dogecoin_bool
  */
 dogecoin_bool dogecoin_tx_add_data_out(dogecoin_tx* tx, const int64_t amount, const uint8_t* data, const size_t datalen)
 {
@@ -907,15 +907,15 @@ dogecoin_bool dogecoin_tx_add_data_out(dogecoin_tx* tx, const int64_t amount, co
 
 
 /**
- * @brief This function adds another transaction output 
+ * @brief This function adds another transaction output
  * containing the puzzle hash for the miner to solve to
  * an existing transaction.
- * 
+ *
  * @param tx The pointer to the transaction which will be updated.
  * @param amount The amount that will be sent in the transaction.
  * @param puzzle The puzzle that the miner must solve in order to spend the coin.
  * @param puzzlelen The length of the puzzle in bytes.
- * 
+ *
  * @return 1 if the puzzle was added successfully, 0 otherwise.
  */
 dogecoin_bool dogecoin_tx_add_puzzle_out(dogecoin_tx* tx, const int64_t amount, const uint8_t* puzzle, const size_t puzzlelen)
@@ -937,15 +937,15 @@ dogecoin_bool dogecoin_tx_add_puzzle_out(dogecoin_tx* tx, const int64_t amount, 
 
 /**
  * @brief This function adds another transaction output
- * containing the destination address to an existing 
+ * containing the destination address to an existing
  * transaction.
- * 
+ *
  * @param tx The pointer to the transaction which will be updated.
  * @param chain The pointer to the chainparams which contain the prefixes for the address types.
- * @param amount The amount that will be sent in the transaction. 
+ * @param amount The amount that will be sent in the transaction.
  * @param address The address to send coins to, which can be a P2PKH, P2SH, or P2WPKH address.
- * 
- * @return 1 if the address was added successfully, 0 otherwise. 
+ *
+ * @return 1 if the address was added successfully, 0 otherwise.
  */
 dogecoin_bool dogecoin_tx_add_address_out(dogecoin_tx* tx, const dogecoin_chainparams* chain, int64_t amount, const char* address)
 {
@@ -966,11 +966,11 @@ dogecoin_bool dogecoin_tx_add_address_out(dogecoin_tx* tx, const dogecoin_chainp
 /**
  * @brief This function adds a new P2PKH output to an
  * existing transaction.
- * 
+ *
  * @param tx The pointer to the transaction which will be updated.
  * @param amount The amount that will be sent in the transaction.
  * @param hash160 The hash160 of the sender public key.
- * 
+ *
  * @return 1 if the output is added successfully.
  */
 dogecoin_bool dogecoin_tx_add_p2pkh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160 hash160)
@@ -987,11 +987,11 @@ dogecoin_bool dogecoin_tx_add_p2pkh_hash160_out(dogecoin_tx* tx, int64_t amount,
 /**
  * @brief This function adds a new P2SH output to an
  * existing transaction.
- * 
+ *
  * @param tx The pointer to the transaction which will be updated.
  * @param amount The amount that will be sent in the transaction.
  * @param hash160 The hash160 of the sender public key.
- * 
+ *
  * @return 1 if the output is added successfully.
  */
 dogecoin_bool dogecoin_tx_add_p2sh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160 hash160)
@@ -1009,11 +1009,11 @@ dogecoin_bool dogecoin_tx_add_p2sh_hash160_out(dogecoin_tx* tx, int64_t amount, 
  * @brief This function adds an output to an existing
  * transaction by hashing the given public key and calling
  * dogecoin_tx_add_p2pkh_hash160_out() using this hash.
- * 
+ *
  * @param tx The pointer to the transaction which will be updated.
  * @param amount The amount that will be sent in the transaction.
  * @param pubkey The pointer to the public key to be hashed.
- * 
+ *
  * @return 1 if the output was added successfully.
  */
 dogecoin_bool dogecoin_tx_add_p2pkh_out(dogecoin_tx* tx, int64_t amount, const dogecoin_pubkey* pubkey)
@@ -1027,9 +1027,9 @@ dogecoin_bool dogecoin_tx_add_p2pkh_out(dogecoin_tx* tx, int64_t amount, const d
 /**
  * @brief This function checks whether a transaction
  * outpoint is null.
- * 
+ *
  * @param tx The pointer to the transaction outpoint to check.
- * 
+ *
  * @return 1 if the outpoint is null.
  */
 dogecoin_bool dogecoin_tx_outpoint_is_null(dogecoin_tx_outpoint* tx)
@@ -1042,11 +1042,11 @@ dogecoin_bool dogecoin_tx_outpoint_is_null(dogecoin_tx_outpoint* tx)
 /**
  * @brief This function checks whether a transaction was
  * a coinbase transaction, which is true if the transaction
- * has only one input, the previous transaction hash is 
- * empty, and the transaction index is UINT32_MAX. 
- * 
+ * has only one input, the previous transaction hash is
+ * empty, and the transaction index is UINT32_MAX.
+ *
  * @param tx The pointer to the transaction to check.
- * @return dogecoin_bool 
+ * @return dogecoin_bool
  */
 dogecoin_bool dogecoin_tx_is_coinbase(dogecoin_tx* tx)
 {
@@ -1063,9 +1063,9 @@ dogecoin_bool dogecoin_tx_is_coinbase(dogecoin_tx* tx)
 /**
  * @brief This function converts the result of the signing
  * into a regular string.
- * 
+ *
  * @param result The string representation of the signing result.
- * 
+ *
  * @return The string representation of the signing result, "UNKNOWN" if result is unrecognized.
  */
 const char* dogecoin_tx_sign_result_to_str(const enum dogecoin_tx_sign_result result)
@@ -1092,7 +1092,7 @@ const char* dogecoin_tx_sign_result_to_str(const enum dogecoin_tx_sign_result re
 /**
  * @brief This function signs the inputs of a given
  * transaction using the private key and signature.
- * 
+ *
  * @param tx_in_out The pointer to the transaction to be signed.
  * @param script The pointer to the cstring containing the script to be signed.
  * @param privkey The pointer to the private key to be used to sign the transaction.
@@ -1101,7 +1101,7 @@ const char* dogecoin_tx_sign_result_to_str(const enum dogecoin_tx_sign_result re
  * @param sigcompact_out The signature in compact format.
  * @param sigder_out The DER-encoded signature.
  * @param sigder_len_out The length of the signature in DER format.
- * 
+ *
  * @return The code denoting which errors occurred, if any.
  */
 enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, const dogecoin_key* privkey, size_t inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, size_t* sigder_len_out)
@@ -1117,7 +1117,7 @@ enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, cons
     if (!dogecoin_privkey_is_valid(privkey)) {
         return DOGECOIN_SIGN_INVALID_KEY;
     }
-    
+
     // calculate pubkey
     dogecoin_pubkey pubkey;
     dogecoin_pubkey_init(&pubkey);
@@ -1191,3 +1191,16 @@ enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, cons
     }
     return res;
 }
+
+/** This function gets the address from a given pubkey hash.
+ *
+ * @param pubkey_hash The pointer to the pubkey hash.
+ * @param is_testnet The pointer to the chainparams which contain the prefixes for the address types.
+ * @param p2pkh_address The address to send coins to, which can be a P2PKH, P2SH, or P2WPKH address.
+ *
+ * @return 1 if the address was added successfully, 0 otherwise.
+ */
+int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]) {
+    return dogecoin_pubkey_hash_to_p2pkh_address((char *)utils_hex_to_uint8(pubkey_hash), SCRIPT_PUBKEY_LENGTH, p2pkh_address, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main);
+}
+

--- a/src/vector.c
+++ b/src/vector.c
@@ -33,10 +33,10 @@
 /**
  * @brief This function creates a new vector object
  * and initializes it to 0.
- * 
+ *
  * @param res The size of memory to allocate for the vector's contents.
  * @param free_f The function that will be called when a vector element is freed.
- * 
+ *
  * @return A pointer to the new vector object.
  */
 vector* vector_new(size_t res, void (*free_f)(void*))
@@ -63,11 +63,11 @@ vector* vector_new(size_t res, void (*free_f)(void*))
 /**
  * @brief This function frees all of a vector's elements,
  * calling the function associated with its free operation
- * set during vector creation. The vector object itself 
+ * set during vector creation. The vector object itself
  * is not freed.
- * 
+ *
  * @param vec The pointer to the vector to be freed.
- * 
+ *
  * @return Nothing.
  */
 static void vector_free_data(vector* vec)
@@ -92,12 +92,12 @@ static void vector_free_data(vector* vec)
 
 
 /**
- * @brief This function frees an entire vector 
+ * @brief This function frees an entire vector
  * object and all of its elements if specified.
- * 
+ *
  * @param vec The pointer to the vector to be freed.
  * @param free_array The flag denoting whether to free the vector's elements.
- * 
+ *
  * @return Nothing.
  */
 void vector_free(vector* vec, dogecoin_bool free_array)
@@ -118,10 +118,10 @@ void vector_free(vector* vec, dogecoin_bool free_array)
 /**
  * @brief This function grows the vector by doubling
  * in size until it is larger than the size specified.
- * 
+ *
  * @param vec The pointer to the vector to be grown.
  * @param min_sz The minimum size the vector must be grown to.
- * 
+ *
  * @return 1 if the vector is grown successfully, 0 if it reaches the max size allowed.
  */
 static dogecoin_bool vector_grow(vector* vec, size_t min_sz)
@@ -149,10 +149,10 @@ static dogecoin_bool vector_grow(vector* vec, size_t min_sz)
 /**
  * @brief This function finds and returns the first element
  * in the vector whose data matches the data specified.
- * 
+ *
  * @param vec The pointer to the vector to search.
  * @param data The data to match.
- * 
+ *
  * @return The index of the data if it exists in the vector, -1 otherwise.
  */
 ssize_t vector_find(vector* vec, void* data)
@@ -173,10 +173,10 @@ ssize_t vector_find(vector* vec, void* data)
 /**
  * @brief This function adds an element to an existing
  * vector, growing it by one if necessary.
- * 
+ *
  * @param vec The pointer to the vector to add to.
  * @param data The data to be added into the vector.
- * 
+ *
  * @return 1 if the element was added successfully, 0 otherwise.
  */
 dogecoin_bool vector_add(vector* vec, void* data)
@@ -196,11 +196,11 @@ dogecoin_bool vector_add(vector* vec, void* data)
 /**
  * @brief This function deletes a range of consecutive
  * elements from the specified vector.
- * 
+ *
  * @param vec The pointer to the vector to edit.
  * @param pos The index of the first item to remove.
  * @param len The number of consecutive elements to remove.
- * 
+ *
  * @return Nothing.
  */
 void vector_remove_range(vector* vec, size_t pos, size_t len)
@@ -224,7 +224,7 @@ void vector_remove_range(vector* vec, size_t pos, size_t len)
 /**
  * @brief This function removes a single element from
  * the specified vector.
- * 
+ *
  * @param vec The pointer to the vector to edit.
  * @param pos The index of the element to remove.
  */
@@ -238,10 +238,10 @@ void vector_remove_idx(vector* vec, size_t pos)
  * @brief This function finds an element whose data
  * matches the data specified and removes it if it
  * exists.
- * 
+ *
  * @param vec The pointer to the vector to edit.
  * @param data The data to match.
- * 
+ *
  * @return 1 if the element was removed successfully, 0 if the data was not found.
  */
 dogecoin_bool vector_remove(vector* vec, void* data)
@@ -262,10 +262,10 @@ dogecoin_bool vector_remove(vector* vec, void* data)
  * is grown and the new elements are left empty. If the
  * new size is smaller, vector elements will be truncated.
  * If the new size is the same, do nothing.
- * 
+ *
  * @param vec The pointer to the vector to resize.
  * @param newsz The new desired size of the vector.
- * 
+ *
  * @return 1 if the vector was resized successfully, 0 otherwise.
  */
 dogecoin_bool vector_resize(vector* vec, size_t newsz)
@@ -302,5 +302,82 @@ dogecoin_bool vector_resize(vector* vec, size_t newsz)
         vec->data[i] = NULL;
     }
 
+    return true;
+}
+
+/**
+ * @brief This function serializes a vector into a string.
+ *
+ * @param vec The vector to serialize.
+ * @param out The output buffer.
+ * @param outlen The length of the output buffer.
+ * @param written The number of bytes written to the output buffer.
+ *
+ * @return 1 if the vector was serialized successfully, 0 otherwise.
+ */
+dogecoin_bool serializeVector(vector* vec, char* out, size_t outlen, size_t* written) {
+    if (!out || !outlen || !vec || !written) {
+        return false;
+    }
+
+    size_t i;
+    size_t offset = 0;
+    for (i = 0; i < vec->len; i++) {
+        if (!vec->data[i]) {
+            continue;
+        }
+
+        size_t len = strlen(vec->data[i]);
+        if (len > outlen - offset) {
+            return false;
+        }
+
+        memcpy(out + offset, vec->data[i], len);
+        offset += len;
+    }
+
+    *written = offset;
+    return true;
+}
+
+/**
+ * @brief This function deserializes a string into a vector.
+ *
+ * @param vec The vector to deserialize into.
+ * @param in The input buffer.
+ * @param inlen The length of the input buffer.
+ * @param read The number of bytes read from the input buffer.
+ *
+ * @return 1 if the vector was deserialized successfully, 0 otherwise.
+ */
+dogecoin_bool deserializeVector(vector* vec, const char* in, size_t inlen, size_t* read) {
+    if (!in || !inlen || !vec || !read) {
+        return false;
+    }
+
+    size_t offset = 0;
+    while (offset < inlen) {
+        size_t len = strlen(in + offset);
+        if (!len) {
+            return false;
+        }
+
+        char* str = dogecoin_malloc(len + 1);
+        if (!str) {
+            return false;
+        }
+
+        memcpy(str, in + offset, len);
+        str[len] = '\0';
+
+        if (!vector_add(vec, str)) {
+            dogecoin_free(str);
+            return false;
+        }
+
+        offset += len;
+    }
+
+    *read = offset;
     return true;
 }

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -944,9 +944,11 @@ dogecoin_wallet_addr* dogecoin_wallet_next_bip44_addr(dogecoin_wallet* wallet)
     uint32_t index = wallet->next_childindex;
 
     char keypath[BIP44_KEY_PATH_MAX_LENGTH + 1] = "";
+    uint32_t account = BIP44_FIRST_ACCOUNT_NODE;
+    char* change = BIP44_CHANGE_EXTERNAL;
 
     /* Derive the child private key at the index */
-    if (derive_bip44_extended_private_key(hdnode, 0, &index, "0", NULL, false, keypath, bip44_key) == -1) {
+    if (derive_bip44_extended_key(hdnode, &account, &index, change, NULL, false, keypath, bip44_key) == -1) {
         return NULL;
     }
 

--- a/test/bip32_tests.c
+++ b/test/bip32_tests.c
@@ -58,7 +58,7 @@ void test_bip32()
 
     /* [Chain m/0'] */
     char path0[] = "m/0'";
-    dogecoin_hd_generate_key(&node, path0, private_key_master, chain_code_master, false);
+    dogecoin_hd_generate_key(&node, path0, private_key_master, 0, chain_code_master, false);
     u_assert_int_eq(node.fingerprint, 0x3442193E);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141"),
@@ -91,7 +91,7 @@ void test_bip32()
 
     /* [Chain m/0'/3] */
     char path1[] = "m/0'/3";
-    dogecoin_hd_generate_key(&node, path1, private_key_master, chain_code_master, false);
+    dogecoin_hd_generate_key(&node, path1, private_key_master, 0, chain_code_master, false);
     u_assert_int_eq(node.fingerprint, 0x5C1BD648);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("c354182c136d7c9efc2f215b963b667d8729e6eb6e8f6605929b6771aace080e"),
@@ -121,7 +121,7 @@ void test_bip32()
 
     /* [Chain m/0'/3/2'] */
     char path2[] = "m/0'/3/2'";
-    dogecoin_hd_generate_key(&node, path2, private_key_master, chain_code_master, false);
+    dogecoin_hd_generate_key(&node, path2, private_key_master, 0, chain_code_master, false);
     u_assert_int_eq(node.fingerprint, 0x73457C28);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("8f96add0124b936f0066645b8805a9ddc072155be93f2d5c12ab950e4f678611"),
@@ -151,7 +151,7 @@ void test_bip32()
 
     /* [Chain m/0'/3/2'/2] */
     char path3[] = "m/0'/3/2'/2";
-    dogecoin_hd_generate_key(&node, path3, private_key_master, chain_code_master, false);
+    dogecoin_hd_generate_key(&node, path3, private_key_master, 0, chain_code_master, false);
     u_assert_int_eq(node.fingerprint, 0x73EECC5F);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("d7dff9258e4d978a05d10a9dfecf8d75c8a862f36bb88c97802a1a78c76cdbe9"),
@@ -181,7 +181,7 @@ void test_bip32()
 
     /* [Chain m/0'/3/2'/2/1000000000] */
     char path4[] = "m/0'/3/2'/2/1000000000";
-    dogecoin_hd_generate_key(&node, path4, private_key_master, chain_code_master, false);
+    dogecoin_hd_generate_key(&node, path4, private_key_master, 0, chain_code_master, false);
     u_assert_int_eq(node.fingerprint, 0x406AACFA);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("4c77a7bf5d73e6b8904ac92aaee3c46b8be0669573d4c7836e90b3829fae997f"),
@@ -245,6 +245,78 @@ void test_bip32()
     u_assert_int_eq(memcmp(nodeheap->private_key, nodeheap_copy->private_key, 32), 0);
     u_assert_int_eq(memcmp(nodeheap->public_key, nodeheap_copy->public_key, 33), 0)
 
-        dogecoin_hdnode_free(nodeheap);
+    dogecoin_hdnode_free(nodeheap);
+
     dogecoin_hdnode_free(nodeheap_copy);
+
+    SEED seed = {0};
+    memcpy(seed, utils_hex_to_uint8("3779b041fab425e9c0fd55846b2a03e9a388fb12784067bd8ebdb464c2574a05bcc7a8eb54d7b2a2c8420ff60f630722ea5132d28605dbc996c8ca7d7a8311c0"), 64);
+    const int seed_len = 64;
+    char masterkey[HDKEYLEN];
+    char masterpubkey[HDKEYLEN];
+    char extkey[HDKEYLEN], extkey2[HDKEYLEN];
+    char extpubkey[HDKEYLEN], extpubkey2[HDKEYLEN];
+
+    u_assert_true(getHDRootKeyFromSeed(seed, seed_len, true, masterkey));
+    u_assert_str_eq(masterkey,
+                    "tprv8ZgxMBicQKsPdM3GJUGqaS67XFjHNqUC8upXBhNb7UXqyKdLCj6HnTfqrjoEo6x89neRY2DzmKXhjWbAkxYvnb1U7vf4cF4qDicyb7Y2mNa");
+
+    u_assert_true(getHDPubKey(masterkey, true, masterpubkey));
+    u_assert_str_eq(masterpubkey,
+                    "tpubD6NzVbkrYhZ4Wp54C7wRyqkE6HFDYAf6iDRJUDQtXkLEoot6q7usxxHi2tGW48TfY783vGoZ3ufE5XH9YP86c7X6G3CjMh8Dua1ZTTWyjSa");
+
+    char keypath[KEYPATHMAXLEN] = "m/44'/1'/0'";
+    u_assert_true(deriveExtKeyFromHDKey(masterkey, keypath, true, extkey));
+    u_assert_str_eq(extkey,
+                    "tprv8fRGXa8U2TD8awz5go6QPzPkP2wxabQip9Tmm7qNnuGhqJah42dmffvKCer9tZzS3U23n1jmaxDLFWPVGR2qLbS3Ec9Nskr7eKYBBZGy9N8");
+
+    u_assert_true(getHDPubKey(extkey, true, extpubkey));
+    u_assert_str_eq(extpubkey,
+                    "tpubDC7JfzAiAptoUR1saSkzoQ3rx4TtjvbdPT4Z3dsgDB56fnqTgRTMrAYBNooSmtJgpxUL7U5wvRtXDkKAx3qnPP33qNdcojAWVSK914c2Kd2");
+
+    char keypath1[KEYPATHMAXLEN] = "m/44'/1'/0'/0";
+    u_assert_true(deriveExtKeyFromHDKey(masterkey, keypath1, true, extkey2));
+    u_assert_str_eq(extkey2,
+                    "tprv8hJrzKEmbFfBx44tsRe1wHh25i5QGztsawJGmxeqryPwdXdKrgxMgJUWn35dY2nrYmomRWWL7Y9wJrA6EvKJ27BfQTX1tWzZVxAXrR2pLLn");
+
+    u_assert_true(getHDPubKey(extkey2, true, extpubkey2));
+    u_assert_str_eq(extpubkey2,
+                    "tpubDDzu8jH1jdLrqX6gm5JcLhM8ejbLSL5nAEu44Uh9HFCLU1t6V5mwro6NxAXCfR2jUJ9vkYkUazKXQSU7WAaA9cbEkxdWmbLxHQnWqLyQ6uR");
+
+    char keypath2[KEYPATHMAXLEN] = "m/0";
+    u_assert_true(deriveExtPubKeyFromHDKey(extpubkey, keypath2, true, extpubkey2));
+    u_assert_str_eq(extpubkey2,
+                    "tpubDDzu8jH1jdLrqX6gm5JcLhM8ejbLSL5nAEu44Uh9HFCLU1t6V5mwro6NxAXCfR2jUJ9vkYkUazKXQSU7WAaA9cbEkxdWmbLxHQnWqLyQ6uR");
+
+
+    u_assert_true(getHDRootKeyFromSeed(seed, seed_len, false, masterkey));
+    u_assert_str_eq(masterkey,
+                    "dgpv51eADS3spNJh8Q6Qzz9L6AABYtvRnEGqvSFKXrxzhwK54fWAHo3NrGHvagERrteHgWo6rifQ9GxswUAYR4Exh9zekTNz6FUhJFAjhae3ptn");
+
+    u_assert_true(getHDPubKey(masterkey, false, masterpubkey));
+    u_assert_str_eq(masterpubkey,
+                    "dgub8kXBZ7ymNWy2RFka3DmJD1hn1TJ4cMJZD32XgyMyW4N5cicrhZb9VZha9vghubutjw72kayz7p38Q56ZiFvbiVvME8rwCSF6gChmQt4RgLZ");
+
+    char keypath3[KEYPATHMAXLEN] = "m/0'";
+    u_assert_true(deriveExtKeyFromHDKey(masterkey, keypath3, false, extkey));
+    u_assert_str_eq(extkey,
+                    "dgpv53Zmoqj7kNTYigGq7A5cTsfDt1yXAuKdCzUCEdBdqPKoM29mg1zhk11b8iSzH2H6ot8eVY9Bdh3dVsqbEeiXU6Exfm3u3ZkwZ3bbYthRE3V");
+
+    u_assert_true(getHDPubKey(extkey, false, extpubkey));
+    u_assert_str_eq(extpubkey,
+                    "dgub8nSo9Xf1JX7t1Xvz9PhaajCpLaMA12MLVbFQPjacdWNou5GU5nYUPJREhzWzRqENdG4nrxckhMEv4sKFEiLbm4pkVvDjBP7SrQZeStHNMEQ");
+
+    char keypath4[KEYPATHMAXLEN] = "m/0'/0";
+    u_assert_true(deriveExtKeyFromHDKey(masterkey, keypath4, false, extkey2));
+    u_assert_str_eq(extkey2,
+                    "dgpv55f5vS3Ct4dEo6Z5oZSbdtdvCXPPttTuBCg4DjQfJWx6xoiSm2RMcRuJendsxU5XZRcBCUTPLwKnydME4rWxLXxECUGrnVaHW2wHP53CfBG");
+
+    u_assert_true(getHDPubKey(extkey2, false, extpubkey2));
+    u_assert_str_eq(extpubkey2,
+                    "dgub8pY7G7y6SDHa5xDEqo4ZkkBWf5m2j1VcToTGNqoe6e17Wrq9Any8FjJxE2hnwdBYM19gxkaA7VWqE2Vw6hGHTeac2neLCHzLR8VojVsdqnA");
+
+    char keypath5[KEYPATHMAXLEN] = "m/0";
+    u_assert_true(deriveExtPubKeyFromHDKey(extpubkey, keypath5, false, extpubkey2));
+    u_assert_str_eq(extpubkey2,
+                    "dgub8pY7G7y6SDHa5xDEqo4ZkkBWf5m2j1VcToTGNqoe6e17Wrq9Any8FjJxE2hnwdBYM19gxkaA7VWqE2Vw6hGHTeac2neLCHzLR8VojVsdqnA");
 }

--- a/test/bip44_tests.c
+++ b/test/bip44_tests.c
@@ -22,6 +22,9 @@ void test_bip44()
     int result;
     dogecoin_hdnode node;
     dogecoin_hdnode bip44_key;
+    dogecoin_hdnode bip44_change_key;
+    dogecoin_hdnode bip44_address_key;
+    uint32_t account = BIP44_FIRST_ACCOUNT_NODE;
     size_t size;
     char keypath[BIP44_KEY_PATH_MAX_LENGTH + 1] = "";
 
@@ -50,70 +53,80 @@ void test_bip44()
 
 
     // Convert mnemonic to seed
-    uint8_t* seed = malloc(64);
-    memset(seed, 0, 64);
-    const uint8_t* test_seed = utils_hex_to_uint8("5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4");
+    uint8_t* seed = malloc(MAX_SEED_SIZE);
+    memset(seed, 0, MAX_SEED_SIZE);
+    const uint8_t* test_seed = malloc(MAX_SEED_SIZE);
+    test_seed = utils_hex_to_uint8("5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc19a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4");
     dogecoin_seed_from_mnemonic (words, "", seed);
-    u_assert_mem_eq(seed, test_seed, 64);
+    u_assert_mem_eq(seed, test_seed, MAX_SEED_SIZE);
 
 
     char* seed_hex;
-    seed_hex = utils_uint8_to_hex(seed, 64);
+    seed_hex = utils_uint8_to_hex(seed, MAX_SEED_SIZE);
     debug_print ("%s\n", seed_hex);
 
     // Generate the root key from the seed
-    result = dogecoin_hdnode_from_seed(seed, 64, &node);
+    result = dogecoin_hdnode_from_seed(seed, MAX_SEED_SIZE, &node);
     u_assert_int_eq(result, true);
 
+    debug_print("%s", "\n\nTESTNET\n\n");
+
     // Print the root key (TESTNET)
-    char root_key_str[112];
+    char root_key_str[HDKEYLEN];
     dogecoin_hdnode_serialize_public(&node, &dogecoin_chainparams_test, root_key_str, sizeof(root_key_str));
     debug_print("BIP32 root pub key: %s\n", root_key_str);
     dogecoin_hdnode_serialize_private(&node, &dogecoin_chainparams_test, root_key_str, sizeof(root_key_str));
     debug_print("BIP32 root prv key: %s\n", root_key_str);
+
+    // Derive the BIP 44 extended key at the account level
+    result = derive_bip44_extended_key(&node, &account, NULL, NULL, NULL, true, keypath, &bip44_key);
+    u_assert_int_eq(result, 0);
+
+    // Print the BIP 44 extended key at the account level
+    char bip44_account_private_key[HDKEYLEN];
+    dogecoin_hdnode_serialize_private(&bip44_key, &dogecoin_chainparams_test, bip44_account_private_key, sizeof(bip44_account_private_key));
+    debug_print("Account extended key: %s\n", bip44_account_private_key);
+
+    // Print the BIP 44 extended public key at the account level
+    char bip44_account_public_key[HDKEYLEN];
+    dogecoin_hdnode_serialize_public(&bip44_key, &dogecoin_chainparams_test, bip44_account_public_key, sizeof(bip44_account_public_key));
+    debug_print("Account extended public key: %s\n", bip44_account_public_key);
 
     char* change_level = BIP44_CHANGE_EXTERNAL;
     for (int i = 0; i <= 1; i++) {
         if (i==1)
             change_level = BIP44_CHANGE_INTERNAL;
 
-        // Derive the BIP 44 extended key
-        result = derive_bip44_extended_private_key(&node, BIP44_FIRST_ACCOUNT_NODE, NULL, change_level, NULL, true, keypath, &bip44_key);
+        // Derive the BIP 44 extended key at the change level
+        result = derive_bip44_extended_key(&node, &account, NULL, change_level, NULL, true, keypath, &bip44_change_key);
         u_assert_int_eq(result, 0);
 
-        // Print the BIP 44 extended private key
-        char bip44_private_key[112];
-        dogecoin_hdnode_serialize_private(&bip44_key, &dogecoin_chainparams_test, bip44_private_key, sizeof(bip44_private_key));
-        debug_print("BIP44 extended private key: %s\n", bip44_private_key);
-
-        char str[112];
-
-        // Print the BIP 44 extended public key
-        char bip44_public_key[112];
-        dogecoin_hdnode_serialize_public(&bip44_key, &dogecoin_chainparams_test, bip44_public_key, sizeof(bip44_public_key));
-        debug_print("BIP44 extended public key: %s\n", bip44_public_key);
+        // Print the BIP 44 extended public key at the change level
+        char bip44_change_public_key[HDKEYLEN];
+        dogecoin_hdnode_serialize_public(&bip44_change_key, &dogecoin_chainparams_test, bip44_change_public_key, sizeof(bip44_change_public_key));
+        debug_print("Change level extended public key %s\n", bip44_change_public_key);
 
         debug_print("%s", "Derived Addresses\n");
 
-        for (uint32_t index = BIP44_FIRST_ACCOUNT_NODE; index < BIP44_ADDRESS_GAP_LIMIT; index++) {
+        char str[HDKEYLEN];
+
+        for (uint32_t index = BIP44_FIRST_ADDRESS_INDEX; index < BIP44_ADDRESS_GAP_LIMIT; index++) {
             // Derive the addresses
-            result = derive_bip44_extended_private_key(&node, BIP44_FIRST_ACCOUNT_NODE, &index, change_level, NULL, true, keypath, &bip44_key);
+            result = derive_bip44_extended_key(&node, &account, &index, change_level, NULL, true, keypath, &bip44_address_key);
             u_assert_int_eq(result, 0);
 
-            // Print the private key
-            dogecoin_hdnode_serialize_private(&bip44_key, &dogecoin_chainparams_test, bip44_private_key, sizeof(bip44_private_key));
-            debug_print("private key: %s\n", utils_uint8_to_hex(bip44_key.private_key, sizeof(bip44_key.private_key)));
-            debug_print("private key (serialized): %s\n", bip44_private_key);
-
             // Print the public key
-            dogecoin_hdnode_serialize_public(&bip44_key, &dogecoin_chainparams_test, bip44_public_key, sizeof(bip44_public_key));
-            debug_print("public key: %s\n", utils_uint8_to_hex(bip44_key.public_key, sizeof(bip44_key.public_key)));
-            debug_print("public key (serialized): %s\n", bip44_public_key);
+            char bip44_change_public_key[HDKEYLEN];
+            dogecoin_hdnode_serialize_public(&bip44_address_key, &dogecoin_chainparams_test, bip44_change_public_key, sizeof(bip44_change_public_key));
+            debug_print("public key: %s\n", utils_uint8_to_hex(bip44_address_key.public_key, sizeof(bip44_address_key.public_key)));
+            debug_print("public key (serialized): %s\n", bip44_change_public_key);
 
-            dogecoin_hdnode_get_p2pkh_address(&bip44_key, &dogecoin_chainparams_test, str, sizeof(str));
+            dogecoin_hdnode_get_p2pkh_address(&bip44_address_key, &dogecoin_chainparams_test, str, sizeof(str));
             debug_print("Address: %s\n", str);
         }
     }
+
+    debug_print("%s", "\n\nMAINNET\n\n");
 
     // Print the root key (MAINNET)
     dogecoin_hdnode_serialize_public(&node, &dogecoin_chainparams_main, root_key_str, sizeof(root_key_str));
@@ -121,48 +134,78 @@ void test_bip44()
     dogecoin_hdnode_serialize_private(&node, &dogecoin_chainparams_main, root_key_str, sizeof(root_key_str));
     debug_print("BIP32 root prv key: %s\n", root_key_str);
 
+    // Derive the BIP 44 extended key at the account level
+    result = derive_bip44_extended_key(&node, &account, NULL, NULL, NULL, false, keypath, &bip44_key);
+    u_assert_int_eq(result, 0);
+
+    // Print the BIP 44 extended key at the account level
+    dogecoin_hdnode_serialize_private(&bip44_key, &dogecoin_chainparams_main, bip44_account_private_key, sizeof(bip44_account_private_key));
+    debug_print("Account extended key: %s\n", bip44_account_private_key);
+
+    // Print the BIP 44 extended public key at the account level
+    dogecoin_hdnode_serialize_public(&bip44_key, &dogecoin_chainparams_main, bip44_account_public_key, sizeof(bip44_account_public_key));
+    debug_print("Account extended public key: %s\n", bip44_account_public_key);
+
     change_level = BIP44_CHANGE_EXTERNAL;
     for (int i = 0; i <= 1; i++) {
         if (i==1)
             change_level = BIP44_CHANGE_INTERNAL;
 
-        // Derive the BIP 44 extended key
-        result = derive_bip44_extended_private_key(&node, BIP44_FIRST_ACCOUNT_NODE, NULL, change_level, NULL, false, keypath, &bip44_key);
+        // Derive the BIP 44 extended key at the change level
+        result = derive_bip44_extended_key(&node, &account, NULL, change_level, NULL, false, keypath, &bip44_change_key);
         u_assert_int_eq(result, 0);
 
-        // Print the BIP 44 extended private key
-        char bip44_private_key[112];
-        dogecoin_hdnode_serialize_private(&bip44_key, &dogecoin_chainparams_main, bip44_private_key, sizeof(bip44_private_key));
-        debug_print("BIP44 extended private key: %s\n", bip44_private_key);
-
-        char str[112];
-
-        // Print the BIP 44 extended public key
-        char bip44_public_key[112];
-        dogecoin_hdnode_serialize_public(&bip44_key, &dogecoin_chainparams_main, bip44_public_key, sizeof(bip44_public_key));
-        debug_print("BIP44 extended public key: %s\n", bip44_public_key);
+        // Print the BIP 44 extended public key at the change level
+        char bip44_change_public_key[HDKEYLEN];
+        dogecoin_hdnode_serialize_public(&bip44_change_key, &dogecoin_chainparams_main, bip44_change_public_key, sizeof(bip44_change_public_key));
+        debug_print("Change level extended public key %s\n", bip44_change_public_key);
 
         debug_print("%s", "Derived Addresses\n");
 
+        char str[HDKEYLEN];
+
         for (uint32_t index = BIP44_FIRST_ACCOUNT_NODE; index < BIP44_ADDRESS_GAP_LIMIT; index++) {
             // Derive the addresses
-            result = derive_bip44_extended_private_key(&node, BIP44_FIRST_ACCOUNT_NODE, &index, change_level, NULL, false, keypath, &bip44_key);
+            result = derive_bip44_extended_key(&node, &account, &index, change_level, NULL, false, keypath, &bip44_address_key);
             u_assert_int_eq(result, 0);
 
-            // Print the private key
-            dogecoin_hdnode_serialize_private(&bip44_key, &dogecoin_chainparams_main, bip44_private_key, sizeof(bip44_private_key));
-            debug_print("private key: %s\n", utils_uint8_to_hex(bip44_key.private_key, sizeof(bip44_key.private_key)));
-            debug_print("private key (serialized): %s\n", bip44_private_key);
-
             // Print the public key
-            dogecoin_hdnode_serialize_public(&bip44_key, &dogecoin_chainparams_main, bip44_public_key, sizeof(bip44_public_key));
-            debug_print("public key: %s\n", utils_uint8_to_hex(bip44_key.public_key, sizeof(bip44_key.public_key)));
-            debug_print("public key (serialized): %s\n", bip44_public_key);
+            char bip44_address_public_key[HDKEYLEN];
+            dogecoin_hdnode_serialize_public(&bip44_address_key, &dogecoin_chainparams_main, bip44_address_public_key, sizeof(bip44_address_public_key));
+            debug_print("public key: %s\n", utils_uint8_to_hex(bip44_address_key.public_key, sizeof(bip44_address_key.public_key)));
+            debug_print("public key (serialized): %s\n", bip44_address_public_key);
 
-            dogecoin_hdnode_get_p2pkh_address(&bip44_key, &dogecoin_chainparams_main, str, sizeof(str));
+            dogecoin_hdnode_get_p2pkh_address(&bip44_address_key, &dogecoin_chainparams_main, str, sizeof(str));
             debug_print("Address: %s\n", str);
         }
     }
+
+    /* test deriveBIP44ExtendedKey */
+    char masterkey[HDKEYLEN];
+    char accountkey[HDKEYLEN];
+    char accountPubkey[HDKEYLEN];
+    char bip32key[HDKEYLEN];
+    char changepubkey[HDKEYLEN];
+
+    u_assert_true(getHDRootKeyFromSeed(test_seed, MAX_SEED_SIZE, true, masterkey));
+    u_assert_true(deriveBIP44ExtendedKey(masterkey, NULL, NULL, NULL, NULL, accountkey, keypath));
+    u_assert_true(deriveBIP44ExtendedKey(masterkey, &account, BIP44_CHANGE_EXTERNAL, NULL, NULL, bip32key, keypath));
+    u_assert_str_eq(bip32key,
+                    "tprv8hi9XJvkuKfu6oRGUsAnPAnQNUKcEjwrLbS2w2hTSPKrFj5YYS3Ax7UDDrZZHd4PSnPLW5whNxAXTW5bBrSNiSD1LUeg9n4j5sdGRJsZZwP");
+
+    debug_print("deriveBIP44ExtendedKey: %s\n", accountkey);
+    debug_print("deriveBIP44ExtendedKey: %s\n", bip32key);
+
+    /* test deriveBIP44ExtendedPublicKey */
+    u_assert_true(deriveBIP44ExtendedKey(masterkey, NULL, NULL, NULL, NULL, accountkey, keypath));
+    u_assert_true(deriveBIP44ExtendedKey(masterkey, &account, BIP44_CHANGE_EXTERNAL, NULL, NULL, bip32key, keypath));
+    u_assert_true(deriveBIP44ExtendedPublicKey(masterkey, &account, NULL, NULL, NULL, accountPubkey, keypath));
+    u_assert_true(deriveBIP44ExtendedPublicKey(masterkey, &account, BIP44_CHANGE_EXTERNAL, NULL, NULL, changepubkey, keypath));
+    u_assert_str_eq(changepubkey,
+                    "tpubDEQBfiy13hMZzGT4NWqNnaSWwVqYQ58kuu2pDYjkrf8F6DLKAprm8c65Pyh7PrzodXHtJuEXFu5yf6JbvYaL8rz7v28zapwbuzZzr7z4UvR");
+
+    debug_print("deriveBIP44ExtendedKey: %s\n", accountPubkey);
+    debug_print("deriveBIP44ExtendedKey: %s\n", changepubkey);
 
     free (entropy_out);
     free (words);

--- a/test/key_tests.c
+++ b/test/key_tests.c
@@ -1,6 +1,6 @@
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2015 Jonas Schnelli
  Copyright (c) 2022 bluezr
  Copyright (c) 2022 The Dogecoin Foundation
@@ -85,5 +85,8 @@ void test_key()
     wiflen = 100;
     dogecoin_key key_wif_decode;
     dogecoin_privkey_decode_wif(wifstr, &dogecoin_chainparams_main, &key_wif_decode);
+    u_assert_mem_eq(key_wif_decode.privkey, key_wif.privkey, sizeof(key_wif_decode.privkey));
+    getWifEncodedPrivKey(key_wif.privkey, false, wifstr, &wiflen);
+    getDecodedPrivKeyWif(wifstr, false, key_wif_decode.privkey);
     u_assert_mem_eq(key_wif_decode.privkey, key_wif.privkey, sizeof(key_wif_decode.privkey));
 }

--- a/test/tool_tests.c
+++ b/test/tool_tests.c
@@ -58,18 +58,19 @@ void test_tool()
     u_assert_int_eq(hd_gen_master(&dogecoin_chainparams_main, masterkey, masterkeysize), true);
     u_assert_int_eq(hd_print_node(&dogecoin_chainparams_main, masterkey), true);
 
+    genHDMaster(false, masterkey, masterkeysize);
+
     size_t extoutsize = 200;
     char* extout=dogecoin_char_vla(extoutsize);
     const char* privkey = "dgpv557t1z21sLCnAz3cJPW5DiVErXdAi7iWpSJwBBaeN87umwje8LuTKREPTYPTNGXGnB3oNd2z6RmFFDU99WKbiRDJKKXfHxf48puZibauJYB";
+    debug_print("\nMaster private key:  %s\n", privkey);
 
     u_assert_int_eq(hd_derive(&dogecoin_chainparams_main, privkey, "m/0", extout, extoutsize), true);
     u_assert_str_eq(extout, "dgpv55wVA8mg2HkLPXa4bSyi83hbXrwVWsiTE2Z3kSTUtC6QUyg3ed3FprcvAFKWUSvyRtaPuVwfbcQMQqVXM12yrxQtSCB2iPF4A6RdDp53jjy");
+    printNode(false, extout);
 
     u_assert_int_eq(hd_derive(&dogecoin_chainparams_main, "dgpv51eADS3spNJh9gCpE1AyQ9NpMGkGh6MJKxM84Tf87KVLNeodEW76V2nJJRPorYLGnvZGJKTgEgvqGCtf9VS9RqhfJaTxV7iqm86VpMUNi5G", "m/3", extout, extoutsize), true);
     u_assert_str_eq(extout, "dgpv54nSmPCbDB5TwYzkNzEo696Qih6DoKHX95sXgSj6zMrLCAAHcaixxjjuaNbxj4mrPouJS6TVpSG8F6xTVCXyDCe3RuJiSJSKjFr1yk8hDYn");
-
-    genHDMaster(false, masterkey, masterkeysize);
-    printNode(false, masterkey);
 
     char keypath[KEYPATHMAXLEN] = "m/0";
 

--- a/test/tool_tests.c
+++ b/test/tool_tests.c
@@ -19,9 +19,16 @@ void test_tool()
     u_assert_int_eq(addresses_from_pubkey(&dogecoin_chainparams_main, "039ca1fdedbe160cb7b14df2a798c8fed41ad4ed30b06a85ad23e03abe43c413b2", addr), true);
     u_assert_str_eq(addr, "DTwqVfB7tbwca2PzwBvPV1g1xDB2YPrCYh");
 
+    u_assert_true(getAddressFromPubkey("039ca1fdedbe160cb7b14df2a798c8fed41ad4ed30b06a85ad23e03abe43c413b2", false, addr));
+    u_assert_str_eq(addr, "DTwqVfB7tbwca2PzwBvPV1g1xDB2YPrCYh");
+
     size_t pubkeylen = 100;
     char* pubkey=dogecoin_char_vla(pubkeylen);
     u_assert_int_eq(pubkey_from_privatekey(&dogecoin_chainparams_main, "QUaohmokNWroj71dRtmPSses5eRw5SGLKsYSRSVisJHyZdxhdDCZ", pubkey, &pubkeylen), true);
+    u_assert_str_eq(pubkey, "024c33fbb2f6accde1db907e88ebf5dd1693e31433c62aaeef42f7640974f602ba");
+
+    pubkeylen = PUBKEYHEXLEN;
+    u_assert_true(getPubkeyFromPrivkey("QUaohmokNWroj71dRtmPSses5eRw5SGLKsYSRSVisJHyZdxhdDCZ", false, pubkey, &pubkeylen));
     u_assert_str_eq(pubkey, "024c33fbb2f6accde1db907e88ebf5dd1693e31433c62aaeef42f7640974f602ba");
 
     free(pubkey);
@@ -31,6 +38,9 @@ void test_tool()
     char privkeyhex[100];
     u_assert_int_eq(gen_privatekey(&dogecoin_chainparams_main, privkeywif, privkeywiflen, NULL), true);
     u_assert_int_eq(gen_privatekey(&dogecoin_chainparams_main, privkeywif, privkeywiflen, privkeyhex), true);
+
+    u_assert_true(genPrivkey(false, privkeywif, privkeywiflen, NULL));
+    u_assert_true(genPrivkey(false, privkeywif, privkeywiflen, privkeyhex));
 
     uint8_t* privkey_data=dogecoin_uint8_vla(strlen(privkeywif));
     dogecoin_base58_decode_check(privkeywif, privkey_data, strlen(privkeywif) * sizeof(privkey_data[0]));
@@ -42,22 +52,31 @@ void test_tool()
 
     free(privkey_data);
     free(privkeywif);
-    
+
     size_t masterkeysize = 200;
     char* masterkey=dogecoin_char_vla(masterkeysize);
     u_assert_int_eq(hd_gen_master(&dogecoin_chainparams_main, masterkey, masterkeysize), true);
     u_assert_int_eq(hd_print_node(&dogecoin_chainparams_main, masterkey), true);
-
-    free(masterkey);
 
     size_t extoutsize = 200;
     char* extout=dogecoin_char_vla(extoutsize);
     const char* privkey = "dgpv557t1z21sLCnAz3cJPW5DiVErXdAi7iWpSJwBBaeN87umwje8LuTKREPTYPTNGXGnB3oNd2z6RmFFDU99WKbiRDJKKXfHxf48puZibauJYB";
 
     u_assert_int_eq(hd_derive(&dogecoin_chainparams_main, privkey, "m/0", extout, extoutsize), true);
-    u_assert_str_eq(extout, "dgpv544MJMFeoz5LXkwbZTWwouwFje2Yp9c1A8ReNaapDFjW44jEcLXv3B3KQg3fjWXWVC9FGRyxLaCHjN1DUeGgoYJxMYM723wrLN6BArKUxe3");
+    u_assert_str_eq(extout, "dgpv55wVA8mg2HkLPXa4bSyi83hbXrwVWsiTE2Z3kSTUtC6QUyg3ed3FprcvAFKWUSvyRtaPuVwfbcQMQqVXM12yrxQtSCB2iPF4A6RdDp53jjy");
 
     u_assert_int_eq(hd_derive(&dogecoin_chainparams_main, "dgpv51eADS3spNJh9gCpE1AyQ9NpMGkGh6MJKxM84Tf87KVLNeodEW76V2nJJRPorYLGnvZGJKTgEgvqGCtf9VS9RqhfJaTxV7iqm86VpMUNi5G", "m/3", extout, extoutsize), true);
+    u_assert_str_eq(extout, "dgpv54nSmPCbDB5TwYzkNzEo696Qih6DoKHX95sXgSj6zMrLCAAHcaixxjjuaNbxj4mrPouJS6TVpSG8F6xTVCXyDCe3RuJiSJSKjFr1yk8hDYn");
+
+    genHDMaster(false, masterkey, masterkeysize);
+    printNode(false, masterkey);
+
+    char keypath[KEYPATHMAXLEN] = "m/0";
+
+    deriveHDExtFromMaster(false, privkey, keypath, extout, extoutsize);
+    u_assert_str_eq(extout, "dgpv55wVA8mg2HkLPXa4bSyi83hbXrwVWsiTE2Z3kSTUtC6QUyg3ed3FprcvAFKWUSvyRtaPuVwfbcQMQqVXM12yrxQtSCB2iPF4A6RdDp53jjy");
+
+    free(masterkey);
 
     free(extout);
 }

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -175,7 +175,7 @@ void test_transaction()
         u_assert_int_eq(3669653, tx_worth_10->locktime);
     //   "vin": [
         dogecoin_tx_in* tx_in_10 = vector_idx(tx_worth_10->vin, 0);
-    //     {    
+    //     {
             reversed_txid = utils_uint8_to_hex(tx_in_10->prevout.hash, sizeof(tx_in_10->prevout.hash));
             utils_reverse_hex(reversed_txid, 64);
     //       "txid": "76c6c28a87a3b378c5b41dddd727f2ba7e586a1db9415608442223cae87b551b",
@@ -270,7 +270,7 @@ void test_transaction()
 
     // ----------------------------------------------------------------
     // test building transaction with multiple inputs and signing with sign_transaction:
-    
+
     // instantiate a new working_transaction object by calling start_transaction()
     // which passes back index and stores in index variable
     int working_transaction_index = start_transaction();
@@ -283,7 +283,7 @@ void test_transaction()
 
     // add output to transaction which is amount and address we are sending to:
     u_assert_int_eq(add_output(working_transaction_index, external_p2pkh_address, "5"), 1);
-    
+
     // confirm total output value equals total utxo input value minus transaction fee
     // validate external p2pkh address by converting script hash to p2pkh and asserting equal:
     char* raw_hexadecimal_transaction  = finalize_transaction(working_transaction_index, external_p2pkh_address, ".00226", "12.0", internal_p2pkh_address);
@@ -293,7 +293,7 @@ void test_transaction()
 
     // ----------------------------------------------------------------
     // test building transaction with single input and signing with sign_transaction:
-    
+
     // instantiate a new working_transaction object by calling start_transaction()
     // which passes back index and stores in index variable
     working_transaction_index = start_transaction();
@@ -303,7 +303,7 @@ void test_transaction()
 
     // add output to transaction which is amount and address we are sending to:
     u_assert_int_eq(add_output(working_transaction_index, external_p2pkh_address, "9.99887"), 1);
-    
+
     // confirm total output value equals total utxo input value minus transaction fee
     // validate external p2pkh address by converting script hash to p2pkh and asserting equal:
     raw_hexadecimal_transaction  = finalize_transaction(working_transaction_index, external_p2pkh_address, ".00113", "10.0", internal_p2pkh_address);
@@ -317,7 +317,7 @@ void test_transaction()
     int working_transaction_index2 = store_raw_transaction(raw_hexadecimal_transaction);
     u_assert_int_eq(working_transaction_index, working_transaction_index2 - 1);
     u_assert_str_eq(get_raw_transaction(working_transaction_index), get_raw_transaction(working_transaction_index2));
-    
+
     // ----------------------------------------------------------------
     // test clear_transaction:
 
@@ -350,7 +350,7 @@ void test_transaction()
 
     raw_hexadecimal_transaction = get_raw_transaction(working_transaction_index);
     u_assert_str_eq(raw_hexadecimal_transaction, unsigned_double_utxo_single_output_hexadecimal_transaction);
-    
+
     // confirm total output value equals total utxo input value minus transaction fee
     // validate external p2pkh address by converting script hash to p2pkh and asserting equal:
     raw_hexadecimal_transaction = finalize_transaction(working_transaction_index, external_p2pkh_address, ".00226", "12.0", internal_p2pkh_address);
@@ -402,7 +402,7 @@ void test_transaction()
 
     raw_hexadecimal_transaction = get_raw_transaction(working_transaction_index);
     u_assert_str_eq(raw_hexadecimal_transaction, unsigned_double_utxo_single_output_hexadecimal_transaction);
-    
+
     // confirm total output value equals total utxo input value minus transaction fee
     // validate external p2pkh address by converting script hash to p2pkh and asserting equal:
     raw_hexadecimal_transaction = finalize_transaction(working_transaction_index, external_p2pkh_address, ".00226", "12.0", internal_p2pkh_address);
@@ -428,14 +428,21 @@ void test_transaction()
     u_assert_str_eq(raw_hexadecimal_transaction, expected_signed_raw_hexadecimal_transaction);
 
     // ----------------------------------------------------------------
-    // test conversion from p2pkh to script hash
+    // test conversion from p2pkh to script hash and back
 
     char* res = dogecoin_malloc(40 + 6 + 4 + 1);
+    char p2pkh_address[PUBKEYLEN];
     u_assert_int_eq(dogecoin_p2pkh_address_to_pubkey_hash(internal_p2pkh_address, res), 1);
     u_assert_str_eq(res, utxo_scriptpubkey);
 
+    u_assert_true(getAddrFromPubkeyHash(res, isTestnetFromB58Prefix(internal_p2pkh_address), p2pkh_address));
+    u_assert_str_eq(p2pkh_address, internal_p2pkh_address);
+
     u_assert_int_eq(dogecoin_p2pkh_address_to_pubkey_hash(external_p2pkh_address, res), 1);
     u_assert_str_not_eq(res, utxo_scriptpubkey);
+
+    u_assert_true(getAddrFromPubkeyHash(res, isTestnetFromB58Prefix(external_p2pkh_address), p2pkh_address));
+    u_assert_str_eq(p2pkh_address, external_p2pkh_address);
     dogecoin_free(res);
 
     // ----------------------------------------------------------------
@@ -449,4 +456,14 @@ void test_transaction()
     // test remove_all - *not noticeable unless running valgrind ./tests*
     // remove working transaction object from hashmap
     remove_all();
+
+    // ----------------------------------------------------------------
+    // test chainparams wrapper functions
+
+    // Call isTestnetFromB58Prefix
+    u_assert_true(isTestnetFromB58Prefix("nhUDhr7bUum2LE2JsuZqY4iy411CQoweuD"));
+
+    // Call isMainnetFromB58Prefix
+    u_assert_true(isMainnetFromB58Prefix("D6vSSr6ftnicfpSNARqezdehAL5Abe2LQw"));
+
 }

--- a/test/vector_tests.c
+++ b/test/vector_tests.c
@@ -92,4 +92,24 @@ void test_vector()
     vec = vector_new(1, free_dummy);
     vector_add(vec, some_data);
     vector_free(vec, true);
+    /* test serialization */
+    char serialized[MAX_SERIALIZE_SIZE] = { 0 };
+    size_t len = 15;
+    size_t written = 0;
+    size_t read = 0;
+    vec = vector_new(1, NULL);
+    res = vector_add(vec, strdup("TEST0"));
+    assert(res == true);
+    res = vector_add(vec, strdup("TEST1"));
+    assert(res == true);
+    res = vector_add(vec, strdup("TEST2"));
+    assert(res == true);
+    assert(serializeVector(vec, serialized, len, &written) == true);
+    assert(strcmp(serialized, "TEST0TEST1TEST2") == 0);
+    /* test deserialization */
+    assert(deserializeVector(vec, serialized, len, &read) == true);
+    assert(strcmp(vector_idx(vec, 0), "TEST0") == 0);
+    assert(strcmp(vector_idx(vec, 1), "TEST1") == 0);
+    assert(strcmp(vector_idx(vec, 2), "TEST2") == 0);
+    vector_free(vec, true);
 }


### PR DESCRIPTION
address: added depth to dogecoin_hd_generate_key for extended keys
chainparams: added isTestnetFromB58Prefix and isMainnetFromB58Prefix wrappers
bip32: added wrappers and depth to dogecoin_hd_generate_key for extended keys
bip39: moved constant to header
bip44: added wrappers and updated to derive_bip44_extended_key
key: added wrappers
dogecoin: added key string and script constants
example: moved constants to header, updated for key string constants, indentation and to derive_bip44_extended_key
tool: added wrappers, assert for dogecoin_pubkey_get_hex call and depth to dogecoin_hd_generate_key for extended keys
tx: added wrapper
vector: added wrappers for serialization/deserialization
test: added wrappers to bip32, key, transaction, tool, and vector tests