### PR TITLE
fix DragonFlyBSD 6.4-RELEASE support

### DIFF
--- a/include/dogecoin/portable_endian.h
+++ b/include/dogecoin/portable_endian.h
@@ -52,7 +52,7 @@ LIBDOGECOIN_BEGIN_DECL
 
 #include <sys/endian.h>
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#elif defined(__NetBSD__) || defined(__FreeBSD__)
 
 #include <sys/endian.h>
 
@@ -64,6 +64,10 @@ LIBDOGECOIN_BEGIN_DECL
 
 #define be64toh(x) betoh64(x)
 #define le64toh(x) letoh64(x)
+
+#elif defined(__DragonFly__)
+
+#include <sys/endian.h>
 
 #elif defined(__WINDOWS__)
 

--- a/include/dogecoin/scrypt.h
+++ b/include/dogecoin/scrypt.h
@@ -23,6 +23,9 @@ extern void (*scrypt_1024_1_1_256_sp_detected)(const char *input, char *output, 
 #define scrypt_1024_1_1_256_sp(input, output, scratchpad) scrypt_1024_1_1_256_sp_generic((input), (output), (scratchpad))
 #endif
 
+#ifdef __DragonFly__
+#include <sys/endian.h>
+#else
 static inline uint32_t le32dec(const void *pp)
 {
         const uint8_t *p = (uint8_t const *)pp;
@@ -38,4 +41,5 @@ static inline void le32enc(void *pp, uint32_t x)
         p[2] = (x >> 16) & 0xff;
         p[3] = (x >> 24) & 0xff;
 }
+#endif
 #endif

--- a/src/scrypt.c
+++ b/src/scrypt.c
@@ -52,6 +52,7 @@
   #define INLINE inline
 #endif
 
+#ifndef __DragonFly__
 static INLINE uint32_t
 be32dec(const void *pp)
 {
@@ -71,6 +72,7 @@ be32enc(void *pp, uint32_t x)
 	p[1] = (x >> 16) & 0xff;
 	p[0] = (x >> 24) & 0xff;
 }
+#endif
 
 #define ROTL(a, b) (((a) << (b)) | ((a) >> (32 - (b))))
 


### PR DESCRIPTION
it has endianness-related functions named the same