### PR TITLE
ci: updated runner to macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
             goal: install
           - name: x86_64-macos
             host: x86_64-apple-darwin15
-            os: macos-12
+            os: macos-13
             run-tests: true
             dep-opts: "SPEED=slow V=1"
             config-opts: "--enable-static --disable-shared --enable-test-passwd"


### PR DESCRIPTION
The macos-12 ci is deprecated, updated to macos-13.