### PR TITLE
cmake: added build type for msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ IF(WITH_NET)
             -DEVENT__DISABLE_REGRESS=ON
             -DEVENT__DISABLE_BENCHMARK=ON
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/libevent/build)
-        execute_process(COMMAND cmake --build .
+        execute_process(COMMAND cmake --build . --config ${CMAKE_BUILD_TYPE}
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/libevent/build)
         file(COPY "${PROJECT_SOURCE_DIR}/src/libevent/build/include" DESTINATION "${PROJECT_SOURCE_DIR}")
         file(COPY "${PROJECT_SOURCE_DIR}/src/libevent/include/event2" DESTINATION "${PROJECT_SOURCE_DIR}/include")

--- a/src/cli/tool.c
+++ b/src/cli/tool.c
@@ -92,7 +92,8 @@ dogecoin_bool pubkey_from_privatekey(const dogecoin_chainparams* chain, const ch
     dogecoin_pubkey_from_key(&key, &pubkey);
     assert(dogecoin_pubkey_is_valid(&pubkey) == 1);
     dogecoin_privkey_cleanse(&key);
-    assert (dogecoin_pubkey_get_hex(&pubkey, pubkey_hex, sizeout) == 1);
+    if (!dogecoin_pubkey_get_hex(&pubkey, pubkey_hex, sizeout))
+        return false;
     dogecoin_pubkey_cleanse(&pubkey);
     return true;
 }
@@ -117,7 +118,8 @@ dogecoin_bool gen_privatekey(const dogecoin_chainparams* chain, char* privkey_wi
     dogecoin_privkey_init(&key);
     dogecoin_privkey_gen(&key);
     memcpy_safe(&pkeybase58c[1], key.privkey, DOGECOIN_ECKEY_PKEY_LENGTH);
-    assert(dogecoin_base58_encode_check(pkeybase58c, 34, privkey_wif, strsize_wif) != 0);
+    if (dogecoin_base58_encode_check(pkeybase58c, 34, privkey_wif, strsize_wif) == 0)
+        return false;
     // also export the hex privkey if use had passed in a valid pointer
     // will always export 32 bytes
     if (privkey_hex_or_null != NULL)
@@ -177,7 +179,8 @@ dogecoin_bool hd_print_node(const dogecoin_chainparams* chain, const char* nodes
     pkeybase58c[33] = 1; /* always use compressed keys */
     char privkey_wif[PRIVKEYWIFLEN];
     memcpy_safe(&pkeybase58c[1], node.private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    assert(dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), privkey_wif, sizeof(privkey_wif)) != 0);
+    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), privkey_wif, sizeof(privkey_wif)) == 0)
+        return false;
     if (dogecoin_hdnode_has_privkey(&node)) {
         printf("privatekey WIF:      %s\n", privkey_wif);
     }

--- a/src/eckey.c
+++ b/src/eckey.c
@@ -22,7 +22,7 @@
  OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE.
- 
+
 */
 
 #include <assert.h>
@@ -36,8 +36,8 @@
 /**
  * @brief This function instantiates a new working eckey,
  * but does not add it to the hash table.
- * 
- * @return A pointer to the new working eckey. 
+ *
+ * @return A pointer to the new working eckey.
  */
 eckey* new_eckey(dogecoin_bool is_testnet) {
     eckey* key = (struct eckey*)dogecoin_calloc(1, sizeof *key);
@@ -54,7 +54,7 @@ eckey* new_eckey(dogecoin_bool is_testnet) {
     pkeybase58c[0] = chain->b58prefix_secret_address;
     pkeybase58c[33] = 1; /* always use compressed keys */
     memcpy_safe(&pkeybase58c[1], &key->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    assert(dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) != 0);
+    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) return false;
     if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) return false;
     key->idx = HASH_COUNT(keys) + 1;
     return key;
