### PR TITLE
net: added http server

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -233,11 +233,13 @@ fi
 
 if test "x$with_net" = xyes; then
   AC_CHECK_HEADER([event2/event.h],, AC_MSG_ERROR(libevent headers missing),)
-  AC_CHECK_LIB([event_core],[main],EVENT_LIBS=-levent_core,AC_MSG_ERROR(libevent_core missing))
+  AC_CHECK_LIB([event],[main],EVENT_LIBS=-levent,AC_MSG_ERROR(libevent missing))
+  AC_CHECK_LIB([event_core],[main],EVENT_CORE_LIBS=-levent_core,AC_MSG_ERROR(libevent_core missing))
+  AC_CHECK_LIB([event_extra],[main],EVENT_EXTRA_LIBS=-levent_extra,AC_MSG_ERROR(libevent_extra missing))
   if test "$host" = "mingw"; then
     AC_CHECK_LIB([event_pthreads],[main],EVENT_PTHREADS_LIBS=-levent_pthreads,AC_MSG_ERROR(libevent_pthreads missing))
   fi
-  LIBS="$LIBS $EVENT_LIBS $EVENT_PTHREADS_LIBS"
+  LIBS="$LIBS $EVENT_LIBS $EVENT_CORE_LIBS $EVENT_EXTRA_LIBS $EVENT_PTHREADS_LIBS"
 fi
 
 if test "x$with_logdb" = xyes; then
@@ -259,6 +261,8 @@ AC_CONFIG_FILES([Makefile libdogecoin.pc])
 AC_SUBST(LIBTOOL_APP_LDFLAGS)
 AC_SUBST(BUILD_EXEEXT)
 AC_SUBST(EVENT_LIBS)
+AC_SUBST(EVENT_CORE_LIBS)
+AC_SUBST(EVENT_EXTRA_LIBS)
 AC_SUBST(EVENT_PTHREADS_LIBS)
 AC_SUBST(LIBUNISTRING)
 AC_SUBST(NASMFLAGS)

--- a/include/dogecoin/net.h
+++ b/include/dogecoin/net.h
@@ -60,6 +60,7 @@ typedef struct dogecoin_node_group_ {
     char clientstr[1024];
     int desired_amount_connected_nodes;
     const dogecoin_chainparams* chainparams;
+    struct evhttp* http_server; /* HTTP server for processing API requests */
 
     /* callbacks */
     int (*log_write_cb)(const char* format, ...); /* log callback, default=printf */
@@ -102,6 +103,17 @@ typedef struct dogecoin_node_ {
 
     uint32_t hints; /* can be use for user defined state */
 } dogecoin_node;
+
+/* =================================== */
+/* HTTP SERVER */
+/* =================================== */
+
+LIBDOGECOIN_API void dogecoin_http_server_init(dogecoin_node_group* group, const char* bindaddr, int port);
+LIBDOGECOIN_API void dogecoin_http_server_shutdown(dogecoin_node_group* group);
+
+/* =================================== */
+/* LOGGING */
+/* =================================== */
 
 LIBDOGECOIN_API int net_write_log_printf(const char* format, ...);
 LIBDOGECOIN_API int net_write_log_null(const char* format, ...);

--- a/include/dogecoin/spv.h
+++ b/include/dogecoin/spv.h
@@ -64,7 +64,7 @@ typedef struct dogecoin_spv_client_
     void *sync_transaction_ctx;
 } dogecoin_spv_client;
 
-LIBDOGECOIN_API dogecoin_spv_client* dogecoin_spv_client_new(const dogecoin_chainparams *params, dogecoin_bool debug, dogecoin_bool headers_memonly, dogecoin_bool use_checkpoints, dogecoin_bool full_sync, int maxnodes);
+LIBDOGECOIN_API dogecoin_spv_client* dogecoin_spv_client_new(const dogecoin_chainparams *params, dogecoin_bool debug, dogecoin_bool headers_memonly, dogecoin_bool use_checkpoints, dogecoin_bool full_sync, int maxnodes, const char *http_server);
 LIBDOGECOIN_API void dogecoin_spv_client_free(dogecoin_spv_client *client);
 LIBDOGECOIN_API dogecoin_bool dogecoin_spv_client_load(dogecoin_spv_client *client, const char *file_path, dogecoin_bool prompt);
 LIBDOGECOIN_API void dogecoin_spv_client_discover_peers(dogecoin_spv_client *client, const char *ips);

