### PR TITLE
ci: added depends options for enclave targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
             run-tests: true
             run-container: true
             packages: g++-aarch64-linux-gnu qemu-user-static qemu-user
-            dep-opts: "CROSS_COMPILE='yes' SPEED=slow V=1"
+            dep-opts: "CROSS_COMPILE='yes' SPEED=slow OPTEE=yes V=1"
             config-opts: "LIBS=-levent_pthreads --enable-static --disable-shared --enable-test-passwd --enable-optee CFLAGS=-U_FORTIFY_SOURCE"
             goal: install
           - name: aarch64-android
@@ -97,7 +97,7 @@ jobs:
             run-tests: true
             run-container: true
             packages: python3-dev python3-dbg python
-            dep-opts: "DEBUG=1 SPEED=slow V=1"
+            dep-opts: "DEBUG=1 SPEED=slow OE=yes V=1"
             config-opts: "--enable-openenclave --enable-test-passwd CFLAGS=-U_FORTIFY_SOURCE"
             goal: install
           - name: x86_64-macos

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -7,6 +7,8 @@ NO_QT ?=
 NO_WALLET ?=
 NO_UPNP ?=
 MULTIPROCESS ?=
+OPTEE ?=
+OE ?=
 FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
 
 BUILD = $(shell ./config.guess)

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=libevent libunistring libyubikey libusb ykpers
+packages:=libevent libunistring
 native_packages := native_ccache
 
 wallet_packages=
@@ -14,4 +14,12 @@ ifeq ($(strip $(FORCE_USE_SYSTEM_CLANG)),)
 darwin_native_packages+= native_clang
 endif
 
+endif
+
+ifneq ($(OPTEE),)
+packages+= libyubikey libusb ykpers
+endif
+
+ifneq ($(OE),)
+packages+= libyubikey libusb ykpers
 endif


### PR DESCRIPTION
Update ci to only build yubikey and libusb in `depends` for enclave targets. Merge after #223.