@@ -63,8 +63,8 @@ eckey* new_eckey(dogecoin_bool is_testnet) {
 /**
  * @brief This function instantiates a new working eckey,
  * but does not add it to the hash table.
- * 
- * @return A pointer to the new working eckey. 
+ *
+ * @return A pointer to the new working eckey.
  */
 eckey* new_eckey_from_privkey(char* private_key) {
     eckey* key = (struct eckey*)dogecoin_calloc(1, sizeof *key);
@@ -80,7 +80,7 @@ eckey* new_eckey_from_privkey(char* private_key) {
     pkeybase58c[0] = chain->b58prefix_secret_address;
     pkeybase58c[33] = 1; /* always use compressed keys */
     memcpy_safe(&pkeybase58c[1], &key->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    assert(dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) != 0);
+    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) return false;
     if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) return false;
     key->idx = HASH_COUNT(keys) + 1;
     return key;
@@ -89,9 +89,9 @@ eckey* new_eckey_from_privkey(char* private_key) {
 /**
  * @brief This function takes a pointer to an existing working
  * eckey object and adds it to the hash table.
- * 
+ *
  * @param key The pointer to the working eckey.
- * 
+ *
  * @return Nothing.
  */
 void add_eckey(eckey *key) {
@@ -108,9 +108,9 @@ void add_eckey(eckey *key) {
 /**
  * @brief This function takes an index and returns the working
  * eckey associated with that index in the hash table.
- * 
+ *
  * @param idx The index of the target working eckey.
- * 
+ *
  * @return The pointer to the working eckey associated with
  * the provided index.
  */
@@ -123,9 +123,9 @@ eckey* find_eckey(int idx) {
 /**
  * @brief This function removes the specified working eckey
  * from the hash table and frees the keys in memory.
- * 
+ *
  * @param key The pointer to the eckey to remove.
- * 
+ *
  * @return Nothing.
  */
 void remove_eckey(eckey* key) {
@@ -138,9 +138,9 @@ void remove_eckey(eckey* key) {
 /**
  * @brief This function frees the memory allocated
  * for an eckey.
- * 
+ *
  * @param eckey The pointer to the eckey to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_key_free(eckey* eckey)
@@ -152,9 +152,9 @@ void dogecoin_key_free(eckey* eckey)
  * @brief This function creates a new key, places it in
  * the hash table, and returns the index of the new key,
  * starting from 1 and incrementing each subsequent call.
- * 
+ *
  * @param is_testnet
- * 
+ *
  * @return The index of the new key.
  */
 int start_key(dogecoin_bool is_testnet) {

--- a/src/key.c
+++ b/src/key.c
@@ -93,7 +93,8 @@ void dogecoin_privkey_encode_wif(const dogecoin_key* privkey, const dogecoin_cha
     pkeybase58c[0] = chain->b58prefix_secret_address;
     pkeybase58c[33] = 1; /* always use compressed keys */
     memcpy_safe(&pkeybase58c[1], privkey->privkey, DOGECOIN_ECKEY_PKEY_LENGTH);
-    assert(dogecoin_base58_encode_check(pkeybase58c, 34, privkey_wif, *strsize_inout) != 0);
+    if (dogecoin_base58_encode_check(pkeybase58c, 34, privkey_wif, *strsize_inout) == 0)
+        *strsize_inout = 0;
     dogecoin_mem_zero(&pkeybase58c, 34);
 }
 

--- a/src/seal.c
+++ b/src/seal.c
@@ -910,6 +910,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_hdnode_encrypt_with_tpm(dogecoin
     TBS_HCONTEXT hContext = 0;
     TBS_CONTEXT_PARAMS2 params;
     params.version = TBS_CONTEXT_VERSION_TWO;
+    params.includeTpm20 = 1;
     TBS_RESULT hr = Tbsi_Context_Create((PCTBS_CONTEXT_PARAMS)&params, &hContext);
     if (hr != TBS_SUCCESS)
     {
@@ -1133,7 +1134,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_hdnode_with_tpm(dogecoin_hdnode* 
     }
 
     // Decrypt the encrypted data
-    status = NCryptDecrypt(hEncryptionKey, pbOutput, bytesRead, NULL, (PBYTE)out, (DWORD)cbResult, &cbResult, NCRYPT_PAD_PKCS1_FLAG);
+    status = NCryptDecrypt(hEncryptionKey, pbOutput, bytesRead, NULL, (PBYTE)out, sizeof(dogecoin_hdnode), &cbResult, NCRYPT_PAD_PKCS1_FLAG);
     if (status != ERROR_SUCCESS)
     {
         // Failed to decrypt the encrypted data
@@ -1576,6 +1577,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_tpm(MNEMON
     TBS_HCONTEXT hContext = 0;
     TBS_CONTEXT_PARAMS2 params;
     params.version = TBS_CONTEXT_VERSION_TWO;
+    params.includeTpm20 = 1;
     TBS_RESULT hr = Tbsi_Context_Create((PCTBS_CONTEXT_PARAMS)&params, &hContext);
     if (hr != TBS_SUCCESS)
     {

--- a/test/tpm_tests.c
+++ b/test/tpm_tests.c
@@ -89,6 +89,7 @@ void test_tpm()
     TBS_HCONTEXT hContext = 0;
     TBS_CONTEXT_PARAMS2 params;
     params.version = TBS_CONTEXT_VERSION_TWO;
+    params.includeTpm20 = 1;
     TBS_RESULT hr = Tbsi_Context_Create((PCTBS_CONTEXT_PARAMS)&params, &hContext);
     u_assert_uint32_eq (hr, TBS_SUCCESS);
 


### PR DESCRIPTION
Added `--config ${CMAKE_BUILD_TYPE}` to the `cmake --build` command to specify the build type for msvc.