--- a/src/spv.c
+++ b/src/spv.c
@@ -114,10 +114,14 @@ void dogecoin_net_set_spv(dogecoin_node_group *nodegroup)
  * @param params The chainparams struct that we created earlier.
  * @param debug If true, the node will print out debug messages to stdout.
  * @param headers_memonly If true, the headers database will not be loaded from disk.
+ * @param use_checkpoints If true, the client will use checkpoints.
+ * @param full_sync If true, the client will do a full sync.
+ * @param maxnodes The maximum amount of nodes that the client will connect to.
+ * @param http_server The IP and port for the HTTP server; if NULL, the HTTP server will not be initialized.
  *
  * @return A pointer to a dogecoin_spv_client object.
  */
-dogecoin_spv_client* dogecoin_spv_client_new(const dogecoin_chainparams *params, dogecoin_bool debug, dogecoin_bool headers_memonly, dogecoin_bool use_checkpoints, dogecoin_bool full_sync, int maxnodes)
+dogecoin_spv_client* dogecoin_spv_client_new(const dogecoin_chainparams *params, dogecoin_bool debug, dogecoin_bool headers_memonly, dogecoin_bool use_checkpoints, dogecoin_bool full_sync, int maxnodes, const char* http_server)
 {
     dogecoin_spv_client* client;
     client = dogecoin_calloc(1, sizeof(*client));
@@ -154,6 +158,18 @@ dogecoin_spv_client* dogecoin_spv_client_new(const dogecoin_chainparams *params,
     client->sync_completed = NULL;
     client->header_message_processed = NULL;
     client->sync_transaction = NULL;
+
+    if (http_server) {
+        // split ip and port
+        char* http_server_copy = strdup(http_server);
+        char* ip = strtok(http_server_copy, ":");
+        char* port = strtok(NULL, ":");
+
+        // HTTP server initialization
+        dogecoin_http_server_init(client->nodegroup, ip, atoi(port));
+        client->nodegroup->log_write_cb("HTTP server initialized\n");
+        free(http_server_copy);
+    }
 
     return client;
 }

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -374,7 +374,7 @@ dogecoin_wallet* dogecoin_wallet_new(const dogecoin_chainparams *params)
     wallet->chain = params;
     set_wallet_filename(wallet, params);
     wallet->hdkeys_rbtree = 0;
-    wallet->utxos = utxos;
+    wallet->utxos = 0;
     wallet->unspent_rbtree = 0;
     wallet->spends_rbtree = 0;
     wallet->vec_wtxes = vector_new(10, (void (*)(void *)) dogecoin_wallet_wtx_free);
@@ -991,6 +991,8 @@ dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_pat
             }
         }
     }
+
+    wallet->utxos = utxos;
 
     return true;
 }

--- a/test/spv_tests.c
+++ b/test/spv_tests.c
@@ -72,7 +72,12 @@ void test_spv()
     unlink(headersfile);
 
     // init new spv client with debugging off and syncing to memory:
-    dogecoin_spv_client* client = dogecoin_spv_client_new(chain, false, true, true, false, 8);
+#ifndef __APPLE__
+    // due to TBD anomaly in ci environment, enable http server if not running Apple
+    dogecoin_spv_client* client = dogecoin_spv_client_new(chain, false, true, true, false, 8, "localhost:8888");
+#else
+    dogecoin_spv_client* client = dogecoin_spv_client_new(chain, false, true, true, false, 8, NULL);
+#endif
     client->header_message_processed = test_spv_header_message_processed;
     client->sync_completed = test_spv_sync_completed;
     dogecoin_spv_client_load(client, headersfile, false);
@@ -99,7 +104,7 @@ void test_reorg() {
     unlink(headersfile);
 
     // Initialize SPV client
-    dogecoin_spv_client* client = dogecoin_spv_client_new(chain, false, true, false, false, 8);
+    dogecoin_spv_client* client = dogecoin_spv_client_new(chain, false, true, false, false, 8, NULL);
     client->header_message_processed = test_spv_header_message_processed;
     client->sync_completed = test_spv_sync_completed;
     dogecoin_spv_client_load(client, headersfile, false);


### PR DESCRIPTION
Added HTTP server functionality to SPV node, enabling RESTful access to node and wallet data through endpoints like `/getBalance` and `/getChaintip`, along with a new command-line option `-u` for setting the server's IP and port.