### PR TITLE
build instructions on windows should target shared libs (.dlls)

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -96,7 +96,7 @@ On Windows, you will need to run the following commands in the Visual Studio Dev
 ```c
 mkdir build
 cd build
-cmake ..
+cmake -DBUILD_SHARED_LIBS=ON ..
 cmake --build .
 Debug\tests.exe
 ```


### PR DESCRIPTION
-DBUILD_SHARED_LIBS=ON should probably be included in the windows build instructions. 