### PR TITLE
add 'dogecoin_node_group_event_loopbreak(dogecoin_node_group)'

### DIFF
--- a/include/dogecoin/net.h
+++ b/include/dogecoin/net.h
@@ -140,6 +140,9 @@ LIBDOGECOIN_API void dogecoin_node_group_add_node(dogecoin_node_group* group, do
 /* start node groups event loop */
 LIBDOGECOIN_API void dogecoin_node_group_event_loop(dogecoin_node_group* group);
 
+/* stop the event loop */
+LIBDOGECOIN_API void dogecoin_node_group_event_loopbreak(dogecoin_node_group* group);
+
 /* connect to more nodes */
 LIBDOGECOIN_API dogecoin_bool dogecoin_node_group_connect_next_nodes(dogecoin_node_group* group);
 

--- a/src/net.c
+++ b/src/net.c
@@ -500,6 +500,16 @@ void dogecoin_node_group_event_loop(dogecoin_node_group* group)
 }
 
 /**
+ * Tells the event loop to stop.
+ *
+ * @param group The dogecoin_node_group object.
+ */
+void dogecoin_node_group_event_loopbreak(dogecoin_node_group* group)
+{
+    event_base_loopbreak(group->event_base);
+}
+
+/**
  * Adds a node to a node group
  * 
  * @param group The node group to add the node to.


### PR DESCRIPTION
i have the spv node event_loop `dogecoin_node_group_event_loop()` running on a separate thread but i've had issues getting the event_loop call to always return (exit) using just `dogecoin_node_group_shutdown()` (symptomatic of another issue?)

all the peers disconnect, but since the event_loop call doesn't always return, sometimes my thread hangs (and apparently you can't just kill threads now in dot-net...)

the new function `dogecoin_node_group_event_loopbreak()`  wraps `event_base_loopbreak()`, which makes the event_loop call return. 


### event_base_loopbreak

Abort the active [event_base_loop()](https://libevent.org/doc/event_8h.html#acd7da32086d1e37008e7c76c9ea54fc4) immediately.

[event_base_loop()](https://libevent.org/doc/event_8h.html#acd7da32086d1e37008e7c76c9ea54fc4) will abort the loop after the next event is completed; [event_base_loopbreak()](https://libevent.org/doc/event_8h.html#a28e0be91488e8a0ed57a582f3343eaf6) is typically invoked from this event's callback. This behavior is analogous to the "break;" statement.

Subsequent invocations of [event_base_loop()](https://libevent.org/doc/event_8h.html#acd7da32086d1e37008e7c76c9ea54fc4) will proceed normally.