### PR TITLE
wallet: free waddrs in dogecoin_wallet_init

### DIFF
--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -150,6 +150,7 @@ LIBDOGECOIN_API void dogecoin_wallet_set_master_key_copy(dogecoin_wallet* wallet
 LIBDOGECOIN_API dogecoin_wallet_addr* dogecoin_wallet_next_addr(dogecoin_wallet* wallet);
 LIBDOGECOIN_API dogecoin_wallet_addr* dogecoin_wallet_next_bip44_addr(dogecoin_wallet* wallet);
 LIBDOGECOIN_API dogecoin_bool dogecoin_p2pkh_address_to_wallet_pubkeyhash(const char* address_in, dogecoin_wallet_addr* addr, dogecoin_wallet* wallet);
+LIBDOGECOIN_API dogecoin_wallet_addr* dogecoin_p2pkh_address_to_wallet(const char* address_in, dogecoin_wallet* wallet);
 
 /** writes all available addresses (P2PKH) to the addr_out vector */
 LIBDOGECOIN_API void dogecoin_wallet_get_addresses(dogecoin_wallet* wallet, vector* addr_out);


### PR DESCRIPTION
-this pr removes 4 memleaks detected in `dogecoin_wallet_init` when passing in watch addresses. since we store the `waddr` in the `wallet->waddr_vector` we really just need to dispose of the `waddr` object being passed back during wallet init. this is also why `dogecoin_p2pkh_addr_from_hash160` was removed since it's unnecessary.