### PR TITLE
depends: disable libunistring for mingw32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
               sudo update-alternatives --set x86_64-w64-mingw32-g++  /usr/bin/x86_64-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine
             dep-opts: "CROSS_COMPILE='yes' SPEED=slow V=1"
-            config-opts: "--enable-test-passwd"
+            config-opts: "--enable-test-passwd --disable-unistring"
             run-tests: true
           - name: x86_64-win-native
             host: x86_64-pc-windows-msvc
@@ -165,7 +165,7 @@ jobs:
               sudo update-alternatives --set i686-w64-mingw32-g++  /usr/bin/i686-w64-mingw32-g++-posix
               sudo update-binfmts --import /usr/share/binfmts/wine
             dep-opts: "CROSS_COMPILE='yes' SPEED=slow V=1"
-            config-opts: "--enable-test-passwd"
+            config-opts: "--enable-test-passwd --disable-unistring"
             run-tests: true
             goal: install
           - name: i686-linux

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -15,3 +15,7 @@ darwin_native_packages+= native_clang
 endif
 
 endif
+
+ifneq ($(host_os),mingw32)
+packages+=libunistring
+endif


### PR DESCRIPTION
Disabled `libunistring` for `mingw32` builds.  Windows provides its own unicode library that's currently used in `src\bip39.c`.