### PR TITLE
ci: pin macos version to 12 instead of latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - x86_64-linux-dbg
           - x86_64-linux-openenclave
           - x86_64-macos
-          - arm64-macos
+          # - arm64-macos
           - x86_64-win
           - x86_64-win-native
           - i686-win
@@ -81,7 +81,7 @@ jobs:
             goal: install
           - name: x86_64-macos
             host: x86_64-apple-darwin15
-            os: macos-latest
+            os: macos-12
             run-tests: true
             dep-opts: "SPEED=slow V=1"
             config-opts: "--enable-static --disable-shared --enable-test-passwd"
@@ -90,17 +90,17 @@ jobs:
             mac-sdk: 12.2
             mac-sdk-build: 12B45b
             mac-sdk-shasum: "df75d30ecafc429e905134333aeae56ac65fac67cb4182622398fd717df77619"
-          - name: arm64-macos
-            host: arm64-apple-darwin
-            os: macos-13-xlarge
-            run-tests: true
-            dep-opts: "SPEED=slow V=1"
-            config-opts: "--enable-static --disable-shared --enable-test-passwd"
-            packages: cmake zlib xorriso libtool
-            goal: install
-            mac-sdk: 12.2
-            mac-sdk-build: 12B45b
-            mac-sdk-shasum: "df75d30ecafc429e905134333aeae56ac65fac67cb4182622398fd717df77619"
+          # - name: arm64-macos
+          #   host: arm64-apple-darwin
+          #   os: macos-13-xlarge
+          #   run-tests: true
+          #   dep-opts: "SPEED=slow V=1"
+          #   config-opts: "--enable-static --disable-shared --enable-test-passwd"
+          #   packages: cmake zlib xorriso libtool
+          #   goal: install
+          #   mac-sdk: 12.2
+          #   mac-sdk-build: 12B45b
+          #   mac-sdk-shasum: "df75d30ecafc429e905134333aeae56ac65fac67cb4182622398fd717df77619"
           - name: x86_64-win
             host: x86_64-w64-mingw32
             arch: i386


### PR DESCRIPTION
As of today, macos-latest runs on an M1, therefore downgrade and pin version to lowest version available which is macos-12:
```
macOS 	3 	14 GB 	14 GB 	macos-12 or macos-11 	The macos-11 label has been deprecated and will no longer be available after 6/28/2024.
macOS 	4 	14 GB 	14 GB 	macos-13 	N/A
macOS 	3 (M1) 	7 GB 	14 GB 	macos-latest or macos-14 	The macos-latest label currently uses the macOS 14 runner image. 
```
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners