### PR TITLE
qa: lower amount of headers we sync in spv_tests

### DIFF
--- a/test/spv_tests.c
+++ b/test/spv_tests.c
@@ -45,10 +45,12 @@ void test_spv_sync_completed(dogecoin_spv_client* client) {
 }
 
 dogecoin_bool test_spv_header_message_processed(struct dogecoin_spv_client_ *client, dogecoin_node *node, dogecoin_blockindex *newtip) {
-    UNUSED(client);
     UNUSED(node);
     if (newtip) {
         printf("New headers tip height %d\n", newtip->height);
+        if (newtip->height >= 4008284) {
+            test_spv_sync_completed(client);
+        }
     }
     return true;
 }


### PR DESCRIPTION
-expedite ci testing by lowering amount of headers synced to 32,000. this accounts for 16,000 non auxpow headers and 16,000 auxpow headers.