### PR TITLE
config: add -levent_core to AC_CHECK_LIB for event_extra

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -234,7 +234,7 @@ fi
 if test "x$with_net" = xyes; then
   AC_CHECK_HEADER([event2/event.h],, AC_MSG_ERROR(libevent headers missing),)
   AC_CHECK_LIB([event],[main],EVENT_LIBS=-levent,AC_MSG_ERROR(libevent missing))
-  AC_CHECK_LIB([event_core],[main],EVENT_CORE_LIBS=-levent_core,AC_MSG_ERROR(libevent_core missing))
+  AC_CHECK_LIB([event_core],[main],EVENT_CORE_LIBS=-levent_core,AC_MSG_ERROR(libevent_core missing),[-levent_core])
   AC_CHECK_LIB([event_extra],[main],EVENT_EXTRA_LIBS=-levent_extra,AC_MSG_ERROR(libevent_extra missing))
   if test "$host" = "mingw"; then
     AC_CHECK_LIB([event_pthreads],[main],EVENT_PTHREADS_LIBS=-levent_pthreads,AC_MSG_ERROR(libevent_pthreads missing))


### PR DESCRIPTION
Added `-levent_core` to `AC_CHECK_LIB` for `event_extra` to fix NixOS builds. Since `libevent_extra` depends indirectly on `libevent_core`, we must explicitly link it because NixOS doesn't automatically resolve indirect dependencies like other distros.