### PR TITLE
bip39: added fclose to error conditions

### DIFF
--- a/src/bip39.c
+++ b/src/bip39.c
@@ -480,11 +480,13 @@ int get_custom_words(const char *filepath, char* wordlist[]) {
     while (fscanf(fp, "%s", word) == 1) {
         if (i >= LANG_WORD_CNT) {
             fprintf(stderr, "ERROR: too many words in file\n");
+            fclose(fp);
             return -1;
         }
         wordlist[i] = malloc(strlen(word) + 1);
         if (wordlist[i] == NULL) {
             fprintf(stderr, "ERROR: cannot allocate memory\n");
+            fclose(fp);
             return -1;
         }
         strcpy(wordlist[i], word);

--- a/src/seal.c
+++ b/src/seal.c
@@ -524,12 +524,14 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw(const SEED seed, con
     if (password == NULL)
     {
         fprintf(stderr, "ERROR: Failed to read password.\n");
+        fclose(fp);
         return false;
     }
     if (strlen(password) == 0)
     {
         fprintf(stderr, "ERROR: Password cannot be empty.\n");
         dogecoin_free(password);
+        fclose(fp);
         return false;
     }
 
@@ -548,6 +550,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw(const SEED seed, con
     {
         fprintf(stderr, "ERROR: Failed to read password.\n");
         dogecoin_free(password);
+        fclose(fp);
         return false;
     }
     if (strcmp(password, confirm_password) != 0)
@@ -557,6 +560,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw(const SEED seed, con
         dogecoin_mem_zero(confirm_password, strlen(confirm_password));
         dogecoin_free(password);
         dogecoin_free(confirm_password);
+        fclose(fp);
         return false;
     }
     // Clear the confirm password
@@ -571,6 +575,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw(const SEED seed, con
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
         dogecoin_mem_zero(password, strlen(password));
         dogecoin_free(password);
+        fclose(fp);
         return false;
     }
 
@@ -595,6 +600,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw(const SEED seed, con
     if (!dogecoin_random_bytes(iv, sizeof(iv), 1))
     {
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
+        fclose(fp);
         return false;
     }
 
@@ -605,6 +611,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw(const SEED seed, con
     if (!encrypted_seed)
     {
         fprintf(stderr, "ERROR: Memory allocation failed.\n");
+        fclose(fp);
         return false;
     }
 
@@ -613,6 +620,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw(const SEED seed, con
     {
         fprintf(stderr, "ERROR: AES encryption failed.\n");
         dogecoin_free(encrypted_seed);
+        fclose(fp);
         return false;
     }
 
@@ -1238,12 +1246,14 @@ dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_hdnode* out, con
     if (password == NULL)
     {
         fprintf(stderr, "ERROR: Failed to read password.\n");
+        fclose(fp);
         return false;
     }
     if (strlen(password) == 0)
     {
         fprintf(stderr, "ERROR: Password cannot be empty.\n");
         dogecoin_free(password);
+        fclose(fp);
         return false;
     }
 
@@ -1263,6 +1273,7 @@ dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_hdnode* out, con
     {
         fprintf(stderr, "ERROR: Failed to read password.\n");
         dogecoin_free(password);
+        fclose(fp);
         return false;
     }
     if (strcmp(password, confirm_password) != 0)
@@ -1272,6 +1283,7 @@ dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_hdnode* out, con
         dogecoin_mem_zero(confirm_password, strlen(confirm_password));
         dogecoin_free(password);
         dogecoin_free(confirm_password);
+        fclose(fp);
         return false;
     }
     dogecoin_mem_zero(confirm_password, strlen(confirm_password));
@@ -1285,6 +1297,7 @@ dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_hdnode* out, con
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
         dogecoin_mem_zero(password, strlen(password));
         dogecoin_free(password);
+        fclose(fp);
         return false;
     }
 
@@ -1309,6 +1322,7 @@ dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_hdnode* out, con
     if (!dogecoin_random_bytes(iv, sizeof(iv), 1))
     {
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
+        fclose(fp);
         return false;
     }
 
@@ -1317,6 +1331,7 @@ dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_hdnode* out, con
     if (!dogecoin_random_bytes(seed, sizeof(seed), 1))
     {
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
+        fclose(fp);
         return false;
     }
     dogecoin_hdnode_from_seed(seed, sizeof(seed), out);
@@ -1328,6 +1343,7 @@ dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_hdnode* out, con
     if (!encrypted_data)
     {
         fprintf(stderr, "ERROR: Memory allocation failed.\n");
+        fclose(fp);
         return false;
     }
 
@@ -1336,6 +1352,7 @@ dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_hdnode* out, con
     {
         fprintf(stderr, "ERROR: AES encryption failed.\n");
         dogecoin_free(encrypted_data);
+        fclose(fp);
         return false;
     }
 
@@ -1972,12 +1989,14 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
     if (password == NULL)
     {
         fprintf(stderr, "ERROR: Failed to read password.\n");
+        fclose(fp);
         return false;
     }
     if (strlen(password) == 0)
     {
         fprintf(stderr, "ERROR: Password cannot be empty.\n");
         dogecoin_free(password);
+        fclose(fp);
         return false;
     }
 
@@ -1996,6 +2015,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
     {
         fprintf(stderr, "ERROR: Failed to read password.\n");
         dogecoin_free(password);
+        fclose(fp);
         return false;
     }
     if (strcmp(password, confirm_password) != 0)
@@ -2005,6 +2025,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
         dogecoin_mem_zero(confirm_password, strlen(confirm_password));
         dogecoin_free(password);
         dogecoin_free(confirm_password);
+        fclose(fp);
         return false;
     }
     dogecoin_mem_zero(confirm_password, strlen(confirm_password));
@@ -2018,6 +2039,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
         dogecoin_mem_zero(password, strlen(password));
         dogecoin_free(password);
+        fclose(fp);
         return false;
     }
 
@@ -2043,6 +2065,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
     if (mnemonicResult == -1)
     {
         fprintf(stderr, "ERROR: Failed to generate mnemonic\n");
+        fclose(fp);
         return false;
     }
 
@@ -2051,6 +2074,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
     if (!dogecoin_random_bytes(iv, sizeof(iv), 1))
     {
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
+        fclose(fp);
         return false;
     }
 
@@ -2060,6 +2084,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
     if (!encrypted_data)
     {
         fprintf(stderr, "ERROR: Memory allocation failed.\n");
+        fclose(fp);
         return false;
     }
     memset(encrypted_data, 0, encrypted_size);
@@ -2069,6 +2094,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
     {
         fprintf(stderr, "ERROR: AES encryption failed.\n");
         dogecoin_free(encrypted_data);
+        fclose(fp);
         return false;
     }
 


### PR DESCRIPTION
Added `fclose(fp)` to error conditions in `src/bip39.c` and `src/seal.c`.