### PR TITLE
validation: check auxpow PoW before other checks

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -72,6 +72,13 @@ dogecoin_bool check(void *ctx, uint256_t* hash, uint32_t chainid, dogecoin_chain
     uint256_t* chain_merkle_root = check_merkle_branch(hash, chain_merkle_branch, block->aux_merkle_index);
     vector_free(chain_merkle_branch, true);
 
+    // Check that there is at least one input in the parent coinbase transaction
+    if (block->parent_coinbase->vin->len == 0) {
+        printf("Aux POW coinbase has no inputs\n");
+        dogecoin_free(chain_merkle_root);
+        return false;
+    }
+
     // Convert the root hash to a human-readable format (hex)
     unsigned char vch_roothash[64]; // Make sure it's large enough to hold the hash
     memcpy(vch_roothash, hash_to_string((uint8_t*)chain_merkle_root), 64); // Copy the data

--- a/src/libevent/CMakeLists.txt
+++ b/src/libevent/CMakeLists.txt
@@ -19,7 +19,7 @@
 #       start libevent.sln
 #
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 if (POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW)

--- a/src/validation.c
+++ b/src/validation.c
@@ -95,14 +95,6 @@ dogecoin_bool check_auxpow(dogecoin_auxpow_block* block, dogecoin_chainparams* p
     }
 
     /* We have auxpow.  Check it.  */
-    uint256_t block_header_hash;
-    dogecoin_block_header_hash(block->header, block_header_hash);
-    uint32_t chainid = get_chainid(block->header->version);
-    if (!block->header->auxpow->check(block, &block_header_hash, chainid, params)) {
-        printf("%s:%d:%s : AUX POW is not valid : %s\n", __FILE__, __LINE__, __func__, strerror(errno));
-        return false;
-    }
-
     uint256_t parent_hash;
     cstring* s2 = cstr_new_sz(64);
     dogecoin_block_header_serialize(s2, block->parent_header);
@@ -110,6 +102,14 @@ dogecoin_bool check_auxpow(dogecoin_auxpow_block* block, dogecoin_chainparams* p
     cstr_free(s2, true);
     if (!check_pow(&parent_hash, block->header->bits, params, chainwork)) {
         printf("%s:%d:%s : AUX proof of work failed: %s\n", __FILE__, __LINE__, __func__, strerror(errno));
+        return false;
+    }
+
+    uint256_t block_header_hash;
+    dogecoin_block_header_hash(block->header, block_header_hash);
+    uint32_t chainid = get_chainid(block->header->version);
+    if (!block->header->auxpow->check(block, &block_header_hash, chainid, params)) {
+        printf("%s:%d:%s : AUX POW is not valid : %s\n", __FILE__, __LINE__, __func__, strerror(errno));
         return false;
     }
 


### PR DESCRIPTION
Ports dogecoin/dogecoin@51cbc1f. Validates AuxPoW before other checks and ensures parent coinbase has an input. Merge after #229.