### PR TITLE
global updates to constants

### DIFF
--- a/contrib/examples/example.c
+++ b/contrib/examples/example.c
@@ -23,10 +23,10 @@ int main() {
 	// create variables
 
 	char wif_privkey[PRIVKEYWIFLEN];
-	char p2pkh_pubkey[PUBKEYLEN];
-	char wif_master_privkey[HDKEYLEN];
-	char p2pkh_master_pubkey[PUBKEYLEN];
-	char p2pkh_child_pubkey[PUBKEYLEN];
+	char p2pkh_pubkey[P2PKHLEN];
+	char hd_master_privkey[HDKEYLEN];
+	char p2pkh_master_pubkey[P2PKHLEN];
+	char p2pkh_child_pubkey[P2PKHLEN];
 
 	// keypair generation
 	if (generatePrivPubKeypair(wif_privkey, p2pkh_pubkey, 0)) {
@@ -37,8 +37,8 @@ int main() {
 		return -1;
 	}
 
-	if (generateHDMasterPubKeypair(wif_master_privkey, p2pkh_master_pubkey, 0)) {
-		printf("Mainnet master keypair 2:\n===============================\nPrivate: %s\nPublic:  %s\n\n", wif_master_privkey, p2pkh_master_pubkey);
+	if (generateHDMasterPubKeypair(hd_master_privkey, p2pkh_master_pubkey, 0)) {
+		printf("Mainnet master keypair 2:\n===============================\nPrivate: %s\nPublic:  %s\n\n", hd_master_privkey, p2pkh_master_pubkey);
 	}
 	else {
 		printf("Error occurred 2.\n");
@@ -46,8 +46,8 @@ int main() {
 	}
 
 
-	if (generateDerivedHDPubkey((const char*)wif_master_privkey, (char*)p2pkh_child_pubkey)) {
-		printf("Mainnet master derived keypair 3:\n===============================\nPrivate: %s\nPublic:  %s\n\n", wif_master_privkey, p2pkh_child_pubkey);
+	if (generateDerivedHDPubkey((const char*)hd_master_privkey, (char*)p2pkh_child_pubkey)) {
+		printf("Mainnet master derived keypair 3:\n===============================\nPrivate: %s\nPublic:  %s\n\n", hd_master_privkey, p2pkh_child_pubkey);
 	}
 	else {
 		printf("Error occurred 3.\n");
@@ -64,19 +64,19 @@ int main() {
 		return -1;
 	}
 
-	if (verifyHDMasterPubKeypair(wif_master_privkey, p2pkh_master_pubkey, 0)) {
-		printf("Keypair (%s, %s) is valid for mainnet 5.\n\n", wif_master_privkey, p2pkh_master_pubkey);
+	if (verifyHDMasterPubKeypair(hd_master_privkey, p2pkh_master_pubkey, 0)) {
+		printf("Keypair (%s, %s) is valid for mainnet 5.\n\n", hd_master_privkey, p2pkh_master_pubkey);
 	}
 	else {
-		printf("Keypair (%s, %s) is not valid for mainnet 5.\n", wif_master_privkey, p2pkh_master_pubkey);
+		printf("Keypair (%s, %s) is not valid for mainnet 5.\n", hd_master_privkey, p2pkh_master_pubkey);
 		return -1;
 	}
 
-	if (verifyHDMasterPubKeypair(wif_master_privkey, p2pkh_child_pubkey, 0)) {
-		printf("Keypair (%s, %s) is valid for mainnet 6.\n\n", wif_master_privkey, p2pkh_child_pubkey);
+	if (verifyHDMasterPubKeypair(hd_master_privkey, p2pkh_child_pubkey, 0)) {
+		printf("Keypair (%s, %s) is valid for mainnet 6.\n\n", hd_master_privkey, p2pkh_child_pubkey);
 	}
 	else {
-		printf("Keypair (%s, %s) is not valid for mainnet 6.\n", wif_master_privkey, p2pkh_child_pubkey);
+		printf("Keypair (%s, %s) is not valid for mainnet 6.\n", hd_master_privkey, p2pkh_child_pubkey);
 		return -1;
 	}
 	printf("\n");
@@ -158,7 +158,7 @@ int main() {
 
 	// TOOLS EXAMPLE
 	printf("\n\nTOOLS EXAMPLE:\n\n");
-	char addr[PUBKEYLEN];
+	char addr[P2PKHLEN];
 	if (addresses_from_pubkey(&dogecoin_chainparams_main, "039ca1fdedbe160cb7b14df2a798c8fed41ad4ed30b06a85ad23e03abe43c413b2", addr)) {
 		printf ("addr: %s\n", addr);
 	}
@@ -172,7 +172,7 @@ int main() {
 
 	size_t privkeywiflen = PRIVKEYWIFLEN;
 	char* privkeywif=dogecoin_char_vla(privkeywiflen);
-	char privkeyhex[100];
+	char privkeyhex[PRIVKEYHEXLEN];
 	if (gen_privatekey(&dogecoin_chainparams_main, privkeywif, privkeywiflen, NULL)) {
 			if (gen_privatekey(&dogecoin_chainparams_main, privkeywif, privkeywiflen, privkeyhex)) {
 			printf ("privkeywif: %s\n", privkeywif);
@@ -212,7 +212,7 @@ int main() {
 	dogecoin_hdnode_serialize_private(&bip44_key, &dogecoin_chainparams_main, bip44_private_key, sizeof(bip44_private_key));
 	printf("BIP44 extended key: %s\n", bip44_private_key);
 
-	char str[PUBKEYLEN];
+	char str[P2PKHLEN];
 
 	// Print the BIP 44 extended public key
 	char bip44_public_key[HDKEYLEN];
@@ -442,7 +442,7 @@ int main() {
 	}
 
 	// test getDerivedHDAddressFromEncryptedSeed
-	char derived_address[PUBKEYLEN];
+	char derived_address[P2PKHLEN];
 	if (getDerivedHDAddressFromEncryptedSeed(0, 0, BIP44_CHANGE_EXTERNAL, derived_address, false, TEST_FILE) == 0) {
 		printf("Derived address: %s\n", derived_address);
 	} else {

--- a/doc/address.md
+++ b/doc/address.md
@@ -101,8 +101,8 @@ _C usage:_
 #include <stdio.h>
 
 int main() {
-  int privkeyLen = 53;
-  int pubkeyLen = 35;
+  int privkeyLen = PRIVKEYWIFLEN;
+  int pubkeyLen = P2PKHLEN;
 
   char privKey[privkeyLen];
   char pubKey[pubkeyLen];
@@ -120,7 +120,7 @@ int main() {
 
 ### **generateHDMasterPubKeypair:**
 
-`int generateHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet)`
+`int generateHDMasterPubKeypair(char* hd_privkey_master, char* p2pkh_pubkey_master, bool is_testnet)`
 
 This function will populate provided string variables (privkey, pubkey) with freshly generated respective private and public keys for a hierarchical deterministic wallet, specifically for either mainnet or testnet as specified through the network flag (is_testnet). The function returns 1 on success and 0 on failure.
 
@@ -131,8 +131,8 @@ _C usage:_
 #include <stdio.h>
 
 int main() {
-  int masterPrivkeyLen = 200; // enough cushion
-  int pubkeyLen = 35;
+  int masterPrivkeyLen = HDKEYLEN; // enough cushion
+  int pubkeyLen = P2PKHLEN;
 
   char masterPrivKey[masterPrivkeyLen];
   char masterPubKey[pubkeyLen];
@@ -150,9 +150,9 @@ int main() {
 
 ### **generateDerivedHDPubKey:**
 
-`int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey)`
+`int generateDerivedHDPubkey(const char* hd_privkey_master, char* p2pkh_pubkey)`
 
-This function takes a given HD master private key (wif_privkey_master) and loads it into the provided pointer for the resulting derived public key (p2pkh_pubkey). This private key input should come from the result of generateHDMasterPubKeypair(). The function returns 1 on success and 0 on failure.
+This function takes a given HD master private key (hd_privkey_master) and loads it into the provided pointer for the resulting derived public key (p2pkh_pubkey). This private key input should come from the result of generateHDMasterPubKeypair(). The function returns 1 on success and 0 on failure.
 
 _C usage:_
 
@@ -161,8 +161,8 @@ _C usage:_
 #include <stdio.h>
 
 int main() {
-  int masterPrivkeyLen = 200; // enough cushion
-  int pubkeyLen = 35;
+  int masterPrivkeyLen = HDKEYLEN; // enough cushion
+  int pubkeyLen = P2PKHLEN;
 
   char masterPrivKey[masterPrivkeyLen];
   char masterPubKey[pubkeyLen];
@@ -194,8 +194,8 @@ _C usage:_
 #include <stdio.h>
 
 int main() {
-  int privkeyLen = 53;
-  int pubkeyLen = 35;
+  int privkeyLen = PRIVKEYWIFLEN;
+  int pubkeyLen = P2PKHLEN;
 
   char privKey[privkeyLen];
   char pubKey[pubkeyLen];
@@ -217,9 +217,9 @@ int main() {
 
 ### **verifyHDMasterPubKeypair**
 
-`int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet)`
+`int verifyHDMasterPubKeypair(char* hd_privkey_master, char* p2pkh_pubkey_master, bool is_testnet)`
 
-This function validates that a given master private key matches a given master public key. This could be useful prior to signing, or in some kind of wallet recovery tool to match keys. This function requires a previously generated HD master key pair (wif_privkey_master, p2pkh_pubkey_master) and the network they were generated for (is_testnet). It then validates that the given public key was indeed derived from the given master private key, returning 1 if the keys are associated and 0 if they are not. This could be useful prior to signing, or in some kind of wallet recovery tool to match keys.
+This function validates that a given master private key matches a given master public key. This could be useful prior to signing, or in some kind of wallet recovery tool to match keys. This function requires a previously generated HD master key pair (hd_privkey_master, p2pkh_pubkey_master) and the network they were generated for (is_testnet). It then validates that the given public key was indeed derived from the given master private key, returning 1 if the keys are associated and 0 if they are not. This could be useful prior to signing, or in some kind of wallet recovery tool to match keys.
 
 _C usage:_
 
@@ -228,8 +228,8 @@ _C usage:_
 #include <stdio.h>
 
 int main() {
-  int masterPrivkeyLen = 200; // enough cushion
-  int pubkeyLen = 35;
+  int masterPrivkeyLen = HDKEYLEN; // enough cushion
+  int pubkeyLen = P2PKHLEN;
 
   char masterPrivKey[masterPrivkeyLen];
   char masterPubKey[pubkeyLen];
@@ -262,8 +262,8 @@ _C usage:_
 #include <stdio.h>
 
 int main() {
-  int privkeyLen = 200; // enough cushion
-  int pubkeyLen = 35;
+  int privkeyLen = HDKEYLEN; // enough cushion
+  int pubkeyLen = P2PKHLEN;
 
   char privKey[privkeyLen];
   char pubKey[pubkeyLen];
@@ -512,7 +512,7 @@ _C usage:_
 #include <stdio.h>
 
 int main () {
-  int addressLen = 53;
+  int addressLen = P2PKHLEN;
 
   MNEMONIC seed_phrase;
   char address [addressLen];
@@ -537,7 +537,7 @@ extern "C" {
 using namespace std;
 
 int main () {
-  int addressLen = 53;
+  int addressLen = P2PKHLEN;
 
   MNEMONIC seed_phrase;
   char address [addressLen];
@@ -567,7 +567,7 @@ _C usage:_
 #include <stdio.h>
 
 int main() {
-    int addressLen = 35;
+    int addressLen = P2PKHLEN;
     char derived_address[addressLen];
 
     if (getDerivedHDAddressFromEncryptedSeed(0, 0, BIP44_CHANGE_EXTERNAL, derived_address, false, TEST_FILE) == 0) {
@@ -594,7 +594,7 @@ _C usage:_
 #include <stdio.h>
 
 int main() {
-    int addressLen = 35;
+    int addressLen = P2PKHLEN;
     char derived_address[addressLen];
 
     if (getDerivedHDAddressFromEncryptedMnemonic(0, 0, BIP44_CHANGE_EXTERNAL, NULL, derived_address, false, TEST_FILE) == 0) {
@@ -621,7 +621,7 @@ _C usage:_
 #include <stdio.h>
 
 int main() {
-    int addressLen = 35;
+    int addressLen = P2PKHLEN;
     char derived_address[addressLen];
 
     if (getDerivedHDAddressFromEncryptedHDNode(0, 0, BIP44_CHANGE_EXTERNAL, derived_address, false, TEST_FILE) == 0) {

--- a/doc/eckey.md
+++ b/doc/eckey.md
@@ -62,10 +62,10 @@ The verification algorithm ensures that the signature pair `r` and `s`, `QA` and
 typedef struct eckey {
     int idx;
     dogecoin_key private_key;
-    char private_key_wif[128];
+    char private_key_wif[PRIVKEYWIFLEN];
     dogecoin_pubkey public_key;
-    char public_key_hex[128];
-    char address[35];
+    char public_key_hex[PUBKEYHEXLEN];
+    char address[P2PKHLEN];
     UT_hash_handle hh;
 } eckey;
 ```

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -140,8 +140,8 @@ int main() {
     char* amt_total = "2.0";
 
     // generate new key pair to send to
-    char newPrivKey[53];
-    char newPubKey[35];
+    char newPrivKey[PRIVKEYWIFLEN];
+    char newPubKey[P2PKHLEN];
     generatePrivPubKeypair(newPrivKey, newPubKey, false);
 
     // build and sign the transaction

--- a/doc/signing.md
+++ b/doc/signing.md
@@ -37,7 +37,7 @@ char* sign_message(char* privkey, char* msg) {
     if (!dogecoin_key_sign_hash_compact_recoverable_fcomp(&key, message_bytes, compact_signature, &compact_signature_length, &recid)) return false;
     if (!dogecoin_key_recover_pubkey((const unsigned char*)compact_signature, message_bytes, recid, &pubkey)) return false;
 
-    char p2pkh_address[35];
+    char p2pkh_address[P2PKHLEN];
     if (!dogecoin_pubkey_getaddr_p2pkh(&pubkey, &dogecoin_chainparams_main, p2pkh_address)) return false;
 
     unsigned char* base64_encoded_output = dogecoin_uchar_vla(1+(sizeof(char)*base64_encoded_size(compact_signature_length)));
@@ -90,7 +90,7 @@ int verify_message(char* sig, char* msg, char* address) {
     if (!dogecoin_key_recover_pubkey((const unsigned char*)decoded_signature, message_bytes, recid, &pub_key)) return false;
     if (!dogecoin_pubkey_verify_sigcmp(&pub_key, message_bytes, decoded_signature)) return false;
 
-    char p2pkh_address[35];
+    char p2pkh_address[P2PKHLEN];
     const dogecoin_chainparams* chain = chain_from_b58_prefix(address);
     if (!dogecoin_pubkey_getaddr_p2pkh(&pub_key, chain, p2pkh_address)) return false;
 

--- a/include/dogecoin/address.h
+++ b/include/dogecoin/address.h
@@ -33,20 +33,20 @@
 
 LIBDOGECOIN_BEGIN_DECL
 
-/* generate a new private key (hex) */
+/* generate a new private key (wif) and p2pkh public key */
 LIBDOGECOIN_API int generatePrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet);
 
-/* generate HD master key and WIF public key */
-LIBDOGECOIN_API int generateHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
+/* generate HD master key and p2pkh public key */
+LIBDOGECOIN_API int generateHDMasterPubKeypair(char* hd_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
 
 /* generate an extended public key */
-LIBDOGECOIN_API int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey);
+LIBDOGECOIN_API int generateDerivedHDPubkey(const char* hd_privkey_master, char* p2pkh_pubkey);
 
 /* verify private and public keys are valid and associated with each other*/
 LIBDOGECOIN_API int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet);
 
 /* verify private and public masters keys are valid and associated with each other */
-LIBDOGECOIN_API int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
+LIBDOGECOIN_API int verifyHDMasterPubKeypair(char* hd_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
 
 /* verify address based on length and checksum */
 LIBDOGECOIN_API int verifyP2pkhAddress(char* p2pkh_pubkey, size_t len);
@@ -72,19 +72,19 @@ bool getDerivedHDNodeByPath(const char* masterkey, const char* derived_path, dog
 LIBDOGECOIN_API int getDerivedHDAddressFromMnemonic(const uint32_t account, const uint32_t index, const CHANGE_LEVEL change_level, const MNEMONIC mnemonic, const PASSPHRASE pass, char* p2pkh_pubkey, const dogecoin_bool is_testnet);
 
 /* generates a HD master key and p2pkh ready-to-use corresponding dogecoin address from a mnemonic */
-LIBDOGECOIN_API int generateHDMasterPubKeypairFromMnemonic(char* wif_privkey_master, char* p2pkh_pubkey_master, const MNEMONIC mnemonic, const PASSPHRASE pass, const dogecoin_bool is_testnet);
+LIBDOGECOIN_API int generateHDMasterPubKeypairFromMnemonic(char* hd_privkey_master, char* p2pkh_pubkey_master, const MNEMONIC mnemonic, const PASSPHRASE pass, const dogecoin_bool is_testnet);
 
 /* verify that a HD master key and a dogecoin address matches a mnemonic */
-LIBDOGECOIN_API int verifyHDMasterPubKeypairFromMnemonic(const char* wif_privkey_master, const char* p2pkh_pubkey_master, const MNEMONIC mnemonic, const PASSPHRASE pass, const dogecoin_bool is_testnet);
+LIBDOGECOIN_API int verifyHDMasterPubKeypairFromMnemonic(const char* hd_privkey_master, const char* p2pkh_pubkey_master, const MNEMONIC mnemonic, const PASSPHRASE pass, const dogecoin_bool is_testnet);
 
 /* generates a new dogecoin address from an encrypted seed and a slip44 key path */
 LIBDOGECOIN_API int getDerivedHDAddressFromEncryptedSeed(const uint32_t account, const uint32_t index, const CHANGE_LEVEL change_level, char* p2pkh_pubkey, const dogecoin_bool is_testnet, const int file_num);
 
 /* generates a HD master key and p2pkh ready-to-use corresponding dogecoin address from an encrypted seed */
-LIBDOGECOIN_API int generateHDMasterPubKeypairFromEncryptedSeed(char* wif_privkey_master, char* p2pkh_pubkey_master, const dogecoin_bool is_testnet, const int file_num);
+LIBDOGECOIN_API int generateHDMasterPubKeypairFromEncryptedSeed(char* hd_privkey_master, char* p2pkh_pubkey_master, const dogecoin_bool is_testnet, const int file_num);
 
 /* verify that a HD master key and a dogecoin address matches an encrypted seed */
-LIBDOGECOIN_API int verifyHDMasterPubKeypairFromEncryptedSeed(const char* wif_privkey_master, const char* p2pkh_pubkey_master, const dogecoin_bool is_testnet, const int file_num);
+LIBDOGECOIN_API int verifyHDMasterPubKeypairFromEncryptedSeed(const char* hd_privkey_master, const char* p2pkh_pubkey_master, const dogecoin_bool is_testnet, const int file_num);
 
 /* generates a new dogecoin address from an encrypted mnemonic and a slip44 key path */
 LIBDOGECOIN_API int getDerivedHDAddressFromEncryptedMnemonic(const uint32_t account, const uint32_t index, const CHANGE_LEVEL change_level, const PASSPHRASE pass, char* p2pkh_pubkey, const bool is_testnet, const int file_num);

--- a/include/dogecoin/bip44.h
+++ b/include/dogecoin/bip44.h
@@ -66,7 +66,7 @@ int derive_bip44_extended_key(const dogecoin_hdnode *master_key, const uint32_t 
 /* Extended private key generated */
 /* Key path string generated */
 dogecoin_bool deriveBIP44ExtendedKey(
-    const char wif_privkey_master[HDKEYLEN],
+    const char hd_privkey_master[HDKEYLEN],
     const uint32_t* account,
     const CHANGE_LEVEL change_level,
     const uint32_t* address_index,
@@ -83,7 +83,7 @@ dogecoin_bool deriveBIP44ExtendedKey(
 /* Extended public key generated */
 /* Key path string generated */
 dogecoin_bool deriveBIP44ExtendedPublicKey(
-    const char wif_privkey_master[HDKEYLEN],
+    const char hd_privkey_master[HDKEYLEN],
     const uint32_t* account,
     const CHANGE_LEVEL change_level,
     const uint32_t* address_index,

--- a/include/dogecoin/chainparams.h
+++ b/include/dogecoin/chainparams.h
@@ -70,8 +70,8 @@ LIBDOGECOIN_API const dogecoin_chainparams* chain_from_b58_prefix(const char* ad
 LIBDOGECOIN_API int chain_from_b58_prefix_bool(char* address);
 
 // check if the given prefix is a testnet or mainnet prefix
-LIBDOGECOIN_API dogecoin_bool isTestnetFromB58Prefix(const char address[PUBKEYLEN]);
-LIBDOGECOIN_API dogecoin_bool isMainnetFromB58Prefix(const char address[PUBKEYLEN]);
+LIBDOGECOIN_API dogecoin_bool isTestnetFromB58Prefix(const char address[P2PKHLEN]);
+LIBDOGECOIN_API dogecoin_bool isMainnetFromB58Prefix(const char address[P2PKHLEN]);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/constants.h
+++ b/include/dogecoin/constants.h
@@ -33,9 +33,6 @@
 LIBDOGECOIN_BEGIN_DECL
 
 #define MAX_INT32_STRINGLEN 12
-#define HD_MASTERKEY_STRINGLEN 112
-#define P2PKH_ADDR_STRINGLEN 35
-#define WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN 53
 #define DERIVED_PATH_STRINGLEN 33
 /* NOTE: Path string composed of m/44/3/+32bits_Account+/+bool_ischange+/+32bits_Address + string terminator; for a total of 33 bytes. */
 #define KOINU_STRINGLEN 21

--- a/include/dogecoin/dogecoin.h
+++ b/include/dogecoin/dogecoin.h
@@ -130,7 +130,8 @@ typedef uint8_t dogecoin_bool; //!serialize, c/c++ save bool
 #define MAX_SEED_SIZE 64
 #define HDKEYLEN 112
 #define PRIVKEYWIFLEN 53
-#define PUBKEYLEN 35
+#define P2PKHLEN 35
+#define PRIVKEYHEXLEN DOGECOIN_ECKEY_PKEY_LENGTH * 2 + 1
 #define PUBKEYHEXLEN 67
 #define PUBKEYHASHLEN 41
 #define KEYPATHMAXLEN 256

--- a/include/dogecoin/eckey.h
+++ b/include/dogecoin/eckey.h
@@ -38,10 +38,10 @@ LIBDOGECOIN_BEGIN_DECL
 typedef struct eckey {
     int idx;
     dogecoin_key private_key;
-    char private_key_wif[128];
+    char private_key_wif[PRIVKEYWIFLEN];
     dogecoin_pubkey public_key;
-    char public_key_hex[128];
-    char address[35];
+    char public_key_hex[PUBKEYHEXLEN];
+    char address[P2PKHLEN];
     UT_hash_handle hh;
 } eckey;
 

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -91,8 +91,8 @@ void dogecoin_ecc_stop(void);
 //#define HDKEYLEN 111 //should be chaincode + privkey; starts with dgpv51eADS3spNJh8 or dgpv51eADS3spNJh9 (112 internally including stringterm? often 128. check this.)
 #define HDKEYLEN 112 // Function expects 128 but needs to be fixed to take 111.
 
-//#define PUBKEYLEN 34 //our mainnet addresses are 34 chars if p2pkh and start with D.  Internally this is cited as 35 for strings that represent it because +stringterm.
-#define PUBKEYLEN 35 // Function expects 35, but needs to be fixed to take 34.
+//#define P2PKHLEN 34 //our mainnet addresses are 34 chars if p2pkh and start with D.  Internally this is cited as 35 for strings that represent it because +stringterm.
+#define P2PKHLEN 35 // Function expects 35, but needs to be fixed to take 34.
 
 //#define PUBKEYHEXLEN 67 //should be 66 for hex pubkey.  Internally this is cited as 67 for strings that represent it because +stringterm.
 #define PUBKEYHEXLEN 67
@@ -104,55 +104,55 @@ void dogecoin_ecc_stop(void);
 #define KEYPATHMAXLEN 256
 
 /* check if a given address is a testnet address */
-dogecoin_bool isTestnetFromB58Prefix(const char address[PUBKEYLEN]);
+dogecoin_bool isTestnetFromB58Prefix(const char address[P2PKHLEN]);
 
 /* check if a given address is a mainnet address */
-dogecoin_bool isMainnetFromB58Prefix(const char address[PUBKEYLEN]);
+dogecoin_bool isMainnetFromB58Prefix(const char address[P2PKHLEN]);
 
 /* generates a private and public keypair (a wallet import format private key and a p2pkh ready-to-use corresponding dogecoin address)*/
-int generatePrivPubKeypair(char wif_privkey[PRIVKEYWIFLEN], char p2pkh_pubkey[PUBKEYLEN], dogecoin_bool is_testnet);
+int generatePrivPubKeypair(char wif_privkey[PRIVKEYWIFLEN], char p2pkh_pubkey[P2PKHLEN], dogecoin_bool is_testnet);
 
-/* generates a hybrid deterministic WIF master key and p2pkh ready-to-use corresponding dogecoin address. */
-int generateHDMasterPubKeypair(char wif_privkey_master[HDKEYLEN], char p2pkh_pubkey_master[PUBKEYLEN], dogecoin_bool is_testnet);
+/* generates a hybrid deterministic HD master key and p2pkh ready-to-use corresponding dogecoin address. */
+int generateHDMasterPubKeypair(char hd_privkey_master[HDKEYLEN], char p2pkh_pubkey_master[P2PKHLEN], dogecoin_bool is_testnet);
 
 /* generates a new dogecoin address from a HD master key */
-int generateDerivedHDPubkey(const char wif_privkey_master[HDKEYLEN], char p2pkh_pubkey[PUBKEYLEN]);
+int generateDerivedHDPubkey(const char hd_privkey_master[HDKEYLEN], char p2pkh_pubkey[P2PKHLEN]);
 
 /* verify that a private key and dogecoin address match */
-int verifyPrivPubKeypair(char wif_privkey[PRIVKEYWIFLEN], char p2pkh_pubkey[PUBKEYLEN], dogecoin_bool is_testnet);
+int verifyPrivPubKeypair(char wif_privkey[PRIVKEYWIFLEN], char p2pkh_pubkey[P2PKHLEN], dogecoin_bool is_testnet);
 
 /* verify that a HD Master key and a dogecoin address matches */
-int verifyHDMasterPubKeypair(char wif_privkey_master[HDKEYLEN], char p2pkh_pubkey_master[PUBKEYLEN], dogecoin_bool is_testnet);
+int verifyHDMasterPubKeypair(char hd_privkey_master[HDKEYLEN], char p2pkh_pubkey_master[P2PKHLEN], dogecoin_bool is_testnet);
 
 /* verify that a dogecoin address is valid. */
-int verifyP2pkhAddress(char p2pkh_pubkey[PUBKEYLEN], size_t len);
+int verifyP2pkhAddress(char p2pkh_pubkey[P2PKHLEN], size_t len);
 
 /* get derived hd address */
-int getDerivedHDAddress(const char masterkey[HDKEYLEN], uint32_t account, dogecoin_bool ischange, uint32_t addressindex, char outaddress[PUBKEYLEN], dogecoin_bool outprivkey);
+int getDerivedHDAddress(const char masterkey[HDKEYLEN], uint32_t account, dogecoin_bool ischange, uint32_t addressindex, char outaddress[P2PKHLEN], dogecoin_bool outprivkey);
 
 /* get derived hd address by custom path */
-int getDerivedHDAddressByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[PUBKEYLEN], dogecoin_bool outprivkey);
+int getDerivedHDAddressByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[P2PKHLEN], dogecoin_bool outprivkey);
 
 /* generate the p2pkh address from a given hex pubkey */
-dogecoin_bool addresses_from_pubkey(const dogecoin_chainparams* chain, const char pubkey_hex[PUBKEYHEXLEN], char p2pkh_address[PUBKEYLEN]);
-int getAddressFromPubkey(const char pubkey_hex[PUBKEYHEXLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]);
+dogecoin_bool addresses_from_pubkey(const dogecoin_chainparams* chain, const char pubkey_hex[PUBKEYHEXLEN], char p2pkh_address[P2PKHLEN]);
+int getAddressFromPubkey(const char pubkey_hex[PUBKEYHEXLEN], const dogecoin_bool is_testnet, char p2pkh_address[P2PKHLEN]);
 
 /* generate the hex publickey from a given hex private key */
-dogecoin_bool pubkey_from_privatekey(const dogecoin_chainparams* chain, const char privkey_hex[PRIVKEYWIFLEN], char pubkey_hex[PUBKEYHEXLEN], size_t* sizeout);
+dogecoin_bool pubkey_from_privatekey(const dogecoin_chainparams* chain, const char privkey_hex[PRIVKEYHEXLEN], char pubkey_hex[PUBKEYHEXLEN], size_t* sizeout);
 int getPubkeyFromPrivkey(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_bool is_testnet, char pubkey_hex[PUBKEYHEXLEN], size_t* sizeout);
 
 /* generate a new private key (hex) */
-dogecoin_bool gen_privatekey(const dogecoin_chainparams* chain, char privkey_wif[PUBKEYHEXLEN], size_t strsize_wif, char privkey_hex[PRIVKEYWIFLEN]);
-int genPrivkey(const dogecoin_bool is_testnet, char privkey_wif[PUBKEYHEXLEN], size_t strsize_wif, char privkey_hex[PRIVKEYWIFLEN]);
+dogecoin_bool gen_privatekey(const dogecoin_chainparams* chain, char privkey_wif[PRIVKEYWIFLEN], size_t strsize_wif, char privkey_hex[PRIVKEYHEXLEN]);
+int genPrivkey(const dogecoin_bool is_testnet, char privkey_wif[PRIVKEYWIFLEN], size_t strsize_wif, char privkey_hex[PRIVKEYHEXLEN]);
 
 /* p2pkh utilities */
-dogecoin_bool dogecoin_pubkey_hash_to_p2pkh_address(char script_pubkey_hex[PUBKEYHEXLEN], size_t script_pubkey_hex_length, char p2pkh[PUBKEYLEN], const dogecoin_chainparams* chain);
-dogecoin_bool dogecoin_p2pkh_address_to_pubkey_hash(char p2pkh[PUBKEYLEN], char scripthash[PUBKEYHASHLEN]);
+dogecoin_bool dogecoin_pubkey_hash_to_p2pkh_address(char script_pubkey_hex[PUBKEYHEXLEN], size_t script_pubkey_hex_length, char p2pkh[P2PKHLEN], const dogecoin_chainparams* chain);
+dogecoin_bool dogecoin_p2pkh_address_to_pubkey_hash(char p2pkh[P2PKHLEN], char scripthash[PUBKEYHASHLEN]);
 char* dogecoin_address_to_pubkey_hash(char p2pkh[PUBKEYHEXLEN]);
 char* dogecoin_private_key_wif_to_pubkey_hash(char private_key_wif[PRIVKEYWIFLEN]);
 
 /* generate the p2pkh address from a given pubkey hash */
-int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]);
+int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN], const dogecoin_bool is_testnet, char p2pkh_address[P2PKHLEN]);
 
 /* privkey utilities */
 typedef struct dogecoin_key_ {
@@ -210,9 +210,9 @@ int printNode(const dogecoin_bool is_testnet, const char nodeser[HDKEYLEN]);
 int deriveHDExtFromMaster(const dogecoin_bool is_testnet, const char masterkey[HDKEYLEN], const char keypath[KEYPATHMAXLEN], char extkeyout[HDKEYLEN], size_t extkeyout_size);
 
 /* get derived hd extended child key and corresponding private key in WIF format */
-char* getHDNodePrivateKeyWIFByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[PUBKEYLEN], bool outprivkey);
+char* getHDNodePrivateKeyWIFByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[P2PKHLEN], bool outprivkey);
 /* get derived hd extended address and compendium hdnode */
-dogecoin_hdnode* getHDNodeAndExtKeyByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[PUBKEYLEN], bool outprivkey);
+dogecoin_hdnode* getHDNodeAndExtKeyByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[P2PKHLEN], bool outprivkey);
 
 /* BIP 44 string constants */
 #define BIP44_PURPOSE "44"       /* Purpose for key derivation according to BIP 44 */
@@ -260,7 +260,7 @@ int derive_bip44_extended_key(const dogecoin_hdnode *master_key, const uint32_t*
 /* Extended private key generated */
 /* Key path string generated */
 dogecoin_bool deriveBIP44ExtendedKey(
-    const char wif_privkey_master[HDKEYLEN],
+    const char hd_privkey_master[HDKEYLEN],
     const uint32_t* account,
     const CHANGE_LEVEL change_level,
     const uint32_t* address_index,
@@ -277,7 +277,7 @@ dogecoin_bool deriveBIP44ExtendedKey(
 /* Extended public key generated */
 /* Key path string generated */
 dogecoin_bool deriveBIP44ExtendedPublicKey(
-    const char wif_privkey_master[HDKEYLEN],
+    const char hd_privkey_master[HDKEYLEN],
     const uint32_t* account,
     const CHANGE_LEVEL change_level,
     const uint32_t* address_index,
@@ -454,10 +454,10 @@ typedef struct dogecoin_pubkey_ {
 typedef struct eckey {
     int idx;
     dogecoin_key private_key;
-    char private_key_wif[128];
+    char private_key_wif[PRIVKEYWIFLEN];
     dogecoin_pubkey public_key;
-    char public_key_hex[128];
-    char address[35];
+    char public_key_hex[PUBKEYHEXLEN];
+    char address[P2PKHLEN];
     UT_hash_handle hh;
 } eckey;
 

--- a/include/dogecoin/tool.h
+++ b/include/dogecoin/tool.h
@@ -47,9 +47,9 @@ LIBDOGECOIN_API dogecoin_bool hd_print_node(const dogecoin_chainparams* chain, c
 LIBDOGECOIN_API dogecoin_bool hd_derive(const dogecoin_chainparams* chain, const char* masterkey, const char* keypath, char* extkeyout, size_t extkeyout_size);
 
 /* wrappers for the above functions */
-LIBDOGECOIN_API int getAddressFromPubkey(const char pubkey_hex[PUBKEYHEXLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]);
+LIBDOGECOIN_API int getAddressFromPubkey(const char pubkey_hex[PUBKEYHEXLEN], const dogecoin_bool is_testnet, char p2pkh_address[P2PKHLEN]);
 LIBDOGECOIN_API int getPubkeyFromPrivkey(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_bool is_testnet, char pubkey_hex[PUBKEYHEXLEN], size_t* sizeout);
-LIBDOGECOIN_API int genPrivkey(const dogecoin_bool is_testnet, char privkey_wif[PUBKEYHEXLEN], size_t strsize_wif, char privkey_hex[PRIVKEYWIFLEN]);
+LIBDOGECOIN_API int genPrivkey(const dogecoin_bool is_testnet, char privkey_wif[PRIVKEYWIFLEN], size_t strsize_wif, char privkey_hex[PRIVKEYHEXLEN]);
 
 LIBDOGECOIN_API int genHDMaster(const dogecoin_bool is_testnet, char masterkeyhex[HDKEYLEN], size_t strsize);
 LIBDOGECOIN_API int printNode(const dogecoin_bool is_testnet, const char nodeser[HDKEYLEN]);

--- a/include/dogecoin/tx.h
+++ b/include/dogecoin/tx.h
@@ -130,7 +130,7 @@ const char* dogecoin_tx_sign_result_to_str(const enum dogecoin_tx_sign_result re
 enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, const cstring* script, const dogecoin_key* privkey, size_t inputindex, int sighashtype, uint8_t* sigcompact_out, uint8_t* sigder_out, size_t* sigder_len);
 
 //!wrapper to get the address from a pubkey hash
-LIBDOGECOIN_API int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]);
+LIBDOGECOIN_API int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN], const dogecoin_bool is_testnet, char p2pkh_address[P2PKHLEN]);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -83,7 +83,7 @@ typedef struct dogecoin_wtx_ {
 typedef struct dogecoin_utxo_ {
     uint256 txid;
     int vout;
-    char address[P2PKH_ADDR_STRINGLEN];
+    char address[P2PKHLEN];
     char* account;
     char script_pubkey[SCRIPT_PUBKEY_STRINGLEN];
     char amount[KOINU_STRINGLEN];

--- a/src/address.c
+++ b/src/address.c
@@ -67,8 +67,8 @@ int generatePrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testne
 {
     /* internal variables */
 
-    char wif_privkey_internal[WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN]; //MLUMIN: Keylength (51 or 52 chars, depending on uncompressed or compressed) +1 for string termination 'internally'?
-    char p2pkh_pubkey_internal[P2PKH_ADDR_STRINGLEN]; //MLUMIN: no magic numbers. p2pkh address should be 34 characters, +1 though for string termination 'internally'?
+    char wif_privkey_internal[PRIVKEYWIFLEN]; //MLUMIN: Keylength (51 or 52 chars, depending on uncompressed or compressed) +1 for string termination 'internally'?
+    char p2pkh_pubkey_internal[P2PKHLEN]; //MLUMIN: no magic numbers. p2pkh address should be 34 characters, +1 though for string termination 'internally'?
     size_t privkey_len = sizeof(wif_privkey_internal);
 
 
@@ -120,20 +120,20 @@ int generatePrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testne
  * key pair for a hierarchical deterministic wallet on the
  * specified network.
  *
- * @param wif_privkey_master The generated master private key.
+ * @param hd_privkey_master The generated master private key.
  * @param p2pkh_pubkey_master The generated master public key.
  * @param is_testnet The flag denoting which network, 0 for mainnet and 1 for testnet.
  *
  * @return 1 if the key pair was generated successfully.
  */
-int generateHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet)
+int generateHDMasterPubKeypair(char* hd_privkey_master, char* p2pkh_pubkey_master, bool is_testnet)
 {
-    char hd_privkey_master[HD_MASTERKEY_STRINGLEN];
-    char hd_pubkey_master[P2PKH_ADDR_STRINGLEN];
+    char hd_privkey_master_local[HDKEYLEN];
+    char hd_pubkey_master[P2PKHLEN];
 
     /* if nothing is passed use internal variables */
-    if (wif_privkey_master) {
-        memcpy_safe(hd_privkey_master, wif_privkey_master, sizeof(hd_privkey_master));
+    if (hd_privkey_master) {
+        memcpy_safe(hd_privkey_master_local, hd_privkey_master, sizeof(hd_privkey_master_local));
     }
     if (p2pkh_pubkey_master) {
         memcpy_safe(hd_pubkey_master, p2pkh_pubkey_master, sizeof(hd_pubkey_master));
@@ -143,16 +143,16 @@ int generateHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_mast
     const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
 
     /* generate a new hd master key */
-    if (!hd_gen_master(chain, hd_privkey_master, sizeof(hd_privkey_master))) {
+    if (!hd_gen_master(chain, hd_privkey_master_local, sizeof(hd_privkey_master_local))) {
         return false;
     }
 
-    if (!generateDerivedHDPubkey(hd_privkey_master, hd_pubkey_master)) {
+    if (!generateDerivedHDPubkey(hd_privkey_master_local, hd_pubkey_master)) {
         return false;
     }
 
-    if (wif_privkey_master) {
-        memcpy_safe(wif_privkey_master, hd_privkey_master, sizeof(hd_privkey_master));
+    if (hd_privkey_master) {
+        memcpy_safe(hd_privkey_master, hd_privkey_master_local, sizeof(hd_privkey_master_local));
     }
     if (p2pkh_pubkey_master) {
         memcpy_safe(p2pkh_pubkey_master, hd_pubkey_master, sizeof(hd_pubkey_master));
@@ -167,22 +167,22 @@ int generateHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_mast
  * on the specified network. This input should come from
  * the result of generateHDMasterPubKeypair().
  *
- * @param wif_privkey_master The master private key to derive the child key from.
+ * @param hd_privkey_master The master private key to derive the child key from.
  * @param p2pkh_pubkey The resulting child public key.
  *
  * @return 1 if the child key was generated successfully, 0 otherwise.
  */
-int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey)
+int generateDerivedHDPubkey(const char* hd_privkey_master, char* p2pkh_pubkey)
 {
     /* require master key */
-    if (!wif_privkey_master) {
+    if (!hd_privkey_master) {
         return false;
     }
 
     /* determine address prefix for network chainparams */
-    const dogecoin_chainparams* chain = chain_from_b58_prefix(wif_privkey_master);
+    const dogecoin_chainparams* chain = chain_from_b58_prefix(hd_privkey_master);
 
-    char str[P2PKH_ADDR_STRINGLEN];
+    char str[P2PKHLEN];
 
     /* if nothing is passed in use internal variables */
     if (p2pkh_pubkey) {
@@ -190,7 +190,7 @@ int generateDerivedHDPubkey(const char* wif_privkey_master, char* p2pkh_pubkey)
     }
 
     dogecoin_hdnode* node = dogecoin_hdnode_new();
-    dogecoin_hdnode_deserialize(wif_privkey_master, chain, node);
+    dogecoin_hdnode_deserialize(hd_privkey_master, chain, node);
 
     dogecoin_hdnode_get_p2pkh_address(node, chain, str, sizeof(str));
 
@@ -230,7 +230,7 @@ int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet)
     dogecoin_privkey_decode_wif(wif_privkey, chain, &key);
     if (!dogecoin_privkey_is_valid(&key)) return false;
 
-    char new_wif_privkey[WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN];
+    char new_wif_privkey[PRIVKEYWIFLEN];
     size_t sizeout = sizeof(new_wif_privkey);
     dogecoin_privkey_encode_wif(&key, chain, new_wif_privkey, &sizeout);
 
@@ -261,22 +261,22 @@ int verifyPrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testnet)
  * that both are valid on the specified network.
  *
  * @param is_testnet The flag denoting which network, 0 for mainnet and 1 for testnet.
- * @param wif_privkey_master The master private key to check.
+ * @param hd_privkey_master The master private key to check.
  * @param p2pkh_pubkey_master The master public key to check.
  *
  * @return 1 if the keys match and are valid on the specified network, 0 otherwise.
  */
-int verifyHDMasterPubKeypair(char* wif_privkey_master, char* p2pkh_pubkey_master, bool is_testnet) {
+int verifyHDMasterPubKeypair(char* hd_privkey_master, char* p2pkh_pubkey_master, bool is_testnet) {
     /* require both private and public key */
-    if (!wif_privkey_master || !p2pkh_pubkey_master) return false;
+    if (!hd_privkey_master || !p2pkh_pubkey_master) return false;
 
     /* determine if mainnet or testnet/regtest */
     const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
 
     /* calculate master pubkey from master privkey */
     dogecoin_hdnode node;
-    dogecoin_hdnode_deserialize(wif_privkey_master, chain, &node);
-    char new_p2pkh_pubkey_master[HD_MASTERKEY_STRINGLEN];
+    dogecoin_hdnode_deserialize(hd_privkey_master, chain, &node);
+    char new_p2pkh_pubkey_master[HDKEYLEN];
     dogecoin_hdnode_get_p2pkh_address(&node, chain, new_p2pkh_pubkey_master, sizeof(new_p2pkh_pubkey_master));
 
     /* compare derived and given pubkeys */
@@ -336,7 +336,7 @@ char* getHDNodePrivateKeyWIFByPath(const char* masterkey, const char* derived_pa
         debug_print("%s", "missing input\n");
         exit(EXIT_FAILURE);
     }
-    size_t wiflen = WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN;
+    size_t wiflen = PRIVKEYWIFLEN;
     char* privkeywif_main = dogecoin_malloc(wiflen);
     const dogecoin_chainparams* chain = chain_from_b58_prefix(masterkey);
     dogecoin_hdnode* hdnode = getHDNodeAndExtKeyByPath(masterkey, derived_path, outaddress, outprivkey);
@@ -372,8 +372,8 @@ dogecoin_hdnode* getHDNodeAndExtKeyByPath(const char* masterkey, const char* der
     bool pubckd = !dogecoin_hdnode_has_privkey(node);
     /* derive child key, use pubckd or privckd */
     dogecoin_hd_generate_key(nodenew, derived_path, pubckd ? node->public_key : node->private_key, node->depth, node->chain_code, pubckd);
-    if (outprivkey) dogecoin_hdnode_serialize_private(nodenew, chain, outaddress, HD_MASTERKEY_STRINGLEN);
-    else dogecoin_hdnode_serialize_public(nodenew, chain, outaddress, HD_MASTERKEY_STRINGLEN);
+    if (outprivkey) dogecoin_hdnode_serialize_private(nodenew, chain, outaddress, HDKEYLEN);
+    else dogecoin_hdnode_serialize_public(nodenew, chain, outaddress, HDKEYLEN);
     dogecoin_hdnode_free(node);
     return nodenew;
 }
@@ -400,7 +400,7 @@ int getDerivedHDAddressByPath(const char* masterkey, const char* derived_path, c
 
     if (ret) {
         const dogecoin_chainparams* chain = chain_from_b58_prefix(masterkey);
-        dogecoin_hdnode_get_p2pkh_address(&node, chain, outaddress, P2PKH_ADDR_STRINGLEN);
+        dogecoin_hdnode_get_p2pkh_address(&node, chain, outaddress, P2PKHLEN);
     }
 
     return ret;
@@ -430,8 +430,8 @@ int getDerivedHDKeyByPath(const char* masterkey, const char* derived_path, char*
 
     if (ret) {
         const dogecoin_chainparams* chain = chain_from_b58_prefix(masterkey);
-        if (outprivkey) dogecoin_hdnode_serialize_private(&node, chain, outaddress, HD_MASTERKEY_STRINGLEN);
-        else dogecoin_hdnode_serialize_public(&node, chain, outaddress, HD_MASTERKEY_STRINGLEN);
+        if (outprivkey) dogecoin_hdnode_serialize_private(&node, chain, outaddress, HDKEYLEN);
+        else dogecoin_hdnode_serialize_public(&node, chain, outaddress, HDKEYLEN);
     }
 
     return ret;
@@ -533,7 +533,7 @@ int getDerivedHDAddressFromMnemonic(const uint32_t account, const uint32_t index
     }
 
     /* Generate the address */
-    dogecoin_hdnode_get_p2pkh_address(&bip44_key, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey, P2PKH_ADDR_STRINGLEN);
+    dogecoin_hdnode_get_p2pkh_address(&bip44_key, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey, P2PKHLEN);
 
    return 0;
 
@@ -542,7 +542,7 @@ int getDerivedHDAddressFromMnemonic(const uint32_t account, const uint32_t index
 /**
  * @brief This function generates a HD master key and p2pkh ready-to-use corresponding dogecoin address from a mnemonic.
  *
- * @param wif_privkey_master The generated master private key.
+ * @param hd_privkey_master The generated master private key.
  * @param p2pkh_pubkey_master The generated master public key.
  * @param mnemonic The mnemonic code words.
  * @param passphrase The passphrase (optional).
@@ -550,7 +550,7 @@ int getDerivedHDAddressFromMnemonic(const uint32_t account, const uint32_t index
  *
  * return: 0 (success), -1 (fail)
  */
-int generateHDMasterPubKeypairFromMnemonic(char* wif_privkey_master, char* p2pkh_pubkey_master, const MNEMONIC mnemonic, const PASSPHRASE pass, const dogecoin_bool is_testnet) {
+int generateHDMasterPubKeypairFromMnemonic(char* hd_privkey_master, char* p2pkh_pubkey_master, const MNEMONIC mnemonic, const PASSPHRASE pass, const dogecoin_bool is_testnet) {
 
     /* Validate input */
     if (!mnemonic) {
@@ -573,10 +573,10 @@ int generateHDMasterPubKeypairFromMnemonic(char* wif_privkey_master, char* p2pkh
     dogecoin_hdnode_from_seed(seed, MAX_SEED_SIZE, &node);
 
     /* Serialize the private key */
-    dogecoin_hdnode_serialize_private(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, wif_privkey_master, HD_MASTERKEY_STRINGLEN);
+    dogecoin_hdnode_serialize_private(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, hd_privkey_master, HDKEYLEN);
 
     /* Generate the address */
-    dogecoin_hdnode_get_p2pkh_address(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey_master, P2PKH_ADDR_STRINGLEN);
+    dogecoin_hdnode_get_p2pkh_address(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey_master, P2PKHLEN);
 
     return 0;
 }
@@ -584,7 +584,7 @@ int generateHDMasterPubKeypairFromMnemonic(char* wif_privkey_master, char* p2pkh
 /**
  * @brief This function verifies that a HD master key and a dogecoin address matches a mnemonic.
  *
- * @param wif_privkey_master The master private key to check.
+ * @param hd_privkey_master The master private key to check.
  * @param p2pkh_pubkey_master The master public key to check.
  * @param mnemonic The mnemonic code words.
  * @param passphrase The passphrase (optional).
@@ -592,7 +592,7 @@ int generateHDMasterPubKeypairFromMnemonic(char* wif_privkey_master, char* p2pkh
  *
  * return: 0 (success), -1 (fail)
  */
-int verifyHDMasterPubKeypairFromMnemonic(const char* wif_privkey_master, const char* p2pkh_pubkey_master, const MNEMONIC mnemonic, const PASSPHRASE pass, const dogecoin_bool is_testnet) {
+int verifyHDMasterPubKeypairFromMnemonic(const char* hd_privkey_master, const char* p2pkh_pubkey_master, const MNEMONIC mnemonic, const PASSPHRASE pass, const dogecoin_bool is_testnet) {
 
     /* Validate input */
     if (!mnemonic) {
@@ -615,17 +615,17 @@ int verifyHDMasterPubKeypairFromMnemonic(const char* wif_privkey_master, const c
     dogecoin_hdnode_from_seed(seed, MAX_SEED_SIZE, &node);
 
     /* Serialize the private key */
-    char wif_privkey_master_calculated[HD_MASTERKEY_STRINGLEN];
-    dogecoin_hdnode_serialize_private(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, wif_privkey_master_calculated, HD_MASTERKEY_STRINGLEN);
+    char hd_privkey_master_calculated[HDKEYLEN];
+    dogecoin_hdnode_serialize_private(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, hd_privkey_master_calculated, HDKEYLEN);
 
     /* Compare the calculated private key with the input private key */
-    if (strcmp(wif_privkey_master, wif_privkey_master_calculated) != 0) {
+    if (strcmp(hd_privkey_master, hd_privkey_master_calculated) != 0) {
         return -1;
     }
 
     /* Generate the address */
-    char p2pkh_pubkey_master_calculated[P2PKH_ADDR_STRINGLEN];
-    dogecoin_hdnode_get_p2pkh_address(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey_master_calculated, P2PKH_ADDR_STRINGLEN);
+    char p2pkh_pubkey_master_calculated[P2PKHLEN];
+    dogecoin_hdnode_get_p2pkh_address(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey_master_calculated, P2PKHLEN);
 
     /* Compare the calculated address with the input address */
     if (strcmp(p2pkh_pubkey_master, p2pkh_pubkey_master_calculated) != 0) {
@@ -671,7 +671,7 @@ int getDerivedHDAddressFromEncryptedSeed(const uint32_t account, const uint32_t 
     }
 
     /* Generate the address */
-    dogecoin_hdnode_get_p2pkh_address(&bip44_key, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey, P2PKH_ADDR_STRINGLEN);
+    dogecoin_hdnode_get_p2pkh_address(&bip44_key, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey, P2PKHLEN);
 
    return 0;
 
@@ -680,13 +680,13 @@ int getDerivedHDAddressFromEncryptedSeed(const uint32_t account, const uint32_t 
 /**
  * @brief This function generates a HD master key and p2pkh ready-to-use corresponding dogecoin address from a encrypted seed.
  *
- * @param wif_privkey_master The generated master private key.
+ * @param hd_privkey_master The generated master private key.
  * @param p2pkh_pubkey_master The generated master public key.
  * @param is_testnet The flag denoting which network, 0 for mainnet and 1 for testnet.
  *
  * return: 0 (success), -1 (fail)
  */
-int generateHDMasterPubKeypairFromEncryptedSeed(char* wif_privkey_master, char* p2pkh_pubkey_master, const dogecoin_bool is_testnet, const int file_num) {
+int generateHDMasterPubKeypairFromEncryptedSeed(char* hd_privkey_master, char* p2pkh_pubkey_master, const dogecoin_bool is_testnet, const int file_num) {
 
     /* Initialize variables */
     dogecoin_hdnode node;
@@ -703,10 +703,10 @@ int generateHDMasterPubKeypairFromEncryptedSeed(char* wif_privkey_master, char* 
     dogecoin_hdnode_from_seed(seed, MAX_SEED_SIZE, &node);
 
     /* Serialize the private key */
-    dogecoin_hdnode_serialize_private(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, wif_privkey_master, HD_MASTERKEY_STRINGLEN);
+    dogecoin_hdnode_serialize_private(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, hd_privkey_master, HDKEYLEN);
 
     /* Generate the address */
-    dogecoin_hdnode_get_p2pkh_address(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey_master, P2PKH_ADDR_STRINGLEN);
+    dogecoin_hdnode_get_p2pkh_address(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey_master, P2PKHLEN);
 
     return 0;
 }
@@ -714,13 +714,13 @@ int generateHDMasterPubKeypairFromEncryptedSeed(char* wif_privkey_master, char* 
 /**
  * @brief This function verifies that a HD master key and a dogecoin address matches a encrypted seed.
  *
- * @param wif_privkey_master The master private key to check.
+ * @param hd_privkey_master The master private key to check.
  * @param p2pkh_pubkey_master The master public key to check.
  * @param is_testnet The flag denoting which network, 0 for mainnet and 1 for testnet.
  *
  * return: 0 (success), -1 (fail)
  */
-int verifyHDMasterPubKeypairFromEncryptedSeed(const char* wif_privkey_master, const char* p2pkh_pubkey_master, const dogecoin_bool is_testnet, const int file_num) {
+int verifyHDMasterPubKeypairFromEncryptedSeed(const char* hd_privkey_master, const char* p2pkh_pubkey_master, const dogecoin_bool is_testnet, const int file_num) {
 
     /* Initialize variables */
     dogecoin_hdnode node;
@@ -737,17 +737,17 @@ int verifyHDMasterPubKeypairFromEncryptedSeed(const char* wif_privkey_master, co
     dogecoin_hdnode_from_seed(seed, MAX_SEED_SIZE, &node);
 
     /* Serialize the private key */
-    char wif_privkey_master_calculated[HD_MASTERKEY_STRINGLEN];
-    dogecoin_hdnode_serialize_private(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, wif_privkey_master_calculated, HD_MASTERKEY_STRINGLEN);
+    char hd_privkey_master_calculated[HDKEYLEN];
+    dogecoin_hdnode_serialize_private(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, hd_privkey_master_calculated, HDKEYLEN);
 
     /* Compare the calculated private key with the input private key */
-    if (strcmp(wif_privkey_master, wif_privkey_master_calculated) != 0) {
+    if (strcmp(hd_privkey_master, hd_privkey_master_calculated) != 0) {
         return -1;
     }
 
     /* Generate the address */
-    char p2pkh_pubkey_master_calculated[P2PKH_ADDR_STRINGLEN];
-    dogecoin_hdnode_get_p2pkh_address(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey_master_calculated, P2PKH_ADDR_STRINGLEN);
+    char p2pkh_pubkey_master_calculated[P2PKHLEN];
+    dogecoin_hdnode_get_p2pkh_address(&node, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey_master_calculated, P2PKHLEN);
 
     /* Compare the calculated address with the input address */
     if (strcmp(p2pkh_pubkey_master, p2pkh_pubkey_master_calculated) != 0) {
@@ -799,7 +799,7 @@ int getDerivedHDAddressFromEncryptedMnemonic(const uint32_t account, const uint3
     }
 
     /* Generate the address */
-    dogecoin_hdnode_get_p2pkh_address(&bip44_key, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey, P2PKH_ADDR_STRINGLEN);
+    dogecoin_hdnode_get_p2pkh_address(&bip44_key, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey, P2PKHLEN);
 
    return 0;
 
@@ -835,7 +835,7 @@ int getDerivedHDAddressFromEncryptedHDNode(const uint32_t account, const uint32_
     }
 
     /* Generate the address */
-    dogecoin_hdnode_get_p2pkh_address(&bip44_key, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey, P2PKH_ADDR_STRINGLEN);
+    dogecoin_hdnode_get_p2pkh_address(&bip44_key, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_pubkey, P2PKHLEN);
 
    return 0;
 

--- a/src/bip44.c
+++ b/src/bip44.c
@@ -103,7 +103,7 @@ int derive_bip44_extended_key(const dogecoin_hdnode *master_key, const uint32_t 
 
 /** @brief This function derives the BIP 44 extended private key from a master private key.
  *
- * @param wif_privkey_master The master private key to derive from.
+ * @param hd_privkey_master The master private key to derive from.
  * @param account The account number to use in the BIP 44 key derivation.
  * @param change_level The change level to use in the BIP 44 key derivation, either "external" or "internal".
  * @param address_index The address index to use in the BIP 44 key derivation.
@@ -114,7 +114,7 @@ int derive_bip44_extended_key(const dogecoin_hdnode *master_key, const uint32_t 
  * @return true if the key is derived successfully, false otherwise.
  */
 dogecoin_bool deriveBIP44ExtendedKey(
-    const char wif_privkey_master[HDKEYLEN],
+    const char hd_privkey_master[HDKEYLEN],
     const uint32_t* account,
     const CHANGE_LEVEL change_level,
     const uint32_t* address_index,
@@ -123,12 +123,12 @@ dogecoin_bool deriveBIP44ExtendedKey(
     KEY_PATH keypath) {
     dogecoin_hdnode master_key;
     dogecoin_hdnode derived_key;
-    dogecoin_bool is_testnet = isTestnetFromB58Prefix(wif_privkey_master);
-    if (wif_privkey_master == NULL || extkeyout == NULL) {
+    dogecoin_bool is_testnet = isTestnetFromB58Prefix(hd_privkey_master);
+    if (hd_privkey_master == NULL || extkeyout == NULL) {
         fprintf(stderr, "ERROR: invalid input arguments\n");
         return false;
     }
-    if (!dogecoin_hdnode_deserialize(wif_privkey_master, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, &master_key)) {
+    if (!dogecoin_hdnode_deserialize(hd_privkey_master, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, &master_key)) {
         fprintf(stderr, "ERROR: invalid master key\n");
         return false;
     }
@@ -142,7 +142,7 @@ dogecoin_bool deriveBIP44ExtendedKey(
 
 /** @brief This function derives the BIP 44 extended public key from a master private key.
  *
- * @param wif_privkey_master The master private key to derive from.
+ * @param hd_privkey_master The master private key to derive from.
  * @param account The account number to use in the BIP 44 key derivation.
  * @param change_level The change level to use in the BIP 44 key derivation, either "external" or "internal".
  * @param address_index The address index to use in the BIP 44 key derivation.
@@ -153,7 +153,7 @@ dogecoin_bool deriveBIP44ExtendedKey(
  * @return true if the key is derived successfully, false otherwise.
  */
 dogecoin_bool deriveBIP44ExtendedPublicKey(
-    const char wif_privkey_master[HDKEYLEN],
+    const char hd_privkey_master[HDKEYLEN],
     const uint32_t* account,
     const CHANGE_LEVEL change_level,
     const uint32_t* address_index,
@@ -162,12 +162,12 @@ dogecoin_bool deriveBIP44ExtendedPublicKey(
     KEY_PATH keypath) {
     dogecoin_hdnode master_key;
     dogecoin_hdnode derived_key;
-    dogecoin_bool is_testnet = isTestnetFromB58Prefix(wif_privkey_master);
-    if (wif_privkey_master == NULL || extkeyout == NULL) {
+    dogecoin_bool is_testnet = isTestnetFromB58Prefix(hd_privkey_master);
+    if (hd_privkey_master == NULL || extkeyout == NULL) {
         fprintf(stderr, "ERROR: invalid input arguments\n");
         return false;
     }
-    if (!dogecoin_hdnode_deserialize(wif_privkey_master, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, &master_key)) {
+    if (!dogecoin_hdnode_deserialize(hd_privkey_master, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, &master_key)) {
         fprintf(stderr, "ERROR: invalid master key\n");
         return false;
     }

--- a/src/chainparams.c
+++ b/src/chainparams.c
@@ -156,7 +156,7 @@ int chain_from_b58_prefix_bool(char* address) {
 }
 
 /* check if a given address is a testnet address */
-dogecoin_bool isTestnetFromB58Prefix(const char address[PUBKEYLEN]) {
+dogecoin_bool isTestnetFromB58Prefix(const char address[P2PKHLEN]) {
     /* Determine address prefix for network chainparams */
     const dogecoin_chainparams* chainparams = chain_from_b58_prefix(address);
 
@@ -165,7 +165,7 @@ dogecoin_bool isTestnetFromB58Prefix(const char address[PUBKEYLEN]) {
 }
 
 /* check if a given address is a mainnet address */
-dogecoin_bool isMainnetFromB58Prefix(const char address[PUBKEYLEN]) {
+dogecoin_bool isMainnetFromB58Prefix(const char address[P2PKHLEN]) {
     /* Determine address prefix for network chainparams */
     const dogecoin_chainparams* chainparams = chain_from_b58_prefix(address);
 

--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -780,7 +780,7 @@ int main(int argc, char* argv[])
     if (strcmp(cmd, "generate_public_key") == 0) {
         /* output compressed hex pubkey from hex privkey */
 
-        char pubkey_hex[128];
+        char pubkey_hex[PUBKEYHEXLEN];
         size_t sizeout = sizeof(pubkey_hex);
 
         if (!pkey)
@@ -806,7 +806,7 @@ int main(int argc, char* argv[])
         /* Creating a new address from a public key. */
         }
     else if (strcmp(cmd, "p2pkh") == 0) {
-        char address_p2pkh[128];
+        char address_p2pkh[P2PKHLEN];
         if (!pubkey)
             return showError("Missing public key (use -k)");
         if (!addresses_from_pubkey(chain, pubkey, address_p2pkh))
@@ -818,8 +818,8 @@ int main(int argc, char* argv[])
         /* Generating a new private key and printing it out. */
         }
     else if (strcmp(cmd, "generate_private_key") == 0) {
-        char newprivkey_wif[128];
-        char newprivkey_hex[128];
+        char newprivkey_wif[PRIVKEYWIFLEN];
+        char newprivkey_hex[PRIVKEYHEXLEN];
 
         /* generate a new private key */
         gen_privatekey(chain, newprivkey_wif, sizeof(newprivkey_wif), newprivkey_hex);
@@ -830,7 +830,7 @@ int main(int argc, char* argv[])
         /* Generating a new master key. */
         }
     else if (strcmp(cmd, "bip32_extended_master_key") == 0) {
-        char masterkey[128];
+        char masterkey[HDKEYLEN];
 
         /* if tpm is enabled, use it to generate a new master key */
         if (tpm) {
@@ -879,7 +879,7 @@ int main(int argc, char* argv[])
             return showError("no extended key (-p)");
         if (!derived_path)
             return showError("no derivation path (-m)");
-        char newextkey[128];
+        char newextkey[HDKEYLEN];
 
         //check if we derive a range of keys
         unsigned int maxlen = 1024;
@@ -1083,8 +1083,8 @@ int main(int argc, char* argv[])
         if (!dogecoin_hdnode_deserialize(pkey, chain, &node)) {
             return showError("dogecoin_hd_deserialize failed!\n");
             }
-        char masterkeyhex[200];
-        int strsize = 200;
+        char masterkeyhex[HDKEYLEN];
+        int strsize = HDKEYLEN;
         dogecoin_hdnode_serialize_private(&node, &dogecoin_chainparams_test, masterkeyhex, strsize);
         printf("xpriv: %s\n", masterkeyhex);
         dogecoin_hdnode_serialize_public(&node, &dogecoin_chainparams_test, masterkeyhex, strsize);
@@ -1173,7 +1173,7 @@ int main(int argc, char* argv[])
                 }
 
             /* serialize the master key */
-            char masterkey[128];
+            char masterkey[HDKEYLEN];
             dogecoin_hdnode_serialize_private (&node, chain, masterkey, sizeof(masterkey));
 
             /* display the master key */
@@ -1219,7 +1219,7 @@ int main(int argc, char* argv[])
         }
     else if (strcmp(cmd, "mnemonic_to_addresses") == 0) { /* Creating wif addresses from a mnemonic via slip44. */
 
-        char hd_pubkey_address[53];
+        char hd_pubkey_address[P2PKHLEN];
 
         /* if tpm is enabled, get mnemonic from tpm */
         if (tpm) {

--- a/src/cli/tool.c
+++ b/src/cli/tool.c
@@ -161,7 +161,7 @@ dogecoin_bool hd_print_node(const dogecoin_chainparams* chain, const char* nodes
     if (!dogecoin_hdnode_deserialize(nodeser, chain, &node))
         return false;
 
-    char str[128];
+    char str[HDKEYLEN];
     size_t strsize = sizeof(str);
     printf("ext key:             %s\n", nodeser);
 
@@ -175,7 +175,7 @@ dogecoin_bool hd_print_node(const dogecoin_chainparams* chain, const char* nodes
 
     pkeybase58c[0] = chain->b58prefix_secret_address;
     pkeybase58c[33] = 1; /* always use compressed keys */
-    char privkey_wif[128];
+    char privkey_wif[PRIVKEYWIFLEN];
     memcpy_safe(&pkeybase58c[1], node.private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
     assert(dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), privkey_wif, sizeof(privkey_wif)) != 0);
     if (dogecoin_hdnode_has_privkey(&node)) {
@@ -220,7 +220,7 @@ dogecoin_bool hd_derive(const dogecoin_chainparams* chain, const char* masterkey
     return true;
 }
 
-int getAddressFromPubkey(const char pubkey_hex[PUBKEYHEXLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]) {
+int getAddressFromPubkey(const char pubkey_hex[PUBKEYHEXLEN], const dogecoin_bool is_testnet, char p2pkh_address[P2PKHLEN]) {
     const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
     return addresses_from_pubkey(chain, pubkey_hex, p2pkh_address);
 }
@@ -230,7 +230,7 @@ int getPubkeyFromPrivkey(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_b
     return (pubkey_from_privatekey(chain, privkey_wif, pubkey_hex, sizeout) == true) ? 1 : 0;
 }
 
-int genPrivkey(const dogecoin_bool is_testnet, char privkey_wif[PUBKEYHEXLEN], size_t strsize_wif, char privkey_hex[PRIVKEYWIFLEN]) {
+int genPrivkey(const dogecoin_bool is_testnet, char privkey_wif[PRIVKEYWIFLEN], size_t strsize_wif, char privkey_hex[PRIVKEYHEXLEN]) {
     const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
     return gen_privatekey(chain, privkey_wif, strsize_wif, privkey_hex);
 }

--- a/src/sign.c
+++ b/src/sign.c
@@ -76,7 +76,7 @@ char* sign_message(char* privkey, char* msg) {
     if (!dogecoin_key_sign_hash_compact_recoverable_fcomp(&key, message_bytes, compact_signature, &compact_signature_length, &recid)) return false;
     if (!dogecoin_key_recover_pubkey((const unsigned char*)compact_signature, message_bytes, recid, &pubkey)) return false;
 
-    char p2pkh_address[35];
+    char p2pkh_address[P2PKHLEN];
     if (!dogecoin_pubkey_getaddr_p2pkh(&pubkey, &dogecoin_chainparams_main, p2pkh_address)) return false;
 
     unsigned char* base64_encoded_output = dogecoin_uchar_vla(1+(sizeof(char)*base64_encoded_size(compact_signature_length)));
@@ -126,7 +126,7 @@ int verify_message(char* sig, char* msg, char* address) {
     if (!dogecoin_key_recover_pubkey((const unsigned char*)decoded_signature, message_bytes, recid, &pub_key)) return false;
     if (!dogecoin_pubkey_verify_sigcmp(&pub_key, message_bytes, decoded_signature)) return false;
 
-    char p2pkh_address[35];
+    char p2pkh_address[P2PKHLEN];
     const dogecoin_chainparams* chain = chain_from_b58_prefix(address);
     if (!dogecoin_pubkey_getaddr_p2pkh(&pub_key, chain, p2pkh_address)) return false;
 

--- a/src/tx.c
+++ b/src/tx.c
@@ -222,7 +222,7 @@ int dogecoin_tx_out_pubkey_hash_to_p2pkh_address(dogecoin_tx_out* txout, char* p
                 break;
         }
     }
-    if (!dogecoin_p2pkh_addr_from_hash160(stripped_array, chain, p2pkh, 35)) {
+    if (!dogecoin_p2pkh_addr_from_hash160(stripped_array, chain, p2pkh, P2PKHLEN)) {
         printf("failed to convert hash160 to p2pkh!\n");
         return false;
     }
@@ -262,7 +262,7 @@ dogecoin_bool dogecoin_pubkey_hash_to_p2pkh_address(char* script_pubkey_hex, siz
                 break;
         }
     }
-    if (!dogecoin_p2pkh_addr_from_hash160(stripped_array, chain, p2pkh, 35)) {
+    if (!dogecoin_p2pkh_addr_from_hash160(stripped_array, chain, p2pkh, P2PKHLEN)) {
         printf("failed to convert hash160 to p2pkh!\n");
         return false;
     }
@@ -284,7 +284,7 @@ dogecoin_bool dogecoin_p2pkh_address_to_pubkey_hash(char* p2pkh, char* pubkey_ha
     if (!p2pkh) return false;
 
     // strlen(p2pkh) + 1 = 35
-    unsigned char dec[35]; //problem is here, it works if its char**
+    unsigned char dec[P2PKHLEN]; //problem is here, it works if its char**
 
     // MLUMIN: MSVC
     size_t decoded_length = dogecoin_base58_decode_check(p2pkh, (uint8_t*)&dec, sizeof(dec) / sizeof(dec[0]));
@@ -314,7 +314,7 @@ char* dogecoin_address_to_pubkey_hash(char* p2pkh) {
     if (!p2pkh) return false;
 
     // strlen(p2pkh) + 1 = 35
-    unsigned char dec[35]; //problem is here, it works if its char**
+    unsigned char dec[P2PKHLEN]; //problem is here, it works if its char**
 
     // MLUMIN: MSVC
     size_t decoded_length = dogecoin_base58_decode_check(p2pkh, (uint8_t*)&dec, sizeof(dec) / sizeof(dec[0]));
@@ -357,7 +357,7 @@ char* dogecoin_private_key_wif_to_pubkey_hash(char* private_key_wif) {
         return false;
     }
 
-    char new_wif_privkey[53];
+    char new_wif_privkey[PRIVKEYWIFLEN];
     size_t sizeout = sizeof(new_wif_privkey);
     dogecoin_privkey_encode_wif(&key, chain, new_wif_privkey, &sizeout);
 
@@ -1200,7 +1200,7 @@ enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, cons
  *
  * @return 1 if the address was added successfully, 0 otherwise.
  */
-int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN], const dogecoin_bool is_testnet, char p2pkh_address[PUBKEYLEN]) {
+int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN], const dogecoin_bool is_testnet, char p2pkh_address[P2PKHLEN]) {
     return dogecoin_pubkey_hash_to_p2pkh_address((char *)utils_hex_to_uint8(pubkey_hash), SCRIPT_PUBKEY_LENGTH, p2pkh_address, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main);
 }
 

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -353,11 +353,8 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
     if (created) {
         // create a new key
         dogecoin_hdnode node;
-#ifdef WITH_UNISTRING
         SEED seed;
-#else
-        uint8_t seed[64];
-#endif
+
         if (mnemonic_in) {
             // generate seed from mnemonic
             if (dogecoin_seed_from_mnemonic(mnemonic_in, pass, seed) == -1) {
@@ -415,8 +412,8 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
         for(;i<1;i++) {
             waddr = dogecoin_wallet_next_bip44_addr(wallet);
         }
-        char str[P2PKH_ADDR_STRINGLEN];
-        dogecoin_p2pkh_addr_from_hash160(waddr->pubkeyhash, wallet->chain, str, P2PKH_ADDR_STRINGLEN);
+        char str[P2PKHLEN];
+        dogecoin_p2pkh_addr_from_hash160(waddr->pubkeyhash, wallet->chain, str, P2PKHLEN);
     }
 #else
     else if (wallet->waddr_vector->len == 0) {
@@ -568,7 +565,7 @@ void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
         dogecoin_tx_out* tx_out = vector_idx(wtx->tx->vout, j);
         // populate address vector if script_pubkey exists:
         if (wallet->waddr_vector->len && tx_out->script_pubkey->len) {
-            char p2pkh_from_script_pubkey[P2PKH_ADDR_STRINGLEN];
+            char p2pkh_from_script_pubkey[P2PKHLEN];
             // convert script pubkey hash to p2pkh address:
             if (!dogecoin_pubkey_hash_to_p2pkh_address(tx_out->script_pubkey->str, tx_out->script_pubkey->len, p2pkh_from_script_pubkey, wallet->chain)) {
                 printf("failed to convert pubkey hash to p2pkh address!\n");
@@ -581,7 +578,7 @@ void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
             for (i = 0; i < addrs->len; i++) {
                 char* addr = vector_idx(addrs, i);
                 // compare wtx->tx->vout with address from wallet->waddr_vector:
-                if (strncmp(p2pkh_from_script_pubkey, addr, P2PKH_ADDR_STRINGLEN - 1)==0) {
+                if (strncmp(p2pkh_from_script_pubkey, addr, P2PKHLEN - 1)==0) {
                     // match so we populate utxo struct:
                     dogecoin_utxo* utxo = dogecoin_wallet_utxo_new();
                     // make the txid:
@@ -611,7 +608,7 @@ void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
                         // set tx->tx_in->prevout.n (utxo->vout):
                         utxo->vout = j;
                         // set utxo p2pkh address:
-                        memcpy_safe(utxo->address, p2pkh_from_script_pubkey, P2PKH_ADDR_STRINGLEN);
+                        memcpy_safe(utxo->address, p2pkh_from_script_pubkey, P2PKHLEN);
                         // set amount of utxo:
                         koinu_to_coins_str(tx_out->value, utxo->amount);
                         // finally add utxo to rbtree:
@@ -888,7 +885,7 @@ void dogecoin_wallet_set_master_key_copy(dogecoin_wallet* wallet, const dogecoin
     wallet->masterkey = dogecoin_hdnode_copy(master_xpub);
 
     cstring* record = cstr_new_sz(256);
-    char strbuf[196];
+    char strbuf[HDKEYLEN];
     dogecoin_hdnode_serialize_public(wallet->masterkey, wallet->chain, strbuf, sizeof(strbuf));
     ser_str(record, strbuf, sizeof(strbuf));
     ser_str(record, strbuf, sizeof(strbuf));
@@ -1016,7 +1013,7 @@ void dogecoin_wallet_get_addresses(dogecoin_wallet* wallet, vector* addr_out)
     for (i = 0; i < wallet->waddr_vector->len; i++) {
         dogecoin_wallet_addr *waddr = vector_idx(wallet->waddr_vector, i);
         if (!waddr->ignore) {
-            size_t addrsize = 35;
+            size_t addrsize = P2PKHLEN;
             char* addr = dogecoin_calloc(1, addrsize);
             dogecoin_p2pkh_addr_from_hash160(waddr->pubkeyhash, wallet->chain, addr, addrsize);
             vector_add(addr_out, addr);
@@ -1029,9 +1026,9 @@ dogecoin_wallet_addr* dogecoin_wallet_find_waddr_byaddr(dogecoin_wallet* wallet,
     if (!wallet || !search_addr)
         return NULL;
 
-    uint8_t hashdata[P2PKH_ADDR_STRINGLEN];
+    uint8_t hashdata[P2PKHLEN];
     dogecoin_mem_zero(hashdata, sizeof(uint160));
-    int outlen = dogecoin_base58_decode_check(search_addr, hashdata, P2PKH_ADDR_STRINGLEN);
+    int outlen = dogecoin_base58_decode_check(search_addr, hashdata, P2PKHLEN);
 
     if (outlen > 0 && hashdata[0] == wallet->chain->b58prefix_pubkey_address) {
 
@@ -1467,13 +1464,13 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
                         dogecoin_wallet_addr_free(waddr);
                         return false;
                     }
-                    char p2pkh_check[35];
+                    char p2pkh_check[P2PKHLEN];
                     dogecoin_wallet_addr_deserialize(waddr, wallet_new->chain, &cbuf);
-                    dogecoin_p2pkh_addr_from_hash160(waddr->pubkeyhash, wallet->chain, p2pkh_check, 35);
+                    dogecoin_p2pkh_addr_from_hash160(waddr->pubkeyhash, wallet->chain, p2pkh_check, P2PKHLEN);
                     if (memcmp(record->str, buf, record->len)==0) {
                         found = 1;
                     } else {
-                        const char* addr_match = find_needle(ptr, strlen(ptr), p2pkh_check, 35);
+                        const char* addr_match = find_needle(ptr, strlen(ptr), p2pkh_check, P2PKHLEN);
                         if (!addr_match) {
                             if (!dogecoin_p2pkh_address_to_wallet_pubkeyhash(p2pkh_check, waddr, wallet_new)) return false;
                         }
@@ -1490,9 +1487,9 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
                     // loop through existing wallet and omit wtx's with matching address:
                     unsigned int i = 0;
                     for (; i < wallet->waddr_vector->len; i++) {
-                        char p2pkh_check[35];
+                        char p2pkh_check[P2PKHLEN];
                         dogecoin_wallet_addr* addr_check = vector_idx(wallet->waddr_vector, i);
-                        dogecoin_p2pkh_addr_from_hash160(addr_check->pubkeyhash, wallet->chain, p2pkh_check, 35);
+                        dogecoin_p2pkh_addr_from_hash160(addr_check->pubkeyhash, wallet->chain, p2pkh_check, P2PKHLEN);
                         const char* match = find_needle(address, strlen(address), p2pkh_check, strlen(p2pkh_check));
                         if (!match) {
                             goto copy;

--- a/test/address_tests.c
+++ b/test/address_tests.c
@@ -18,10 +18,10 @@
 void test_address()
 {
     /* initialize testing variables for simple keypair gen */
-    char privkeywif_main[53];
-    char privkeywif_test[53];
-    char p2pkh_pubkey_main[35];
-    char p2pkh_pubkey_test[35];
+    char privkeywif_main[PRIVKEYWIFLEN];
+    char privkeywif_test[PRIVKEYWIFLEN];
+    char p2pkh_pubkey_main[P2PKHLEN];
+    char p2pkh_pubkey_test[P2PKHLEN];
     dogecoin_mem_zero(privkeywif_main, sizeof(privkeywif_main));
     dogecoin_mem_zero(privkeywif_test, sizeof(privkeywif_test));
     // test generation ability
@@ -51,8 +51,8 @@ void test_address()
     u_assert_int_eq(verifyP2pkhAddress(p2pkh_pubkey_test, strlen(p2pkh_pubkey_test)), true);
 
     /* initialize testing variables for hd keypair gen */
-    size_t masterkeylen = 200;
-    size_t pubkeylen = 35;
+    size_t masterkeylen = HDKEYLEN;
+    size_t pubkeylen = P2PKHLEN;
 
     char* masterkey_main = dogecoin_char_vla(masterkeylen);
     char* masterkey_test=dogecoin_char_vla(masterkeylen);

--- a/test/bip32_tests.c
+++ b/test/bip32_tests.c
@@ -15,7 +15,7 @@
 void test_bip32()
 {
     dogecoin_hdnode node, node2, node3, node4;
-    char str[112];
+    char str[HDKEYLEN];
     int r;
     uint8_t private_key_master[32];
     uint8_t chain_code_master[32];

--- a/test/key_tests.c
+++ b/test/key_tests.c
@@ -79,10 +79,10 @@ void test_key()
     assert(dogecoin_privkey_is_valid(&key_wif) == 0);
     dogecoin_privkey_gen(&key_wif);
     assert(dogecoin_privkey_is_valid(&key_wif) == 1);
-    char wifstr[100];
-    size_t wiflen = 100;
+    char wifstr[PRIVKEYWIFLEN];
+    size_t wiflen = PRIVKEYWIFLEN;
     dogecoin_privkey_encode_wif(&key_wif, &dogecoin_chainparams_main, wifstr, &wiflen);
-    wiflen = 100;
+    wiflen = PRIVKEYWIFLEN;
     dogecoin_key key_wif_decode;
     dogecoin_privkey_decode_wif(wifstr, &dogecoin_chainparams_main, &key_wif_decode);
     u_assert_mem_eq(key_wif_decode.privkey, key_wif.privkey, sizeof(key_wif_decode.privkey));

--- a/test/tool_tests.c
+++ b/test/tool_tests.c
@@ -15,14 +15,14 @@
 
 void test_tool()
 {
-    char addr[100];
+    char addr[P2PKHLEN];
     u_assert_int_eq(addresses_from_pubkey(&dogecoin_chainparams_main, "039ca1fdedbe160cb7b14df2a798c8fed41ad4ed30b06a85ad23e03abe43c413b2", addr), true);
     u_assert_str_eq(addr, "DTwqVfB7tbwca2PzwBvPV1g1xDB2YPrCYh");
 
     u_assert_true(getAddressFromPubkey("039ca1fdedbe160cb7b14df2a798c8fed41ad4ed30b06a85ad23e03abe43c413b2", false, addr));
     u_assert_str_eq(addr, "DTwqVfB7tbwca2PzwBvPV1g1xDB2YPrCYh");
 
-    size_t pubkeylen = 100;
+    size_t pubkeylen = PUBKEYHEXLEN;
     char* pubkey=dogecoin_char_vla(pubkeylen);
     u_assert_int_eq(pubkey_from_privatekey(&dogecoin_chainparams_main, "QUaohmokNWroj71dRtmPSses5eRw5SGLKsYSRSVisJHyZdxhdDCZ", pubkey, &pubkeylen), true);
     u_assert_str_eq(pubkey, "024c33fbb2f6accde1db907e88ebf5dd1693e31433c62aaeef42f7640974f602ba");
@@ -33,9 +33,9 @@ void test_tool()
 
     free(pubkey);
 
-    size_t privkeywiflen = 100;
+    size_t privkeywiflen = PRIVKEYWIFLEN;
     char* privkeywif=dogecoin_char_vla(privkeywiflen);
-    char privkeyhex[100];
+    char privkeyhex[PRIVKEYHEXLEN];
     u_assert_int_eq(gen_privatekey(&dogecoin_chainparams_main, privkeywif, privkeywiflen, NULL), true);
     u_assert_int_eq(gen_privatekey(&dogecoin_chainparams_main, privkeywif, privkeywiflen, privkeyhex), true);
 
@@ -53,14 +53,14 @@ void test_tool()
     free(privkey_data);
     free(privkeywif);
 
-    size_t masterkeysize = 200;
+    size_t masterkeysize = HDKEYLEN;
     char* masterkey=dogecoin_char_vla(masterkeysize);
     u_assert_int_eq(hd_gen_master(&dogecoin_chainparams_main, masterkey, masterkeysize), true);
     u_assert_int_eq(hd_print_node(&dogecoin_chainparams_main, masterkey), true);
 
     genHDMaster(false, masterkey, masterkeysize);
 
-    size_t extoutsize = 200;
+    size_t extoutsize = HDKEYLEN;
     char* extout=dogecoin_char_vla(extoutsize);
     const char* privkey = "dgpv557t1z21sLCnAz3cJPW5DiVErXdAi7iWpSJwBBaeN87umwje8LuTKREPTYPTNGXGnB3oNd2z6RmFFDU99WKbiRDJKKXfHxf48puZibauJYB";
     debug_print("\nMaster private key:  %s\n", privkey);

--- a/test/tpm_tests.c
+++ b/test/tpm_tests.c
@@ -110,7 +110,7 @@ void test_tpm()
     debug_print("Mnemonic: %s\n", mnemonic);
 
     // test getDerivedHDAddressFromEncryptedSeed
-    char derived_address[35];
+    char derived_address[P2PKHLEN];
     u_assert_true (getDerivedHDAddressFromEncryptedSeed(0, 0, BIP44_CHANGE_EXTERNAL, derived_address, false, TEST_FILE) == 0);
     debug_print("Derived address: %s\n", derived_address);
 

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -245,7 +245,7 @@ void test_transaction()
 
     // prove internal p2pkh address was derived from public key hex:
 
-    char p2pkh_pubkey_internal[35];
+    char p2pkh_pubkey_internal[P2PKHLEN];
     dogecoin_pubkey pubkeytx;
     dogecoin_pubkey_init(&pubkeytx);
     pubkeytx.compressed = true;
@@ -431,7 +431,7 @@ void test_transaction()
     // test conversion from p2pkh to script hash and back
 
     char* res = dogecoin_malloc(40 + 6 + 4 + 1);
-    char p2pkh_address[PUBKEYLEN];
+    char p2pkh_address[P2PKHLEN];
     u_assert_int_eq(dogecoin_p2pkh_address_to_pubkey_hash(internal_p2pkh_address, res), 1);
     u_assert_str_eq(res, utxo_scriptpubkey);
 

--- a/test/tx_tests.c
+++ b/test/tx_tests.c
@@ -832,15 +832,15 @@ void test_tx_sighash_ext()
         uint8_t* script_data=dogecoin_uint8_vla(strlen(txvalid_sighash[i].script) / 2);
         utils_hex_to_bin(txvalid_sighash[i].script, script_data, strlen(txvalid_sighash[i].script), &outlen_sighash);
         cstring* str = cstr_new_buf(script_data, outlen_sighash);
-        
+
         free(script_data);
-        
+
         uint256 hash;
         dogecoin_tx_sighash(tx_sighash, str, txvalid_sighash[i].i, SIGHASH_ALL, hash);
 
         dogecoin_tx_free(tx_sighash);
         cstr_free(str, true);
- 
+
         char sighash_hex[sizeof(hash) * 2 + 1];
         memset(sighash_hex, 0, sizeof(sighash_hex));
         utils_bin_to_hex(hash, sizeof(hash), sighash_hex);
@@ -866,9 +866,9 @@ void test_tx_sighash()
         uint8_t* script_data=dogecoin_uint8_vla(strlen(test->script) / 2);
         utils_hex_to_bin(test->script, script_data, strlen(test->script), &outlen);
         cstring* script = cstr_new_buf(script_data, outlen);
-        
+
         free(script_data);
-        
+
         uint256 sighash;
         dogecoin_mem_zero(sighash, sizeof(sighash));
         dogecoin_tx_sighash(tx, script, test->inputindex, test->hashtype, sighash);
@@ -1034,7 +1034,7 @@ void test_script_parse()
     u_assert_str_eq(hexbuf2, "01000000000200ca9a3b000000001976a91457b78cc8347175aee968eaa91846e840ef36ff9288ac4e61bc00000000001976a914dcba7ad8b58f35ea9a7ffa2102dcfb2612b6ba9088ac00000000");
 
     free(hexbuf2);
-    
+
     dogecoin_tx_hash(tx, txhash);
     utils_bin_to_hex((unsigned char*)txhash, sizeof(txhash), txhashhex);
     utils_reverse_hex(txhashhex, 64);
@@ -1052,7 +1052,7 @@ void test_script_parse()
     u_assert_str_eq(hexbuf3, "01000000000300ca9a3b000000001976a91457b78cc8347175aee968eaa91846e840ef36ff9288ac4e61bc00000000001976a914dcba7ad8b58f35ea9a7ffa2102dcfb2612b6ba9088aceafc3e340000000017a914f763f798ede75a6ebf4e061b9e68ddb6df0442928700000000");
 
     free(hexbuf3);
-    
+
     cstr_free(txser, true);
 
     dogecoin_tx_add_address_out(tx, &dogecoin_chainparams_regtest, 100000000, "dcrt1qfupfj4yx83dz8vhcpcahhxyg4sfqr8pvx8l6l2");
@@ -1063,13 +1063,13 @@ void test_script_parse()
     u_assert_str_eq(hexbuf4, "01000000000300ca9a3b000000001976a91457b78cc8347175aee968eaa91846e840ef36ff9288ac4e61bc00000000001976a914dcba7ad8b58f35ea9a7ffa2102dcfb2612b6ba9088aceafc3e340000000017a914f763f798ede75a6ebf4e061b9e68ddb6df0442928700000000");
     cstr_free(txser, true);
     free(hexbuf4);
-    
+
 
     vector_free(pubkeys, true);
     dogecoin_tx_free(tx);
 
     // op_return test
-    char masterkey[200];
+    char masterkey[HDKEYLEN];
     u_assert_int_eq(hd_gen_master(&dogecoin_chainparams_main, masterkey, sizeof(masterkey)), true);
 
     dogecoin_hdnode node;
@@ -1108,7 +1108,7 @@ void test_script_parse()
     // TODO: test
     cstr_free(txser, true);
     free(hexbuf5);
-    
+
     dogecoin_tx_free(tx);
 }
 
@@ -1192,7 +1192,7 @@ void test_tx_sign_p2pkh(dogecoin_tx* tx)
     u_assert_mem_eq(sigder, expected_sigder_data, sigder_len);
 
     free(expected_sigder_data);
-    
+
     cstring* tx_ser = cstr_new_sz(1024);
     dogecoin_tx_serialize(tx_ser, tx);
 
@@ -1219,9 +1219,9 @@ void test_tx_sign_p2pkh_i2(dogecoin_tx* tx)
     size_t outlen;
     uint8_t* tx_data=dogecoin_uint8_vla(strlen(tx_hex) / 2);
     utils_hex_to_bin(tx_hex, tx_data, strlen(tx_hex), &outlen);
-    
+
     free(tx_data);
-    
+
     uint8_t* script_data=dogecoin_uint8_vla(strlen(script_hex_correct) / 2);
     utils_hex_to_bin(script_hex_correct, script_data, strlen(script_hex_correct), &outlen);
     cstring* script = cstr_new_buf(script_data, outlen);
@@ -1251,7 +1251,7 @@ void test_tx_sign_p2pkh_i2(dogecoin_tx* tx)
     u_assert_int_eq(res, DOGECOIN_SIGN_OK);
     //u_assert_mem_eq(sigcomp, expected_sigcomp_data, 64);
     u_assert_mem_eq(sigder, expected_sigder_data, sigder_len);
-    
+
     free(expected_sigder_data);
 
     cstring* tx_ser = cstr_new_sz(1024);
@@ -1260,10 +1260,10 @@ void test_tx_sign_p2pkh_i2(dogecoin_tx* tx)
     char* hexbuf=dogecoin_char_vla(tx_ser->len * 2 + 1);
     utils_bin_to_hex((unsigned char*)tx_ser->str, tx_ser->len, hexbuf);
     u_assert_str_eq(hexbuf, expected_tx_signed);
-    
+
     free(expected_tx_signed_data);
     free(hexbuf);
-    
+
     cstr_free(tx_ser, true);
     cstr_free(script, true);
     cstr_free(script_wrong, true);

--- a/test/wallet_tests.c
+++ b/test/wallet_tests.c
@@ -225,8 +225,8 @@ void test_wallet_basics()
     vector_free(addrs, true);
 
     dogecoin_wallet_addr *waddr_search = dogecoin_wallet_find_waddr_byaddr(wallet, "DMTbb3NbwAdimWDMVabwip7FjPAVx6Qeq4");
-    char tmp_p2pkh[35];
-    dogecoin_p2pkh_addr_from_hash160(waddr_search->pubkeyhash, &dogecoin_chainparams_main, tmp_p2pkh, 35);
+    char tmp_p2pkh[P2PKHLEN];
+    dogecoin_p2pkh_addr_from_hash160(waddr_search->pubkeyhash, &dogecoin_chainparams_main, tmp_p2pkh, P2PKHLEN);
     u_assert_str_eq(tmp_p2pkh, "DMTbb3NbwAdimWDMVabwip7FjPAVx6Qeq4");
     waddr_search = dogecoin_wallet_find_waddr_byaddr(wallet, "dcrt1qre2XXXXXXXXXXXXXXXXXXXXX"); // must return NULL
     u_assert_is_null(waddr_search);


### PR DESCRIPTION
PUBKEYLEN to P2PKHLEN (for addresses)
wif_master_privkey to hd_master_privkey (for b58-encoded private keys) 35, 53, 100, 112, 128, 200 magic numbers to constants HD_MASTERKEY_STRINGLEN to HDKEYLEN
P2PKH_ADDR_STRINGLEN to P2PKHLEN
WIF_UNCOMPRESSED_PRIVKEY_STRINGLEN to PRIVKEYWIFLEN

tool: added PRIVKEYHEXLEN for ecc private key (in hex), updated gen_privatekey and genPrivkey
address: updated generateHDMasterPubKeypair, hd_privkey_master local to hd_privkey_master_local
wallet: removed ifdef from dogecoin_wallet_init, SEED type is visible