### PR TITLE
add _t suffix to uint256, uint160 and vector types

### DIFF
--- a/doc/signing.md
+++ b/doc/signing.md
@@ -22,7 +22,7 @@ This document describes the process of message signing within libdogecoin. It ai
 char* sign_message(char* privkey, char* msg) {
     if (!privkey || !msg) return false;
 
-    uint256 message_bytes;
+    uint256_t message_bytes;
     hash_message(msg, message_bytes);
 
     size_t compact_signature_length = 65;
@@ -66,7 +66,7 @@ char* sig = sign_message("QUtnMFjt3JFk1NfeMe6Dj5u4p25DHZA54FsvEFAiQxcNP4bZkPu2",
 int verify_message(char* sig, char* msg, char* address) {
     if (!(sig || msg || address)) return false;
 
-    uint256 message_bytes;
+    uint256_t message_bytes;
     hash_message(msg, message_bytes);
 
     size_t encoded_length = strlen((const char*)sig);

--- a/doc/transaction_extended.md
+++ b/doc/transaction_extended.md
@@ -16,8 +16,8 @@ The `dogecoin_tx` structure describes a dogecoin transaction in reply to getdata
 ```
 typedef struct dogecoin_tx_ {
     int32_t version;
-    vector* vin;
-    vector* vout;
+    vector_t* vin;
+    vector_t* vout;
     uint32_t locktime;
 } dogecoin_tx;
 ```
@@ -51,7 +51,7 @@ The `dogecoin_tx_outpoint` structure represented above as `prevout` consists of 
 `include/dogecoin/tx.h`:
 ```
 typedef struct dogecoin_tx_outpoint_ {
-    uint256 hash;
+    uint256_t hash;
     uint32_t n;
 } dogecoin_tx_outpoint;
 ```
@@ -88,7 +88,7 @@ OP_DUP OP_HASH160    Bytes to push
 ```
 ##### **Note: scriptSig is in the input of the spending transaction and scriptPubKey is in the output of the previously unspent i.e. "available" transaction.**
 
-Here is how each word is processed: 
+Here is how each word is processed:
 | Stack      | Script | Description |
 | ----------- | ----------- | - |
 | Empty | `<sig> <pubKey>` OP_DUP OP_HASH160 `<pubKeyHash>` OP_EQUALVERIFY OP_CHECKSIG | scriptSig and scriptPubKey are combined. |

--- a/include/dogecoin/arith_uint256.h
+++ b/include/dogecoin/arith_uint256.h
@@ -57,7 +57,7 @@ void arith_shift_left(arith_uint256* input, unsigned int shift);
 void arith_shift_right(arith_uint256* input, unsigned int shift);
 arith_uint256* set_compact(arith_uint256* hash, uint32_t compact, dogecoin_bool *pf_negative, dogecoin_bool *pf_overflow);
 uint8_t* arith_to_uint256(const arith_uint256* a);
-arith_uint256* uint_to_arith(const uint256* a);
+arith_uint256* uint_to_arith(const uint256_t* a);
 uint64_t get_low64(arith_uint256* a);
 arith_uint256* div_arith_uint256(arith_uint256* a, arith_uint256* b);
 arith_uint256* add_arith_uint256(arith_uint256* a, arith_uint256* b);

--- a/include/dogecoin/auxpow.h
+++ b/include/dogecoin/auxpow.h
@@ -44,7 +44,7 @@ LIBDOGECOIN_BEGIN_DECL
 static const unsigned char pch_merged_mining_header[] = { 0xfa, 0xbe, 'm', 'm' };
 
 int get_expected_index(uint32_t nNonce, int nChainId, unsigned h);
-uint256* check_merkle_branch(uint256* hash, const vector* merkle_branch, int index);
+uint256_t* check_merkle_branch(uint256_t* hash, const vector_t* merkle_branch, int index);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/base58.h
+++ b/include/dogecoin/base58.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2013-2014 Pavol Rusnak
  * Copyright (c) 2022 bluezr
  * Copyright (c) 2022 The Dogecoin Foundation
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
@@ -39,8 +39,8 @@ LIBDOGECOIN_API size_t dogecoin_base58_decode_check(const char* str, uint8_t* da
 LIBDOGECOIN_API int dogecoin_base58_encode(char* b58, size_t* b58sz, const void* data, size_t binsz);
 LIBDOGECOIN_API int dogecoin_base58_decode(void* bin, size_t* binszp, const char* b58, size_t b58sz);
 
-LIBDOGECOIN_API dogecoin_bool dogecoin_p2pkh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char* addrout, size_t len);
-LIBDOGECOIN_API dogecoin_bool dogecoin_p2sh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char* addrout, size_t len);
+LIBDOGECOIN_API dogecoin_bool dogecoin_p2pkh_addr_from_hash160(const uint160_t hashin, const dogecoin_chainparams* chain, char* addrout, size_t len);
+LIBDOGECOIN_API dogecoin_bool dogecoin_p2sh_addr_from_hash160(const uint160_t hashin, const dogecoin_chainparams* chain, char* addrout, size_t len);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/bip32.h
+++ b/include/dogecoin/bip32.h
@@ -60,7 +60,7 @@ LIBDOGECOIN_API void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* nod
 LIBDOGECOIN_API void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 
 /* gives out the raw sha256/ripemd160 hash */
-LIBDOGECOIN_API void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_out);
+LIBDOGECOIN_API void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160_t hash160_out);
 LIBDOGECOIN_API void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_get_pub_hex(const dogecoin_hdnode* node, char* str, size_t* strsize);
 LIBDOGECOIN_API dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const dogecoin_chainparams* chain, dogecoin_hdnode* node);

--- a/include/dogecoin/block.h
+++ b/include/dogecoin/block.h
@@ -43,14 +43,14 @@ LIBDOGECOIN_BEGIN_DECL
 
 typedef struct _auxpow {
     dogecoin_bool is;
-    dogecoin_bool (*check)(void* ctx, uint256* hash, uint32_t chainid, dogecoin_chainparams* params);
+    dogecoin_bool (*check)(void* ctx, uint256_t* hash, uint32_t chainid, dogecoin_chainparams* params);
     void *ctx;
 } auxpow;
 
 typedef struct dogecoin_block_header_ {
     int32_t version;
-    uint256 prev_block;
-    uint256 merkle_root;
+    uint256_t prev_block;
+    uint256_t merkle_root;
     uint32_t timestamp;
     uint32_t bits;
     uint32_t nonce;
@@ -60,12 +60,12 @@ typedef struct dogecoin_block_header_ {
 typedef struct dogecoin_auxpow_block_ {
     dogecoin_block_header* header;
     dogecoin_tx* parent_coinbase;
-    uint256 parent_hash;
+    uint256_t parent_hash;
     uint8_t parent_merkle_count;
-    uint256* parent_coinbase_merkle;
+    uint256_t* parent_coinbase_merkle;
     uint32_t parent_merkle_index;
     uint8_t aux_merkle_count;
-    uint256* aux_merkle_branch;
+    uint256_t* aux_merkle_branch;
     uint32_t aux_merkle_index;
     dogecoin_block_header* parent_header;
 } dogecoin_auxpow_block;
@@ -74,11 +74,11 @@ LIBDOGECOIN_API dogecoin_block_header* dogecoin_block_header_new();
 LIBDOGECOIN_API void dogecoin_block_header_free(dogecoin_block_header* header);
 LIBDOGECOIN_API dogecoin_auxpow_block* dogecoin_auxpow_block_new();
 LIBDOGECOIN_API void dogecoin_auxpow_block_free(dogecoin_auxpow_block* block);
-LIBDOGECOIN_API int dogecoin_block_header_deserialize(dogecoin_block_header* header, struct const_buffer* buf, const dogecoin_chainparams *params, uint256* chainwork);
-LIBDOGECOIN_API int deserialize_dogecoin_auxpow_block(dogecoin_auxpow_block* block, struct const_buffer* buffer, const dogecoin_chainparams *params, uint256* chainwork);
+LIBDOGECOIN_API int dogecoin_block_header_deserialize(dogecoin_block_header* header, struct const_buffer* buf, const dogecoin_chainparams *params, uint256_t* chainwork);
+LIBDOGECOIN_API int deserialize_dogecoin_auxpow_block(dogecoin_auxpow_block* block, struct const_buffer* buffer, const dogecoin_chainparams *params, uint256_t* chainwork);
 LIBDOGECOIN_API void dogecoin_block_header_serialize(cstring* s, const dogecoin_block_header* header);
 LIBDOGECOIN_API void dogecoin_block_header_copy(dogecoin_block_header* dest, const dogecoin_block_header* src);
-LIBDOGECOIN_API dogecoin_bool dogecoin_block_header_hash(dogecoin_block_header* header, uint256 hash);
+LIBDOGECOIN_API dogecoin_bool dogecoin_block_header_hash(dogecoin_block_header* header, uint256_t hash);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/blockchain.h
+++ b/include/dogecoin/blockchain.h
@@ -39,8 +39,8 @@ LIBDOGECOIN_BEGIN_DECL
  */
 typedef struct dogecoin_blockindex {
     uint32_t height;
-    uint256 hash;
-    uint256 chainwork;
+    uint256_t hash;
+    uint256_t chainwork;
     dogecoin_block_header header;
     struct dogecoin_blockindex* prev;
 } dogecoin_blockindex;

--- a/include/dogecoin/chainparams.h
+++ b/include/dogecoin/chainparams.h
@@ -46,14 +46,14 @@ typedef struct dogecoin_chainparams_ {
     uint32_t b58prefix_bip32_privkey;
     uint32_t b58prefix_bip32_pubkey;
     const unsigned char netmagic[4];
-    uint256 genesisblockhash;
-    uint256 genesisblockchainwork;
+    uint256_t genesisblockhash;
+    uint256_t genesisblockchainwork;
     int default_port;
     dogecoin_dns_seed dnsseeds[8];
     dogecoin_bool strict_id;
     dogecoin_bool auxpow_id;
-    uint256 pow_limit;
-    uint256 minimumchainwork;
+    uint256_t pow_limit;
+    uint256_t minimumchainwork;
 } dogecoin_chainparams;
 
 typedef struct dogecoin_checkpoint_ {

--- a/include/dogecoin/dogecoin.h
+++ b/include/dogecoin/dogecoin.h
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(HAVE_CONFIG_H)
+#if defined(HAVE_CONFIG_H) && !defined(USE_LIB)
 #include <config/libdogecoin-config.h>
 #endif
 
@@ -147,8 +147,8 @@ typedef uint8_t dogecoin_bool; //!serialize, c/c++ save bool
 LIBDOGECOIN_BEGIN_DECL
 
 /* Data array types */
-typedef uint8_t uint256[32];
-typedef uint8_t uint160[20];
+typedef uint8_t uint256_t[32];
+typedef uint8_t uint160_t[20];
 typedef uint8_t SEED[MAX_SEED_SIZE];
 
 static const int WIDTH = 0x0000100/32;

--- a/include/dogecoin/ecc.h
+++ b/include/dogecoin/ecc.h
@@ -57,22 +57,22 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_verify_privatekey(const uint8_t* priv
 LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_verify_pubkey(const uint8_t* public_key, dogecoin_bool compressed);
 
 //!create a DER signature (72-74 bytes) with private key
-LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_sign(const uint8_t* private_key, const uint256 hash, unsigned char* sigder, size_t* outlen);
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_sign(const uint8_t* private_key, const uint256_t hash, unsigned char* sigder, size_t* outlen);
 
 //!create a compact (64bytes) signature with private key
-LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_sign_compact(const uint8_t* private_key, const uint256 hash, unsigned char* sigcomp, size_t* outlen);
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_sign_compact(const uint8_t* private_key, const uint256_t hash, unsigned char* sigcomp, size_t* outlen);
 
 //!create a compact recoverable (65bytes) signature with private key
-LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_sign_compact_recoverable(const uint8_t* private_key, const uint256 hash, unsigned char* sigcomprec, size_t* outlen, int* recid);
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_sign_compact_recoverable(const uint8_t* private_key, const uint256_t hash, unsigned char* sigcomprec, size_t* outlen, int* recid);
 
 //!create a compact recoverable (65bytes) signature with private key with compressed or uncompressed bytes flag
-LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_sign_compact_recoverable_fcomp(const uint8_t* private_key, const uint256 hash, unsigned char* sigrec, size_t* outlen, int* recid, bool fCompressed);
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_sign_compact_recoverable_fcomp(const uint8_t* private_key, const uint256_t hash, unsigned char* sigrec, size_t* outlen, int* recid, bool fCompressed);
 
 //!recover a specific pubkey from a signature and recid
-LIBDOGECOIN_API dogecoin_bool dogecoin_recover_pubkey(const unsigned char* sigrec, const uint256 hash, const int recid, uint8_t* public_key, size_t* outlen);
+LIBDOGECOIN_API dogecoin_bool dogecoin_recover_pubkey(const unsigned char* sigrec, const uint256_t hash, const int recid, uint8_t* public_key, size_t* outlen);
 
 //!recover a pubkey from a signature and recid
-LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_recover_pubkey(const unsigned char* sigrec, const uint256 hash, const int recid, uint8_t* public_key, size_t* outlen);
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_recover_pubkey(const unsigned char* sigrec, const uint256_t hash, const int recid, uint8_t* public_key, size_t* outlen);
 
 //!converts (and normalized) a compact signature to DER
 LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_compact_to_der_normalized(unsigned char* sigcomp_in, unsigned char* sigder_out, size_t* sigder_len_out);
@@ -81,10 +81,10 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_compact_to_der_normalized(unsigned ch
 LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_der_to_compact(unsigned char* sigder_in, size_t sigder_len, unsigned char* sigcomp_out);
 
 //!verify DER signature with public key
-LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_verify_sig(const uint8_t* public_key, dogecoin_bool compressed, const uint256 hash, unsigned char* sigder, size_t siglen);
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_verify_sig(const uint8_t* public_key, dogecoin_bool compressed, const uint256_t hash, unsigned char* sigder, size_t siglen);
 
 //!verify compact signature with public key
-LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_verify_sigcmp(const uint8_t* public_key, dogecoin_bool compressed, const uint256 hash, unsigned char* sigcmp);
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_verify_sigcmp(const uint8_t* public_key, dogecoin_bool compressed, const uint256_t hash, unsigned char* sigcmp);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/hash.h
+++ b/include/dogecoin/hash.h
@@ -41,45 +41,45 @@
 
 LIBDOGECOIN_BEGIN_DECL
 
-LIBDOGECOIN_API static inline dogecoin_bool dogecoin_hash_is_empty(uint256 hash)
+LIBDOGECOIN_API static inline dogecoin_bool dogecoin_hash_is_empty(uint256_t hash)
 {
     return hash[0] == 0 && !memcmp(hash, hash + 1, 19);
 }
 
-LIBDOGECOIN_API static inline void dogecoin_hash_clear(uint256 hash)
+LIBDOGECOIN_API static inline void dogecoin_hash_clear(uint256_t hash)
 {
     dogecoin_mem_zero(hash, DOGECOIN_HASH_LENGTH);
 }
 
-LIBDOGECOIN_API static inline dogecoin_bool dogecoin_hash_equal(uint256 hash_a, uint256 hash_b)
+LIBDOGECOIN_API static inline dogecoin_bool dogecoin_hash_equal(uint256_t hash_a, uint256_t hash_b)
 {
     return (memcmp(hash_a, hash_b, DOGECOIN_HASH_LENGTH) == 0);
 }
 
-LIBDOGECOIN_API static inline void dogecoin_hash_set(uint256 hash_dest, const uint256 hash_src)
+LIBDOGECOIN_API static inline void dogecoin_hash_set(uint256_t hash_dest, const uint256_t hash_src)
 {
     memcpy_safe(hash_dest, hash_src, DOGECOIN_HASH_LENGTH);
 }
 
-LIBDOGECOIN_API static inline void dogecoin_hash(const unsigned char* datain, size_t length, uint256 hashout)
+LIBDOGECOIN_API static inline void dogecoin_hash(const unsigned char* datain, size_t length, uint256_t hashout)
 {
     sha256_raw(datain, length, hashout);
     sha256_raw(hashout, SHA256_DIGEST_LENGTH, hashout); // dogecoin double sha256 hash
 }
 
-LIBDOGECOIN_API static inline dogecoin_bool dogecoin_dblhash(const unsigned char* datain, size_t length, uint256 hashout)
+LIBDOGECOIN_API static inline dogecoin_bool dogecoin_dblhash(const unsigned char* datain, size_t length, uint256_t hashout)
 {
     sha256_raw(datain, length, hashout);
     sha256_raw(hashout, SHA256_DIGEST_LENGTH, hashout); // dogecoin double sha256 hash
     return true;
 }
 
-LIBDOGECOIN_API static inline void dogecoin_hash_sngl_sha256(const unsigned char* datain, size_t length, uint256 hashout)
+LIBDOGECOIN_API static inline void dogecoin_hash_sngl_sha256(const unsigned char* datain, size_t length, uint256_t hashout)
 {
     sha256_raw(datain, length, hashout); // single sha256 hash
 }
 
-LIBDOGECOIN_API static inline void dogecoin_get_auxpow_hash(const uint32_t version, uint256 hashout)
+LIBDOGECOIN_API static inline void dogecoin_get_auxpow_hash(const uint32_t version, uint256_t hashout)
 {
     scrypt_1024_1_1_256(BEGIN(version), BEGIN(hashout));
 }
@@ -87,7 +87,7 @@ LIBDOGECOIN_API static inline void dogecoin_get_auxpow_hash(const uint32_t versi
 DISABLE_WARNING_PUSH
 DISABLE_WARNING(-Wunused-function)
 DISABLE_WARNING(-Wunused-variable)
-typedef uint256 chain_code;
+typedef uint256_t chain_code;
 
 typedef struct _chash256 {
     sha256_context* sha;
@@ -107,19 +107,19 @@ static inline chash256* dogecoin_chash256_init() {
     return chash;
 }
 
-// Hashes the data from two uint256 values and returns the double SHA-256 hash.
-static inline uint256* Hash(const uint256* p1, const uint256* p2) {
-    uint256* result = dogecoin_uint256_vla(1);
+// Hashes the data from two uint256_t values and returns the double SHA-256 hash.
+static inline uint256_t* Hash(const uint256_t* p1, const uint256_t* p2) {
+    uint256_t* result = dogecoin_uint256_vla(1);
     chash256* chash = dogecoin_chash256_init();
 
-    // Write the first uint256 to the hash context
+    // Write the first uint256_t to the hash context
     if (p1) {
-        chash->write(chash->sha, (const uint8_t*)p1, sizeof(uint256));
+        chash->write(chash->sha, (const uint8_t*)p1, sizeof(uint256_t));
     }
 
-    // Write the second uint256 to the hash context
+    // Write the second uint256_t to the hash context
     if (p2) {
-        chash->write(chash->sha, (const uint8_t*)p2, sizeof(uint256));
+        chash->write(chash->sha, (const uint8_t*)p2, sizeof(uint256_t));
     }
 
     // Finalize and reset for double hashing
@@ -148,11 +148,11 @@ typedef struct hashwriter {
     int n_type;
     int n_version;
     cstring* cstr;
-    uint256* hash;
+    uint256_t* hash;
     int (*get_type)(struct hashwriter* hw);
     int (*get_version)(struct hashwriter* hw);
     void (*write_hash)(struct hashwriter* hw, const char* pch, size_t size);
-    uint256* (*get_hash)(struct hashwriter* hw);
+    uint256_t* (*get_hash)(struct hashwriter* hw);
     void (*ser)(cstring* cstr, const void* obj);
 } hashwriter;
 
@@ -168,7 +168,7 @@ static void write_hash(struct hashwriter* hw, const char* pch, size_t size) {
     hw->ctx->write(hw->ctx->sha, (const unsigned char*)pch, size);
 }
 
-static uint256* get_hash(struct hashwriter* hw) {
+static uint256_t* get_hash(struct hashwriter* hw) {
     dogecoin_dblhash((const unsigned char*)hw->cstr->str, hw->cstr->len, *hw->hash);
     cstr_free(hw->cstr, true);
     return hw->hash;
@@ -289,10 +289,10 @@ static uint64_t siphasher_finalize(struct siphasher* sh) {
 }
 
 typedef union u256 {
-    uint256 data;
+    uint256_t data;
 } u256;
 
-static uint64_t get_uint64(uint256* data, int pos) {
+static uint64_t get_uint64(uint256_t* data, int pos) {
     const uint8_t* ptr = (const uint8_t*)data + pos * 8;
     return ((uint64_t)ptr[0]) | \
             ((uint64_t)ptr[1]) << 8 | \
@@ -304,14 +304,14 @@ static uint64_t get_uint64(uint256* data, int pos) {
             ((uint64_t)ptr[7]) << 56;
 }
 
-static inline union u256 init_u256(uint256* val) {
+static inline union u256 init_u256(uint256_t* val) {
     union u256* u256 = dogecoin_calloc(1, sizeof(*u256));
     memcpy_safe(u256->data, dogecoin_uint256_vla(1), 32);
     if (val != NULL) memcpy(u256->data, val, 32);
     return *u256;
 }
 
-static uint64_t siphash_u256(uint64_t k0, uint64_t k1, uint256* val) {
+static uint64_t siphash_u256(uint64_t k0, uint64_t k1, uint256_t* val) {
     /* Specialized implementation for efficiency */
     uint64_t d = get_uint64(val, 0);
     uint64_t v0 = 0x736f6d6570736575ULL ^ k0;

--- a/include/dogecoin/headersdb.h
+++ b/include/dogecoin/headersdb.h
@@ -47,12 +47,12 @@ typedef struct dogecoin_headers_db_interface_
     void* (*init)(const dogecoin_chainparams* chainparams, dogecoin_bool inmem_only);
     void (*free)(void *db);
     dogecoin_bool (*load)(void *db, const char *filename, dogecoin_bool prompt);
-    void (*fill_blocklocator_tip)(void* db, vector *blocklocators);
+    void (*fill_blocklocator_tip)(void* db, vector_t *blocklocators);
     dogecoin_blockindex *(*connect_hdr)(void* db, struct const_buffer *buf, dogecoin_bool load_process, dogecoin_bool *connected);
     dogecoin_blockindex* (*getchaintip)(void *db);
     dogecoin_bool (*disconnect_tip)(void *db);
     dogecoin_bool (*has_checkpoint_start)(void *db);
-    void (*set_checkpoint_start)(void *db, uint256 hash, uint32_t height, uint256 chainwork);
+    void (*set_checkpoint_start)(void *db, uint256_t hash, uint32_t height, uint256_t chainwork);
 } dogecoin_headers_db_interface;
 
 LIBDOGECOIN_END_DECL

--- a/include/dogecoin/headersdb_file.h
+++ b/include/dogecoin/headersdb_file.h
@@ -58,23 +58,23 @@ dogecoin_headers_db *dogecoin_headers_db_new(const dogecoin_chainparams* chainpa
 void dogecoin_headers_db_free(dogecoin_headers_db *db);
 dogecoin_bool dogecoin_headers_db_load(dogecoin_headers_db* db, const char *filename, dogecoin_bool prompt);
 dogecoin_blockindex * dogecoin_headers_db_connect_hdr(dogecoin_headers_db* db, struct const_buffer *buf, dogecoin_bool load_process, dogecoin_bool *connected);
-void dogecoin_headers_db_fill_block_locator(dogecoin_headers_db* db, vector *blocklocators);
-dogecoin_blockindex * dogecoin_headersdb_find(dogecoin_headers_db* db, uint256 hash);
+void dogecoin_headers_db_fill_block_locator(dogecoin_headers_db* db, vector_t *blocklocators);
+dogecoin_blockindex * dogecoin_headersdb_find(dogecoin_headers_db* db, uint256_t hash);
 dogecoin_blockindex * dogecoin_headersdb_getchaintip(dogecoin_headers_db* db);
 dogecoin_bool dogecoin_headersdb_disconnect_tip(dogecoin_headers_db* db);
 dogecoin_bool dogecoin_headersdb_has_checkpoint_start(dogecoin_headers_db* db);
-void dogecoin_headersdb_set_checkpoint_start(dogecoin_headers_db* db, uint256 hash, uint32_t height, uint256 chainwork);
+void dogecoin_headersdb_set_checkpoint_start(dogecoin_headers_db* db, uint256_t hash, uint32_t height, uint256_t chainwork);
 
 static const dogecoin_headers_db_interface dogecoin_headers_db_interface_file = {
     (void* (*)(const dogecoin_chainparams*, dogecoin_bool))dogecoin_headers_db_new,
     (void (*)(void *))dogecoin_headers_db_free,
     (dogecoin_bool (*)(void *, const char *, dogecoin_bool))dogecoin_headers_db_load,
-    (void (*)(void* , vector *))dogecoin_headers_db_fill_block_locator,
+    (void (*)(void* , vector_t *))dogecoin_headers_db_fill_block_locator,
     (dogecoin_blockindex *(*)(void* , struct const_buffer *, dogecoin_bool , dogecoin_bool *))dogecoin_headers_db_connect_hdr,
     (dogecoin_blockindex* (*)(void *))dogecoin_headersdb_getchaintip,
     (dogecoin_bool (*)(void *))dogecoin_headersdb_disconnect_tip,
     (dogecoin_bool (*)(void *))dogecoin_headersdb_has_checkpoint_start,
-    (void (*)(void *, uint256, uint32_t, uint256))dogecoin_headersdb_set_checkpoint_start
+    (void (*)(void *, uint256_t, uint32_t, uint256_t))dogecoin_headersdb_set_checkpoint_start
 };
 
 LIBDOGECOIN_END_DECL

--- a/include/dogecoin/key.h
+++ b/include/dogecoin/key.h
@@ -64,32 +64,32 @@ LIBDOGECOIN_API void dogecoin_pubkey_cleanse(dogecoin_pubkey* pubkey);
 LIBDOGECOIN_API void dogecoin_pubkey_from_key(const dogecoin_key* privkey, dogecoin_pubkey* pubkey_inout);
 
 // get the hash160 (single SHA256 + RIPEMD160)
-LIBDOGECOIN_API void dogecoin_pubkey_get_hash160(const dogecoin_pubkey* pubkey, uint160 hash160);
+LIBDOGECOIN_API void dogecoin_pubkey_get_hash160(const dogecoin_pubkey* pubkey, uint160_t hash160);
 
 // get the hex representation of a pubkey, strsize must be at leat 66 bytes
 LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_get_hex(const dogecoin_pubkey* pubkey, char* str, size_t* strsize);
 
 // sign a 32byte message/hash and returns a DER encoded signature (through *sigout)
-LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_hash(const dogecoin_key* privkey, const uint256 hash, unsigned char* sigout, size_t* outlen);
+LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_hash(const dogecoin_key* privkey, const uint256_t hash, unsigned char* sigout, size_t* outlen);
 
 // sign a 32byte message/hash and returns a 64 byte compact signature (through *sigout)
-LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_hash_compact(const dogecoin_key* privkey, const uint256 hash, unsigned char* sigout, size_t* outlen);
+LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_hash_compact(const dogecoin_key* privkey, const uint256_t hash, unsigned char* sigout, size_t* outlen);
 
 // sign a 32byte message/hash and returns a 64 byte compact signature (through *sigout) plus a 1byte recovery id
-LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_hash_compact_recoverable(const dogecoin_key* privkey, const uint256 hash, unsigned char* sigout, size_t* outlen, int* recid);
+LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_hash_compact_recoverable(const dogecoin_key* privkey, const uint256_t hash, unsigned char* sigout, size_t* outlen, int* recid);
 
 // sign a 32byte message/hash and returns a 64 byte compact signature (through *sigout) plus a 1byte recovery id
-LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_hash_compact_recoverable_fcomp(const dogecoin_key* privkey, const uint256 hash, unsigned char* sigout, size_t* outlen, int* recid);
+LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_hash_compact_recoverable_fcomp(const dogecoin_key* privkey, const uint256_t hash, unsigned char* sigout, size_t* outlen, int* recid);
 
-LIBDOGECOIN_API dogecoin_bool dogecoin_key_recover_pubkey(const unsigned char* sig, const uint256 hash, int recid, dogecoin_pubkey* pubkey);
+LIBDOGECOIN_API dogecoin_bool dogecoin_key_recover_pubkey(const unsigned char* sig, const uint256_t hash, int recid, dogecoin_pubkey* pubkey);
 
-LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_recover_pubkey(const unsigned char* sig, const uint256 hash, int recid, dogecoin_pubkey* pubkey);
+LIBDOGECOIN_API dogecoin_bool dogecoin_key_sign_recover_pubkey(const unsigned char* sig, const uint256_t hash, int recid, dogecoin_pubkey* pubkey);
 
 // verifies a DER encoded signature with given pubkey and return true if valid
-LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_verify_sig(const dogecoin_pubkey* pubkey, const uint256 hash, unsigned char* sigder, size_t len);
+LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_verify_sig(const dogecoin_pubkey* pubkey, const uint256_t hash, unsigned char* sigder, size_t len);
 
 // verifies a compact encoded signature with given pubkey and return true if valid
-LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_verify_sigcmp(const dogecoin_pubkey* pubkey, const uint256 hash, unsigned char* sigcmp);
+LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_verify_sigcmp(const dogecoin_pubkey* pubkey, const uint256_t hash, unsigned char* sigcmp);
 
 // derive a p2pkh address from a public key
 LIBDOGECOIN_API dogecoin_bool dogecoin_pubkey_getaddr_p2pkh(const dogecoin_pubkey* pubkey, const dogecoin_chainparams* chain, char* addrout);

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -54,7 +54,7 @@ typedef struct dogecoin_chainparams_ {
     uint32_t b58prefix_bip32_privkey;
     uint32_t b58prefix_bip32_pubkey;
     const unsigned char netmagic[4];
-    uint256 genesisblockhash;
+    uint256_t genesisblockhash;
     int default_port;
     dogecoin_dns_seed dnsseeds[8];
 } dogecoin_chainparams;
@@ -196,7 +196,7 @@ void dogecoin_hdnode_fill_public_key(dogecoin_hdnode* node);
 void dogecoin_hdnode_serialize_public(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 
-void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_out);
+void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160_t hash160_out);
 void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize);
 dogecoin_bool dogecoin_hdnode_get_pub_hex(const dogecoin_hdnode* node, char* str, size_t* strsize);
 dogecoin_bool dogecoin_hdnode_deserialize(const char* str, const dogecoin_chainparams* chain, dogecoin_hdnode* node);
@@ -527,24 +527,24 @@ int verify_message(char* sig, char* msg, char* address);
 --------------------------------------------------------------------------
 */
 
-typedef struct vector {
+typedef struct vector_t {
     void** data;  /* array of pointers */
     size_t len;   /* array element count */
     size_t alloc; /* allocated array elements */
 
     void (*elem_free_f)(void*);
-} vector;
+} vector_t;
 
 #define vector_idx(vec, idx) vec->data[idx]
 
-vector* vector_new(size_t res, void (*free_f)(void*));
-void vector_free(vector* vec, dogecoin_bool free_array);
-dogecoin_bool vector_add(vector* vec, void* data);
-dogecoin_bool vector_remove(vector* vec, void* data);
-void vector_remove_idx(vector* vec, size_t idx);
-void vector_remove_range(vector* vec, size_t idx, size_t len);
-dogecoin_bool vector_resize(vector* vec, size_t newsz);
-ssize_t vector_find(vector* vec, void* data);
+vector_t* vector_new(size_t res, void (*free_f)(void*));
+void vector_free(vector_t* vec, dogecoin_bool free_array);
+dogecoin_bool vector_add(vector_t* vec, void* data);
+dogecoin_bool vector_remove(vector_t* vec, void* data);
+void vector_remove_idx(vector_t* vec, size_t idx);
+void vector_remove_range(vector_t* vec, size_t idx, size_t len);
+dogecoin_bool vector_resize(vector_t* vec, size_t newsz);
+ssize_t vector_find(vector_t* vec, void* data);
 
 
 /* Wallet API
@@ -552,7 +552,7 @@ ssize_t vector_find(vector* vec, void* data);
 */
 
 int dogecoin_unregister_watch_address_with_node(char* address);
-int dogecoin_get_utxo_vector(char* address, vector* utxos);
+int dogecoin_get_utxo_vector(char* address, vector_t* utxos);
 uint8_t* dogecoin_get_utxos(char* address);
 unsigned int dogecoin_get_utxos_length(char* address);
 char* dogecoin_get_utxo_txid_str(char* address, unsigned int index);

--- a/include/dogecoin/mem.h
+++ b/include/dogecoin/mem.h
@@ -63,7 +63,7 @@ LIBDOGECOIN_API volatile void* dogecoin_mem_zero(volatile void* dst, size_t len)
 
 LIBDOGECOIN_API uint8_t* dogecoin_uint8_vla(size_t size);
 LIBDOGECOIN_API uint32_t* dogecoin_uint32_vla(size_t size);
-LIBDOGECOIN_API uint256* dogecoin_uint256_vla(size_t size);
+LIBDOGECOIN_API uint256_t* dogecoin_uint256_vla(size_t size);
 LIBDOGECOIN_API char* dogecoin_char_vla(size_t size);
 LIBDOGECOIN_API char* dogecoin_string_vla(size_t size);
 LIBDOGECOIN_API unsigned char* dogecoin_uchar_vla(size_t size);

--- a/include/dogecoin/net.h
+++ b/include/dogecoin/net.h
@@ -56,7 +56,7 @@ struct dogecoin_node_;
 typedef struct dogecoin_node_group_ {
     void* ctx; /* flexible context usefull in conjunction with the callbacks */
     struct event_base* event_base;
-    vector* nodes; /* the groups nodes */
+    vector_t* nodes; /* the groups nodes */
     char clientstr[1024];
     int desired_amount_connected_nodes;
     const dogecoin_chainparams* chainparams;
@@ -90,7 +90,7 @@ typedef struct dogecoin_node_ {
     uint64_t lastping;
     uint64_t time_started_con;
     uint64_t time_last_request;
-    uint256 last_requested_inv;
+    uint256_t last_requested_inv;
 
     cstring* recvBuffer;
     uint64_t nonce;
@@ -172,7 +172,7 @@ LIBDOGECOIN_API void dogecoin_node_connection_state_changed(dogecoin_node* node)
 /* =================================== */
 
 LIBDOGECOIN_API dogecoin_bool dogecoin_node_group_add_peers_by_ip_or_seed(dogecoin_node_group *group, const char *ips);
-LIBDOGECOIN_API size_t dogecoin_get_peers_from_dns(const char* seed, vector* ips_out, int port, int family);
+LIBDOGECOIN_API size_t dogecoin_get_peers_from_dns(const char* seed, vector_t* ips_out, int port, int family);
 
 struct broadcast_ctx {
     const dogecoin_tx* tx;

--- a/include/dogecoin/pow.h
+++ b/include/dogecoin/pow.h
@@ -39,7 +39,7 @@
 
 LIBDOGECOIN_BEGIN_DECL
 
-dogecoin_bool check_pow(uint256* hash, unsigned int nbits, const dogecoin_chainparams *params, uint256* chainwork);
+dogecoin_bool check_pow(uint256_t* hash, unsigned int nbits, const dogecoin_chainparams *params, uint256_t* chainwork);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/protocol.h
+++ b/include/dogecoin/protocol.h
@@ -54,7 +54,7 @@ static const unsigned int DOGECOIN_P2P_HDRSZ = 24; //(4 + 12 + 4 + 4)  magic, co
 
 DISABLE_WARNING_PUSH
 DISABLE_WARNING(-Wunused-variable)
-static uint256 NULLHASH = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+static uint256_t NULLHASH = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
 enum service_bits {
     // Nothing
@@ -128,7 +128,7 @@ typedef struct dogecoin_p2p_msg_hdr_ {
 
 typedef struct dogecoin_p2p_inv_msg_ {
     uint32_t type;
-    uint256 hash;
+    uint256_t hash;
 } dogecoin_p2p_inv_msg;
 
 typedef struct dogecoin_p2p_address_ {
@@ -189,7 +189,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_p2p_msg_version_deser(dogecoin_p2p_versio
 /* =================================== */
 
 /* sets an inv message-element*/
-LIBDOGECOIN_API void dogecoin_p2p_msg_inv_init(dogecoin_p2p_inv_msg* msg, uint32_t type, uint256 hash);
+LIBDOGECOIN_API void dogecoin_p2p_msg_inv_init(dogecoin_p2p_inv_msg* msg, uint32_t type, uint256_t hash);
 
 /* serialize a p2p "inv" message to an existing cstring */
 LIBDOGECOIN_API void dogecoin_p2p_msg_inv_ser(dogecoin_p2p_inv_msg* msg, cstring* buf);
@@ -234,10 +234,10 @@ LIBDOGECOIN_API cstring* dogecoin_p2p_message_new(const unsigned char netmagic[4
 /* =================================== */
 
 /* creates a getheader message */
-LIBDOGECOIN_API void dogecoin_p2p_msg_getheaders(vector* blocklocators, uint256 hashstop, cstring* str_out);
+LIBDOGECOIN_API void dogecoin_p2p_msg_getheaders(vector_t* blocklocators, uint256_t hashstop, cstring* str_out);
 
 /* directly deserialize a getheaders message to blocklocators, hashstop */
-LIBDOGECOIN_API dogecoin_bool dogecoin_p2p_deser_msg_getheaders(vector* blocklocators, uint256 hashstop, struct const_buffer* buf);
+LIBDOGECOIN_API dogecoin_bool dogecoin_p2p_deser_msg_getheaders(vector_t* blocklocators, uint256_t hashstop, struct const_buffer* buf);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/random.h
+++ b/include/dogecoin/random.h
@@ -46,15 +46,15 @@ typedef struct fast_random_context {
     void (*random_seed)(struct fast_random_context* this);
     void (*fill_byte_buffer)(struct fast_random_context* this);
     void (*fill_bit_buffer)(struct fast_random_context* this);
-    uint256* (*rand256)(struct fast_random_context* this);
+    uint256_t* (*rand256)(struct fast_random_context* this);
     uint64_t (*rand64)(struct fast_random_context* this);
     uint64_t (*randbits)(struct fast_random_context* this, int bits);
     uint32_t (*rand32)(struct fast_random_context* this);
     dogecoin_bool (*randbool)(struct fast_random_context* this);
 } fast_random_context;
 
-struct fast_random_context* init_fast_random_context(dogecoin_bool f_deterministic, const uint256* seed);
-uint256* rand256(struct fast_random_context* this);
+struct fast_random_context* init_fast_random_context(dogecoin_bool f_deterministic, const uint256_t* seed);
+uint256_t* rand256(struct fast_random_context* this);
 uint64_t rand64(struct fast_random_context* this);
 void free_fast_random_context(struct fast_random_context* this);
 

--- a/include/dogecoin/script.h
+++ b/include/dogecoin/script.h
@@ -24,7 +24,7 @@
  OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE.
- 
+
 */
 
 #ifndef __LIBDOGECOIN_SCRIPT_H__
@@ -219,19 +219,19 @@ dogecoin_bool dogecoin_script_copy_without_op_codeseperator(const cstring* scrip
 LIBDOGECOIN_API dogecoin_script_op* dogecoin_script_op_new();
 LIBDOGECOIN_API void dogecoin_script_op_free(dogecoin_script_op* script_op);
 void dogecoin_script_op_free_cb(void* data);
-dogecoin_bool dogecoin_script_get_ops(const cstring* script_in, vector* ops_out);
+dogecoin_bool dogecoin_script_get_ops(const cstring* script_in, vector_t* ops_out);
 
-LIBDOGECOIN_API enum dogecoin_tx_out_type dogecoin_script_classify_ops(const vector* ops);
-LIBDOGECOIN_API enum dogecoin_tx_out_type dogecoin_script_classify(const cstring* script, vector* data_out);
+LIBDOGECOIN_API enum dogecoin_tx_out_type dogecoin_script_classify_ops(const vector_t* ops);
+LIBDOGECOIN_API enum dogecoin_tx_out_type dogecoin_script_classify(const cstring* script, vector_t* data_out);
 
 LIBDOGECOIN_API enum opcodetype dogecoin_encode_op_n(const int n);
 LIBDOGECOIN_API void dogecoin_script_append_op(cstring* script_in, enum opcodetype op);
 LIBDOGECOIN_API void dogecoin_script_append_pushdata(cstring* script_in, const unsigned char* data, const size_t datalen);
 
-LIBDOGECOIN_API dogecoin_bool dogecoin_script_build_multisig(cstring* script_in, const unsigned int required_signatures, const vector* pubkeys_chars);
-LIBDOGECOIN_API dogecoin_bool dogecoin_script_build_p2pkh(cstring* script, const uint160 hash160);
-LIBDOGECOIN_API dogecoin_bool dogecoin_script_build_p2sh(cstring* script_in, const uint160 hash160);
-LIBDOGECOIN_API dogecoin_bool dogecoin_script_get_scripthash(const cstring* script_in, uint160 scripthash);
+LIBDOGECOIN_API dogecoin_bool dogecoin_script_build_multisig(cstring* script_in, const unsigned int required_signatures, const vector_t* pubkeys_chars);
+LIBDOGECOIN_API dogecoin_bool dogecoin_script_build_p2pkh(cstring* script, const uint160_t hash160);
+LIBDOGECOIN_API dogecoin_bool dogecoin_script_build_p2sh(cstring* script_in, const uint160_t hash160);
+LIBDOGECOIN_API dogecoin_bool dogecoin_script_get_scripthash(const cstring* script_in, uint160_t scripthash);
 
 LIBDOGECOIN_API const char* dogecoin_tx_out_type_to_str(const enum dogecoin_tx_out_type type);
 

--- a/include/dogecoin/sign.h
+++ b/include/dogecoin/sign.h
@@ -1,6 +1,6 @@
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2023 bluezr, edtubbs
  Copyright (c) 2023 The Dogecoin Foundation
 
@@ -30,7 +30,7 @@
 LIBDOGECOIN_BEGIN_DECL
 
 /* double sha256 hash a message */
-LIBDOGECOIN_API void hash_message(char* msg, uint256 message_bytes);
+LIBDOGECOIN_API void hash_message(char* msg, uint256_t message_bytes);
 
 /* sign a message with a private key */
 LIBDOGECOIN_API char* sign_message(char* privkey, char* msg);

--- a/include/dogecoin/tx.h
+++ b/include/dogecoin/tx.h
@@ -42,12 +42,12 @@ LIBDOGECOIN_BEGIN_DECL
 
 typedef struct dogecoin_script_ {
     int* data;
-    size_t limit;   // Total size of the vector
+    size_t limit;   // Total size of the vector_t
     size_t current; //Number of vectors in it at present
 } dogecoin_script;
 
 typedef struct dogecoin_tx_outpoint_ {
-    uint256 hash;
+    uint256_t hash;
     uint32_t n;
 } dogecoin_tx_outpoint;
 
@@ -64,8 +64,8 @@ typedef struct dogecoin_tx_out_ {
 
 typedef struct dogecoin_tx_ {
     int32_t version;
-    vector* vin;
-    vector* vout;
+    vector_t* vin;
+    vector_t* vout;
     uint32_t locktime;
 } dogecoin_tx;
 
@@ -101,13 +101,13 @@ LIBDOGECOIN_API int dogecoin_tx_deserialize(const unsigned char* tx_serialized, 
 //!serialize a dogecoin data structure into a p2p serialized buffer
 LIBDOGECOIN_API void dogecoin_tx_serialize(cstring* s, const dogecoin_tx* tx);
 
-LIBDOGECOIN_API void dogecoin_tx_hash(const dogecoin_tx* tx, uint256 hashout);
+LIBDOGECOIN_API void dogecoin_tx_hash(const dogecoin_tx* tx, uint256_t hashout);
 
-LIBDOGECOIN_API dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, size_t in_num, int hashtype, uint256 hash);
+LIBDOGECOIN_API dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, size_t in_num, int hashtype, uint256_t hash);
 
 LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_address_out(dogecoin_tx* tx, const dogecoin_chainparams* chain, int64_t amount, const char* address);
-LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_p2sh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160 hash160);
-LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_p2pkh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160 hash160);
+LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_p2sh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160_t hash160);
+LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_p2pkh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160_t hash160);
 LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_p2pkh_out(dogecoin_tx* tx, int64_t amount, const dogecoin_pubkey* pubkey);
 
 LIBDOGECOIN_API dogecoin_bool dogecoin_tx_add_data_out(dogecoin_tx* tx, const int64_t amount, const uint8_t* data, const size_t datalen);

--- a/include/dogecoin/utils.h
+++ b/include/dogecoin/utils.h
@@ -61,7 +61,7 @@ LIBDOGECOIN_API char* utils_uint8_to_hex(const uint8_t* bin, size_t l);
 LIBDOGECOIN_API void utils_reverse_hex(char* h, size_t len);
 LIBDOGECOIN_API signed char utils_hex_digit(char c);
 LIBDOGECOIN_API void utils_uint256_sethex(char* psz, uint8_t* out);
-LIBDOGECOIN_API uint256* uint256S(const char *str);
+LIBDOGECOIN_API uint256_t* uint256S(const char *str);
 LIBDOGECOIN_API unsigned char* parse_hex(const char* psz);
 LIBDOGECOIN_API void swap_bytes(uint8_t *buf, int buf_size);
 LIBDOGECOIN_API const char *find_needle(const char *haystack, size_t haystack_length, const char *needle, size_t needle_length);

--- a/include/dogecoin/validation.h
+++ b/include/dogecoin/validation.h
@@ -45,8 +45,8 @@ LIBDOGECOIN_BEGIN_DECL
 LIBDOGECOIN_API uint32_t get_chainid(uint32_t version);
 LIBDOGECOIN_API dogecoin_bool is_auxpow(uint32_t version);
 LIBDOGECOIN_API dogecoin_bool is_legacy(uint32_t version);
-LIBDOGECOIN_API dogecoin_bool check_auxpow(dogecoin_auxpow_block* block, dogecoin_chainparams* params, uint256* chainwork);
-LIBDOGECOIN_API dogecoin_bool dogecoin_block_header_scrypt_hash(cstring* s, uint256* hash);
+LIBDOGECOIN_API dogecoin_bool check_auxpow(dogecoin_auxpow_block* block, dogecoin_chainparams* params, uint256_t* chainwork);
+LIBDOGECOIN_API dogecoin_bool dogecoin_block_header_scrypt_hash(cstring* s, uint256_t* hash);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/vector.h
+++ b/include/dogecoin/vector.h
@@ -33,30 +33,30 @@
 
 LIBDOGECOIN_BEGIN_DECL
 
-typedef struct vector {
+typedef struct vector_t {
     void** data;  /* array of pointers */
     size_t len;   /* array element count */
     size_t alloc; /* allocated array elements */
 
     void (*elem_free_f)(void*);
-} vector;
+} vector_t;
 
 #define vector_idx(vec, idx) vec->data[idx]
 
-LIBDOGECOIN_API vector* vector_new(size_t res, void (*free_f)(void*));
-LIBDOGECOIN_API void vector_free(vector* vec, dogecoin_bool free_array);
+LIBDOGECOIN_API vector_t* vector_new(size_t res, void (*free_f)(void*));
+LIBDOGECOIN_API void vector_free(vector_t* vec, dogecoin_bool free_array);
 
-LIBDOGECOIN_API dogecoin_bool vector_add(vector* vec, void* data);
-LIBDOGECOIN_API dogecoin_bool vector_remove(vector* vec, void* data);
-LIBDOGECOIN_API void vector_remove_idx(vector* vec, size_t idx);
-LIBDOGECOIN_API void vector_remove_range(vector* vec, size_t idx, size_t len);
-LIBDOGECOIN_API dogecoin_bool vector_resize(vector* vec, size_t newsz);
+LIBDOGECOIN_API dogecoin_bool vector_add(vector_t* vec, void* data);
+LIBDOGECOIN_API dogecoin_bool vector_remove(vector_t* vec, void* data);
+LIBDOGECOIN_API void vector_remove_idx(vector_t* vec, size_t idx);
+LIBDOGECOIN_API void vector_remove_range(vector_t* vec, size_t idx, size_t len);
+LIBDOGECOIN_API dogecoin_bool vector_resize(vector_t* vec, size_t newsz);
 
-LIBDOGECOIN_API ssize_t vector_find(vector* vec, void* data);
+LIBDOGECOIN_API ssize_t vector_find(vector_t* vec, void* data);
 
 /* serialization functions */
-LIBDOGECOIN_API dogecoin_bool serializeVector(vector* vec, char* out, size_t outlen, size_t* written);
-LIBDOGECOIN_API dogecoin_bool deserializeVector(vector* vec, const char* in, size_t inlen, size_t* read);
+LIBDOGECOIN_API dogecoin_bool serializeVector(vector_t* vec, char* out, size_t outlen, size_t* written);
+LIBDOGECOIN_API dogecoin_bool deserializeVector(vector_t* vec, const char* in, size_t inlen, size_t* read);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -53,7 +53,7 @@ LIBDOGECOIN_BEGIN_DECL
 
 typedef struct dogecoin_utxo_ {
     int index;
-    uint256 txid;
+    uint256_t txid;
     int vout;
     char address[P2PKHLEN];
     char script_pubkey[SCRIPT_PUBKEY_STRINGLEN];
@@ -83,22 +83,22 @@ typedef struct dogecoin_wallet_ {
     dogecoin_utxo* utxos;
     void* unspent_rbtree;
     void* spends_rbtree;
-    vector *vec_wtxes;
+    vector_t *vec_wtxes;
     void* wtxes_rbtree;
-    vector *waddr_vector; //points to the addr objects managed by the waddr_rbtree [in order]
+    vector_t *waddr_vector; //points to the addr objects managed by the waddr_rbtree [in order]
     void* waddr_rbtree;
 } dogecoin_wallet;
 
 typedef struct dogecoin_wtx_ {
-    uint256 tx_hash_cache;
-    uint256 blockhash;
+    uint256_t tx_hash_cache;
+    uint256_t blockhash;
     uint32_t height;
     dogecoin_tx* tx;
     dogecoin_bool ignore; //if set, transaction will be ignored (soft-delete)
 } dogecoin_wtx;
 
 typedef struct dogecoin_wallet_addr_{
-    uint160 pubkeyhash;
+    uint160_t pubkeyhash;
     uint8_t type;
     uint32_t childindex;
     dogecoin_bool ignore;
@@ -162,8 +162,8 @@ LIBDOGECOIN_API dogecoin_wallet_addr* dogecoin_wallet_next_bip44_addr(dogecoin_w
 LIBDOGECOIN_API dogecoin_bool dogecoin_p2pkh_address_to_wallet_pubkeyhash(const char* address_in, dogecoin_wallet_addr* addr, dogecoin_wallet* wallet);
 LIBDOGECOIN_API dogecoin_wallet_addr* dogecoin_p2pkh_address_to_wallet(const char* address_in, dogecoin_wallet* wallet);
 
-/** writes all available addresses (P2PKH) to the addr_out vector */
-LIBDOGECOIN_API void dogecoin_wallet_get_addresses(dogecoin_wallet* wallet, vector* addr_out);
+/** writes all available addresses (P2PKH) to the addr_out vector_t */
+LIBDOGECOIN_API void dogecoin_wallet_get_addresses(dogecoin_wallet* wallet, vector_t* addr_out);
 
 /** finds wallet address object based on pure addresses (base58/bech32) */
 LIBDOGECOIN_API dogecoin_wallet_addr* dogecoin_wallet_find_waddr_byaddr(dogecoin_wallet* wallet, const char* search_addr);
@@ -184,9 +184,9 @@ LIBDOGECOIN_API int64_t dogecoin_wallet_wtx_get_available_credit(dogecoin_wallet
 LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_txout_is_mine(dogecoin_wallet* wallet, dogecoin_tx_out* tx_out);
 
 /** checks if a transaction outpoint is owned by the wallet */
-LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_is_spent(dogecoin_wallet* wallet, uint256 hash, uint32_t n);
-LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_get_unspents(dogecoin_wallet* wallet, vector* unspents);
-LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_get_unspent(vector* unspents);
+LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_is_spent(dogecoin_wallet* wallet, uint256_t hash, uint32_t n);
+LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_get_unspents(dogecoin_wallet* wallet, vector_t* unspents);
+LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_get_unspent(vector_t* unspents);
 
 /** checks a transaction or relevance to the wallet */
 LIBDOGECOIN_API void dogecoin_wallet_check_transaction(void *ctx, dogecoin_tx *tx, unsigned int pos, dogecoin_blockindex *pindex);
@@ -195,12 +195,12 @@ LIBDOGECOIN_API void dogecoin_wallet_check_transaction(void *ctx, dogecoin_tx *t
  * may return NULL if transaction could not be found
  * memory is managed by the transaction tree
  */
-LIBDOGECOIN_API dogecoin_wtx * dogecoin_wallet_get_wtx(dogecoin_wallet* wallet, const uint256 hash);
+LIBDOGECOIN_API dogecoin_wtx * dogecoin_wallet_get_wtx(dogecoin_wallet* wallet, const uint256_t hash);
 
 LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_read(char* address);
 LIBDOGECOIN_API int dogecoin_register_watch_address_with_node(char* address);
 LIBDOGECOIN_API int dogecoin_unregister_watch_address_with_node(char* address);
-LIBDOGECOIN_API int dogecoin_get_utxo_vector(char* address, vector* utxo_vec);
+LIBDOGECOIN_API int dogecoin_get_utxo_vector(char* address, vector_t* utxo_vec);
 LIBDOGECOIN_API uint8_t* dogecoin_get_utxos(char* address);
 LIBDOGECOIN_API unsigned int dogecoin_get_utxos_length(char* address);
 LIBDOGECOIN_API char* dogecoin_get_utxo_txid_str(char* address, unsigned int index);

--- a/src/arith_uint256.c
+++ b/src/arith_uint256.c
@@ -100,7 +100,7 @@ arith_uint256* set_compact(arith_uint256* hash, uint32_t compact, dogecoin_bool 
     return hash;
 }
 
-arith_uint256* uint_to_arith(const uint256* a)
+arith_uint256* uint_to_arith(const uint256_t* a)
 {
     static arith_uint256 b;
     memcpy_safe(b.pn, a, sizeof(b.pn));
@@ -108,8 +108,8 @@ arith_uint256* uint_to_arith(const uint256* a)
 }
 
 uint8_t* arith_to_uint256(const arith_uint256* a) {
-    static uint256 b = {0};
-    memcpy_safe(b, a->pn, sizeof(uint256));
+    static uint256_t b = {0};
+    memcpy_safe(b, a->pn, sizeof(uint256_t));
     return &b[0];
 }
 

--- a/src/auxpow.c
+++ b/src/auxpow.c
@@ -57,25 +57,25 @@ int get_expected_index (uint32_t nNonce, int nChainId, unsigned h)
 }
 
 // Computes the Merkle root from a given hash, Merkle branch, and index.
-uint256* check_merkle_branch(uint256* hash, const vector* merkle_branch, int index) {
+uint256_t* check_merkle_branch(uint256_t* hash, const vector_t* merkle_branch, int index) {
     if (index == -1) {
-        return dogecoin_uint256_vla(1);  // Return a zeroed-out uint256 array.
+        return dogecoin_uint256_vla(1);  // Return a zeroed-out uint256_t array.
     }
 
-    uint256* current_hash = dogecoin_uint256_vla(1);
-    memcpy(current_hash, hash, sizeof(uint256)); // Copy the initial hash
+    uint256_t* current_hash = dogecoin_uint256_vla(1);
+    memcpy(current_hash, hash, sizeof(uint256_t)); // Copy the initial hash
 
     for (size_t i = 0; i < merkle_branch->len; ++i) {
-        uint256* next_branch_hash = (uint256*)vector_idx(merkle_branch, i);
-        uint256* new_hash;
+        uint256_t* next_branch_hash = (uint256_t*)vector_idx(merkle_branch, i);
+        uint256_t* new_hash;
 
         if (index & 1) {
-            new_hash = Hash((const uint256*) next_branch_hash, (const uint256*) current_hash);
+            new_hash = Hash((const uint256_t*) next_branch_hash, (const uint256_t*) current_hash);
         } else {
-            new_hash = Hash((const uint256*) current_hash, (const uint256*) next_branch_hash);
+            new_hash = Hash((const uint256_t*) current_hash, (const uint256_t*) next_branch_hash);
         }
 
-        memcpy(current_hash, new_hash, sizeof(uint256)); // Update the current hash
+        memcpy(current_hash, new_hash, sizeof(uint256_t)); // Update the current hash
         dogecoin_free(new_hash); // Free the new hash memory
         index >>= 1;
     }

--- a/src/base58.c
+++ b/src/base58.c
@@ -127,7 +127,7 @@ int dogecoin_base58_decode(void* bin, size_t* binszp, const char* b58, size_t b5
 
 int dogecoin_b58check(const void* bin, size_t binsz, const char* base58str)
 {
-    uint256 buf[32];
+    uint256_t buf[32];
     dogecoin_mem_zero(buf, 32);
     const uint8_t* binc = bin;
     unsigned i = 0;
@@ -200,7 +200,7 @@ size_t dogecoin_base58_encode_check(const uint8_t* data, size_t datalen, char* s
     if (datalen > 128) {
         return 0;
     }
-    size_t buf_size = datalen + sizeof(uint256);
+    size_t buf_size = datalen + sizeof(uint256_t);
     uint8_t* buf = dogecoin_uint8_vla(buf_size);
     uint8_t* hash = buf + datalen;
     memcpy_safe(buf, data, datalen);
@@ -243,20 +243,20 @@ size_t dogecoin_base58_decode_check(const char* str, uint8_t* data, size_t datal
     return ret;
 }
 
-dogecoin_bool dogecoin_p2pkh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char *addrout, size_t len) {
-    uint8_t hash160[sizeof(uint160)+1];
+dogecoin_bool dogecoin_p2pkh_addr_from_hash160(const uint160_t hashin, const dogecoin_chainparams* chain, char *addrout, size_t len) {
+    uint8_t hash160[sizeof(uint160_t)+1];
     hash160[0] = chain->b58prefix_pubkey_address;
-    memcpy_safe(hash160 + 1, hashin, sizeof(uint160));
+    memcpy_safe(hash160 + 1, hashin, sizeof(uint160_t));
 
-    return (dogecoin_base58_encode_check(hash160, sizeof(uint160)+1, addrout, len) > 0);
+    return (dogecoin_base58_encode_check(hash160, sizeof(uint160_t)+1, addrout, len) > 0);
 }
 
-dogecoin_bool dogecoin_p2sh_addr_from_hash160(const uint160 hashin, const dogecoin_chainparams* chain, char* addrout,
+dogecoin_bool dogecoin_p2sh_addr_from_hash160(const uint160_t hashin, const dogecoin_chainparams* chain, char* addrout,
                                     size_t len)
 {
-    uint8_t hash160[sizeof(uint160) + 1];
+    uint8_t hash160[sizeof(uint160_t) + 1];
     hash160[0] = chain->b58prefix_script_address;
-    memcpy_safe(hash160 + 1, hashin, sizeof(uint160));
+    memcpy_safe(hash160 + 1, hashin, sizeof(uint160_t));
 
-    return (dogecoin_base58_encode_check(hash160, sizeof(uint160) + 1, addrout, len) > 0);
+    return (dogecoin_base58_encode_check(hash160, sizeof(uint160_t) + 1, addrout, len) > 0);
 }

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -362,9 +362,9 @@ void dogecoin_hdnode_serialize_private(const dogecoin_hdnode* node, const dogeco
  *
  * @return Nothing.
  */
-void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_out)
+void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160_t hash160_out)
 {
-    uint256 hashout;
+    uint256_t hashout;
     dogecoin_hash_sngl_sha256(node->public_key, DOGECOIN_ECKEY_COMPRESSED_LENGTH, hashout);
     rmd160(hashout, sizeof(hashout), hash160_out);
 }
@@ -384,7 +384,7 @@ void dogecoin_hdnode_get_hash160(const dogecoin_hdnode* node, uint160 hash160_ou
  */
 void dogecoin_hdnode_get_p2pkh_address(const dogecoin_hdnode* node, const dogecoin_chainparams* chain, char* str, size_t strsize)
 {
-    uint8_t hash160[sizeof(uint160) + 1];
+    uint8_t hash160[sizeof(uint160_t) + 1];
     hash160[0] = chain->b58prefix_pubkey_address;
     dogecoin_hdnode_get_hash160(node, hash160 + 1);
     dogecoin_base58_encode_check(hash160, sizeof(hash160), str, strsize);

--- a/src/block.c
+++ b/src/block.c
@@ -43,7 +43,7 @@
 #include <dogecoin/utils.h>
 #include <dogecoin/validation.h>
 
-dogecoin_bool check(void *ctx, uint256* hash, uint32_t chainid, dogecoin_chainparams* params) {
+dogecoin_bool check(void *ctx, uint256_t* hash, uint32_t chainid, dogecoin_chainparams* params) {
     dogecoin_auxpow_block* block = (dogecoin_auxpow_block*)ctx;
 
     if (block->parent_merkle_index != 0) {
@@ -57,7 +57,7 @@ dogecoin_bool check(void *ctx, uint256* hash, uint32_t chainid, dogecoin_chainpa
         return false;
     }
 
-    vector* chain_merkle_branch = vector_new(block->aux_merkle_count, NULL);
+    vector_t* chain_merkle_branch = vector_new(block->aux_merkle_count, NULL);
     for (size_t p = 0; p < block->aux_merkle_count; p++) {
         vector_add(chain_merkle_branch, block->aux_merkle_branch[p]);
     }
@@ -69,7 +69,7 @@ dogecoin_bool check(void *ctx, uint256* hash, uint32_t chainid, dogecoin_chainpa
     }
 
     // First call to check_merkle_branch for the auxiliary blockchain's merkle branch
-    uint256* chain_merkle_root = check_merkle_branch(hash, chain_merkle_branch, block->aux_merkle_index);
+    uint256_t* chain_merkle_root = check_merkle_branch(hash, chain_merkle_branch, block->aux_merkle_index);
     vector_free(chain_merkle_branch, true);
 
     // Convert the root hash to a human-readable format (hex)
@@ -78,20 +78,20 @@ dogecoin_bool check(void *ctx, uint256* hash, uint32_t chainid, dogecoin_chainpa
     dogecoin_free(chain_merkle_root); // Free the computed merkle root
 
     // Compute the Merkle root for the parent block
-    vector* parent_merkle_branch = vector_new(block->parent_merkle_count, NULL);
+    vector_t* parent_merkle_branch = vector_new(block->parent_merkle_count, NULL);
     for (size_t p = 0; p < block->parent_merkle_count; p++) {
         vector_add(parent_merkle_branch, block->parent_coinbase_merkle[p]);
     }
 
     // Compute the hash of the parent block's coinbase transaction
-    uint256 parent_coinbase_hash;
+    uint256_t parent_coinbase_hash;
     dogecoin_tx_hash(block->parent_coinbase, parent_coinbase_hash);
 
-    uint256* parent_merkle_root = check_merkle_branch(&parent_coinbase_hash, parent_merkle_branch, block->parent_merkle_index);
+    uint256_t* parent_merkle_root = check_merkle_branch(&parent_coinbase_hash, parent_merkle_branch, block->parent_merkle_index);
     vector_free(parent_merkle_branch, true);
 
     // Check that the computed Merkle root matches the parent block's Merkle root
-    if (memcmp(parent_merkle_root, block->parent_header->merkle_root, sizeof(uint256)) != 0) {
+    if (memcmp(parent_merkle_root, block->parent_header->merkle_root, sizeof(uint256_t)) != 0) {
         printf("Aux POW merkle root incorrect\n");
         dogecoin_free(parent_merkle_root);
         return false;
@@ -313,7 +313,7 @@ void print_block(dogecoin_auxpow_block* block) {
  *
  * @return 1 if deserialization was successful, 0 otherwise.
  */
-int dogecoin_block_header_deserialize(dogecoin_block_header* header, struct const_buffer* buf, const dogecoin_chainparams *params, uint256* chainwork) {
+int dogecoin_block_header_deserialize(dogecoin_block_header* header, struct const_buffer* buf, const dogecoin_chainparams *params, uint256_t* chainwork) {
     dogecoin_auxpow_block* block = dogecoin_auxpow_block_new();
     if (!deser_s32(&block->header->version, buf))
         return false;
@@ -339,7 +339,7 @@ int dogecoin_block_header_deserialize(dogecoin_block_header* header, struct cons
     return true;
     }
 
-int deserialize_dogecoin_auxpow_block(dogecoin_auxpow_block* block, struct const_buffer* buffer, const dogecoin_chainparams *params, uint256* chainwork) {
+int deserialize_dogecoin_auxpow_block(dogecoin_auxpow_block* block, struct const_buffer* buffer, const dogecoin_chainparams *params, uint256_t* chainwork) {
     if (buffer->len > DOGECOIN_MAX_P2P_MSG_SIZE) {
         return printf("\ntransaction is invalid or to large.\n\n");
         }
@@ -372,7 +372,7 @@ int deserialize_dogecoin_auxpow_block(dogecoin_auxpow_block* block, struct const
     }
     uint8_t i = 0;
     if (block->parent_merkle_count > 0) {
-        block->parent_coinbase_merkle = dogecoin_calloc(block->parent_merkle_count, sizeof(uint256));
+        block->parent_coinbase_merkle = dogecoin_calloc(block->parent_merkle_count, sizeof(uint256_t));
     }
     for (; i < block->parent_merkle_count; i++) {
         if (!deser_u256(block->parent_coinbase_merkle[i], buffer)) {
@@ -390,7 +390,7 @@ int deserialize_dogecoin_auxpow_block(dogecoin_auxpow_block* block, struct const
         return false;
     }
     if (block->aux_merkle_count > 0) {
-        block->aux_merkle_branch = dogecoin_calloc(block->aux_merkle_count, sizeof(uint256));
+        block->aux_merkle_branch = dogecoin_calloc(block->aux_merkle_count, sizeof(uint256_t));
     }
     for (i = 0; i < block->aux_merkle_count; i++) {
         if (!deser_u256(block->aux_merkle_branch[i], buffer)) {
@@ -484,7 +484,7 @@ void dogecoin_block_header_copy(dogecoin_block_header* dest, const dogecoin_bloc
  *
  * @return True.
  */
-dogecoin_bool dogecoin_block_header_hash(dogecoin_block_header* header, uint256 hash) {
+dogecoin_bool dogecoin_block_header_hash(dogecoin_block_header* header, uint256_t hash) {
     cstring* s = cstr_new_sz(80);
     dogecoin_block_header_serialize(s, header);
     sha256_raw((const uint8_t*)s->str, s->len, hash);

--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -1032,7 +1032,7 @@ int main(int argc, char* argv[])
         cstring* script = cstr_new_buf(script_data, outlen);
         free(script_data);
 
-        uint256 sighash;
+        uint256_t sighash;
         dogecoin_mem_zero(sighash, sizeof(sighash));
         dogecoin_tx_sighash(tx, script, inputindex, sighashtype, sighash);
 

--- a/src/ecc.c
+++ b/src/ecc.c
@@ -87,7 +87,7 @@ dogecoin_bool dogecoin_ecc_verify_pubkey(const uint8_t* public_key, dogecoin_boo
     return true;
 }
 
-dogecoin_bool dogecoin_ecc_sign(const uint8_t* private_key, const uint256 hash, unsigned char* sigder, size_t* outlen)
+dogecoin_bool dogecoin_ecc_sign(const uint8_t* private_key, const uint256_t hash, unsigned char* sigder, size_t* outlen)
 {
     assert(secp256k1_ctx);
     secp256k1_ecdsa_signature sig;
@@ -98,7 +98,7 @@ dogecoin_bool dogecoin_ecc_sign(const uint8_t* private_key, const uint256 hash, 
     return 1;
 }
 
-dogecoin_bool dogecoin_ecc_sign_compact(const uint8_t* private_key, const uint256 hash, unsigned char* sigcomp, size_t* outlen)
+dogecoin_bool dogecoin_ecc_sign_compact(const uint8_t* private_key, const uint256_t hash, unsigned char* sigcomp, size_t* outlen)
 {
     assert(secp256k1_ctx);
     secp256k1_ecdsa_signature sig;
@@ -110,7 +110,7 @@ dogecoin_bool dogecoin_ecc_sign_compact(const uint8_t* private_key, const uint25
     return 1;
 }
 
-dogecoin_bool dogecoin_ecc_sign_compact_recoverable(const uint8_t* private_key, const uint256 hash, unsigned char* sigrec, size_t* outlen, int* recid)
+dogecoin_bool dogecoin_ecc_sign_compact_recoverable(const uint8_t* private_key, const uint256_t hash, unsigned char* sigrec, size_t* outlen, int* recid)
 {
     assert(secp256k1_ctx);
     secp256k1_ecdsa_recoverable_signature sig;
@@ -122,7 +122,7 @@ dogecoin_bool dogecoin_ecc_sign_compact_recoverable(const uint8_t* private_key, 
     return 1;
 }
 
-dogecoin_bool dogecoin_ecc_sign_compact_recoverable_fcomp(const uint8_t* private_key, const uint256 hash, unsigned char* sigrec, size_t* outlen, int* recid, bool fCompressed)
+dogecoin_bool dogecoin_ecc_sign_compact_recoverable_fcomp(const uint8_t* private_key, const uint256_t hash, unsigned char* sigrec, size_t* outlen, int* recid, bool fCompressed)
 {
     assert(secp256k1_ctx);
     secp256k1_ecdsa_recoverable_signature sig;
@@ -134,7 +134,7 @@ dogecoin_bool dogecoin_ecc_sign_compact_recoverable_fcomp(const uint8_t* private
     return true;
 }
 
-dogecoin_bool dogecoin_recover_pubkey(const unsigned char* sigrec, const uint256 hash, const int recid, uint8_t* public_key, size_t* outlen)
+dogecoin_bool dogecoin_recover_pubkey(const unsigned char* sigrec, const uint256_t hash, const int recid, uint8_t* public_key, size_t* outlen)
 {
     assert(secp256k1_ctx);
     secp256k1_pubkey pubkey;
@@ -148,7 +148,7 @@ dogecoin_bool dogecoin_recover_pubkey(const unsigned char* sigrec, const uint256
     return 1;
 }
 
-dogecoin_bool dogecoin_ecc_recover_pubkey(const unsigned char* sigrec, const uint256 hash, const int recid, uint8_t* public_key, size_t* outlen)
+dogecoin_bool dogecoin_ecc_recover_pubkey(const unsigned char* sigrec, const uint256_t hash, const int recid, uint8_t* public_key, size_t* outlen)
 {
     assert(secp256k1_ctx);
     secp256k1_pubkey pubkey;
@@ -162,7 +162,7 @@ dogecoin_bool dogecoin_ecc_recover_pubkey(const unsigned char* sigrec, const uin
     return 1;
 }
 
-dogecoin_bool dogecoin_ecc_verify_sig(const uint8_t* public_key, dogecoin_bool compressed, const uint256 hash, unsigned char* sigder, size_t siglen)
+dogecoin_bool dogecoin_ecc_verify_sig(const uint8_t* public_key, dogecoin_bool compressed, const uint256_t hash, unsigned char* sigder, size_t siglen)
 {
     assert(secp256k1_ctx);
     secp256k1_ecdsa_signature sig;
@@ -174,7 +174,7 @@ dogecoin_bool dogecoin_ecc_verify_sig(const uint8_t* public_key, dogecoin_bool c
     return secp256k1_ecdsa_verify(secp256k1_ctx, &sig, hash, &pubkey);
 }
 
-dogecoin_bool dogecoin_ecc_verify_sigcmp(const uint8_t* public_key, dogecoin_bool compressed, const uint256 hash, unsigned char* sigcmp)
+dogecoin_bool dogecoin_ecc_verify_sigcmp(const uint8_t* public_key, dogecoin_bool compressed, const uint256_t hash, unsigned char* sigcmp)
 {
     assert(secp256k1_ctx);
     secp256k1_ecdsa_signature sig;

--- a/src/headersdb_file.c
+++ b/src/headersdb_file.c
@@ -59,7 +59,7 @@ int dogecoin_header_compare(const void *l, const void *r)
     uint8_t *hashB = (uint8_t *)lr->hash;
 
     unsigned int i;
-    for (i = 0; i < sizeof(uint256); i++) {
+    for (i = 0; i < sizeof(uint256_t); i++) {
         uint8_t iA = hashA[i];
         uint8_t iB = hashB[i];
         if (iA > iB)
@@ -223,9 +223,9 @@ dogecoin_bool dogecoin_headers_db_load(dogecoin_headers_db* db, const char *file
 
                 //load all
 
-                uint256 hash;
+                uint256_t hash;
                 uint32_t height;
-                uint256 chainwork;
+                uint256_t chainwork;
                 deser_u256(hash, &cbuf_all);
                 deser_u32(&height, &cbuf_all);
                 deser_u256(chainwork, &cbuf_all);
@@ -258,7 +258,7 @@ dogecoin_bool dogecoin_headers_db_load(dogecoin_headers_db* db, const char *file
                         connected_headers_count++;
                     }
                 }
-                memcpy(db->chaintip->chainwork, chainwork, sizeof(uint256));
+                memcpy(db->chaintip->chainwork, chainwork, sizeof(uint256_t));
             }
         }
     }
@@ -336,7 +336,7 @@ dogecoin_blockindex * dogecoin_headers_db_connect_hdr(dogecoin_headers_db* db, s
     if (connect_at != NULL) {
         // Check the proof of work
         if (!is_auxpow(blockindex->header.version)) {
-            uint256 hash = {0};
+            uint256_t hash = {0};
             cstring* s = cstr_new_sz(64);
             dogecoin_block_header_serialize(s, (const dogecoin_block_header*) &blockindex->header);
             dogecoin_block_header_scrypt_hash(s, &hash);
@@ -475,12 +475,12 @@ dogecoin_blockindex * dogecoin_headers_db_connect_hdr(dogecoin_headers_db* db, s
 
 /**
  * The function iterates through the chain tip and adds the hash of each block to the blocklocators
- * vector
+ * vector_t
  *
  * @param db the database object
- * @param blocklocators a vector of block hashes
+ * @param blocklocators a vector_t of block hashes
  */
-void dogecoin_headers_db_fill_block_locator(dogecoin_headers_db* db, vector *blocklocators)
+void dogecoin_headers_db_fill_block_locator(dogecoin_headers_db* db, vector_t *blocklocators)
 {
     dogecoin_blockindex *scan_tip = db->chaintip;
     if (scan_tip->height > 0)
@@ -489,8 +489,8 @@ void dogecoin_headers_db_fill_block_locator(dogecoin_headers_db* db, vector *blo
         for(; i<10;i++)
         {
             //TODO: try to share memory and avoid heap allocation
-            uint256 *hash = dogecoin_calloc(1, sizeof(uint256));
-            memcpy_safe(hash, scan_tip->hash, sizeof(uint256));
+            uint256_t *hash = dogecoin_calloc(1, sizeof(uint256_t));
+            memcpy_safe(hash, scan_tip->hash, sizeof(uint256_t));
             vector_add(blocklocators, (void *)hash);
 
             if (scan_tip->prev)
@@ -509,11 +509,11 @@ void dogecoin_headers_db_fill_block_locator(dogecoin_headers_db* db, vector *blo
  *
  * @return A pointer to the blockindex.
  */
-dogecoin_blockindex * dogecoin_headersdb_find(dogecoin_headers_db* db, uint256 hash) {
+dogecoin_blockindex * dogecoin_headersdb_find(dogecoin_headers_db* db, uint256_t hash) {
     if (db->use_binary_tree)
     {
         dogecoin_blockindex *blockindex = dogecoin_calloc(1, sizeof(dogecoin_blockindex));
-        memcpy_safe(blockindex->hash, hash, sizeof(uint256));
+        memcpy_safe(blockindex->hash, hash, sizeof(uint256_t));
         dogecoin_blockindex *blockindex_f = dogecoin_btree_tfind(blockindex, &db->tree_root, dogecoin_header_compare); /* read */
         if (blockindex_f) {
             blockindex_f = *(dogecoin_blockindex **)blockindex_f;
@@ -576,10 +576,10 @@ dogecoin_bool dogecoin_headersdb_has_checkpoint_start(dogecoin_headers_db* db) {
  * @param height The height of the block that this is a checkpoint for.
  * @param chainwork The chainwork of the block that this is a checkpoint for.
  */
-void dogecoin_headersdb_set_checkpoint_start(dogecoin_headers_db* db, uint256 hash, uint32_t height, uint256 chainwork) {
+void dogecoin_headersdb_set_checkpoint_start(dogecoin_headers_db* db, uint256_t hash, uint32_t height, uint256_t chainwork) {
     db->chainbottom = dogecoin_calloc(1, sizeof(dogecoin_blockindex));
     db->chainbottom->height = height;
-    memcpy_safe(db->chainbottom->hash, hash, sizeof(uint256));
-    memcpy_safe(db->chainbottom->chainwork, chainwork, sizeof(uint256));
+    memcpy_safe(db->chainbottom->hash, hash, sizeof(uint256_t));
+    memcpy_safe(db->chainbottom->chainwork, chainwork, sizeof(uint256_t));
     db->chaintip = db->chainbottom;
 }

--- a/src/key.c
+++ b/src/key.c
@@ -75,7 +75,7 @@ dogecoin_bool dogecoin_privkey_gen(dogecoin_key* privkey)
 
 dogecoin_bool dogecoin_privkey_verify_pubkey(dogecoin_key* privkey, dogecoin_pubkey* pubkey)
 {
-    uint256 rnddata, hash;
+    uint256_t rnddata, hash;
     const dogecoin_bool res = dogecoin_random_bytes(rnddata, DOGECOIN_HASH_LENGTH, 0);
     if (!res)
         return false;
@@ -150,9 +150,9 @@ void dogecoin_pubkey_cleanse(dogecoin_pubkey* pubkey)
     dogecoin_mem_zero(pubkey->pubkey, DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH);
 }
 
-void dogecoin_pubkey_get_hash160(const dogecoin_pubkey* pubkey, uint160 hash160)
+void dogecoin_pubkey_get_hash160(const dogecoin_pubkey* pubkey, uint160_t hash160)
 {
-    uint256 hashout;
+    uint256_t hashout;
     dogecoin_hash_sngl_sha256(pubkey->pubkey, pubkey->compressed ? DOGECOIN_ECKEY_COMPRESSED_LENGTH : DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH, hashout);
     rmd160(hashout, sizeof(hashout), hash160);
 }
@@ -175,27 +175,27 @@ void dogecoin_pubkey_from_key(const dogecoin_key* privkey, dogecoin_pubkey* pubk
     pubkey_inout->compressed = true;
 }
 
-dogecoin_bool dogecoin_key_sign_hash(const dogecoin_key* privkey, const uint256 hash, unsigned char* sigout, size_t* outlen)
+dogecoin_bool dogecoin_key_sign_hash(const dogecoin_key* privkey, const uint256_t hash, unsigned char* sigout, size_t* outlen)
 {
     return dogecoin_ecc_sign(privkey->privkey, hash, sigout, outlen);
 }
 
-dogecoin_bool dogecoin_key_sign_hash_compact(const dogecoin_key* privkey, const uint256 hash, unsigned char* sigout, size_t* outlen)
+dogecoin_bool dogecoin_key_sign_hash_compact(const dogecoin_key* privkey, const uint256_t hash, unsigned char* sigout, size_t* outlen)
 {
     return dogecoin_ecc_sign_compact(privkey->privkey, hash, sigout, outlen);
 }
 
-dogecoin_bool dogecoin_key_sign_hash_compact_recoverable(const dogecoin_key* privkey, const uint256 hash, unsigned char* sigout, size_t* outlen, int* recid)
+dogecoin_bool dogecoin_key_sign_hash_compact_recoverable(const dogecoin_key* privkey, const uint256_t hash, unsigned char* sigout, size_t* outlen, int* recid)
 {
     return dogecoin_ecc_sign_compact_recoverable(privkey->privkey, hash, sigout, outlen, recid);
 }
 
-dogecoin_bool dogecoin_key_sign_hash_compact_recoverable_fcomp(const dogecoin_key* privkey, const uint256 hash, unsigned char* sigout, size_t* outlen, int* recid)
+dogecoin_bool dogecoin_key_sign_hash_compact_recoverable_fcomp(const dogecoin_key* privkey, const uint256_t hash, unsigned char* sigout, size_t* outlen, int* recid)
 {
     return dogecoin_ecc_sign_compact_recoverable_fcomp(privkey->privkey, hash, sigout, outlen, recid, true);
 }
 
-dogecoin_bool dogecoin_key_recover_pubkey(const unsigned char* sig, const uint256 hash, int recid, dogecoin_pubkey* pubkey)
+dogecoin_bool dogecoin_key_recover_pubkey(const unsigned char* sig, const uint256_t hash, int recid, dogecoin_pubkey* pubkey)
 {
     uint8_t pubkeybuf[128];
     size_t outlen = 128;
@@ -208,7 +208,7 @@ dogecoin_bool dogecoin_key_recover_pubkey(const unsigned char* sig, const uint25
     return 1;
 }
 
-dogecoin_bool dogecoin_key_sign_recover_pubkey(const unsigned char* sig, const uint256 hash, int recid, dogecoin_pubkey* pubkey)
+dogecoin_bool dogecoin_key_sign_recover_pubkey(const unsigned char* sig, const uint256_t hash, int recid, dogecoin_pubkey* pubkey)
 {
     uint8_t pubkeybuf[128];
     size_t outlen = 128;
@@ -221,12 +221,12 @@ dogecoin_bool dogecoin_key_sign_recover_pubkey(const unsigned char* sig, const u
     return 1;
 }
 
-dogecoin_bool dogecoin_pubkey_verify_sig(const dogecoin_pubkey* pubkey, const uint256 hash, unsigned char* sigder, size_t len)
+dogecoin_bool dogecoin_pubkey_verify_sig(const dogecoin_pubkey* pubkey, const uint256_t hash, unsigned char* sigder, size_t len)
 {
     return dogecoin_ecc_verify_sig(pubkey->pubkey, pubkey->compressed, hash, sigder, len);
 }
 
-dogecoin_bool dogecoin_pubkey_verify_sigcmp(const dogecoin_pubkey* pubkey, const uint256 hash, unsigned char* sigcmp)
+dogecoin_bool dogecoin_pubkey_verify_sigcmp(const dogecoin_pubkey* pubkey, const uint256_t hash, unsigned char* sigcmp)
 {
     return dogecoin_ecc_verify_sigcmp(pubkey->pubkey, pubkey->compressed, hash, sigcmp);
 }
@@ -251,7 +251,7 @@ dogecoin_bool init_keypair(char* privkeywif, dogecoin_key* key, dogecoin_pubkey*
 
 dogecoin_bool dogecoin_pubkey_getaddr_p2pkh(const dogecoin_pubkey* pubkey, const dogecoin_chainparams* chain, char* addrout)
 {
-    uint8_t hash160[sizeof(uint160) + 1];
+    uint8_t hash160[sizeof(uint160_t) + 1];
     hash160[0] = chain->b58prefix_pubkey_address;
     dogecoin_pubkey_get_hash160(pubkey, hash160 + 1);
     dogecoin_base58_encode_check(hash160, sizeof(hash160), addrout, 100);

--- a/src/map.c
+++ b/src/map.c
@@ -33,8 +33,8 @@
 /**
  * @brief This function instantiates a new working hash,
  * but does not add it to the hash table.
- * 
- * @return A pointer to the new working hash. 
+ *
+ * @return A pointer to the new working hash.
  */
 hash* new_hash() {
     hash* h = (struct hash*)dogecoin_calloc(1, sizeof *h);
@@ -47,9 +47,9 @@ hash* new_hash() {
 /**
  * @brief This function takes a pointer to an existing working
  * hash object and adds it to the hash table.
- * 
+ *
  * @param map The pointer to the working hash.
- * 
+ *
  * @return Nothing.
  */
 void add_hash(hash *x) {
@@ -67,7 +67,7 @@ void add_hash(hash *x) {
  * @brief This function creates a new map, places it in
  * the hash table, and returns the index of the new map,
  * starting from 1 and incrementing each subsequent call.
- * 
+ *
  * @return The index of the new map.
  */
 int start_hash() {
@@ -79,9 +79,9 @@ int start_hash() {
 /**
  * @brief This function takes an index and returns the working
  * hash associated with that index in the hash table.
- * 
+ *
  * @param index The index of the target working hash.
- * 
+ *
  * @return The pointer to the working hash associated with
  * the provided index.
  */
@@ -93,7 +93,7 @@ hash* find_hash(int index) {
 
 hash* zero_hash(int index) {
     hash* hash = find_hash(index);
-    dogecoin_mem_zero(hash->data.u8, sizeof(uint256));
+    dogecoin_mem_zero(hash->data.u8, sizeof(uint256_t));
     return hash;
 }
 
@@ -113,8 +113,8 @@ void print_hash(int index) {
 /**
  * @brief This function counts the number of working
  * hashes currently in the hash table.
- * 
- * @return Nothing. 
+ *
+ * @return Nothing.
  */
 void count_hashes() {
     int temp = HASH_COUNT(hashes);
@@ -129,9 +129,9 @@ char* get_hash_by_index(int index) {
 /**
  * @brief This function removes the specified working hash
  * from the hash table and frees the hashes in memory.
- * 
+ *
  * @param map The pointer to the hash to remove.
- * 
+ *
  * @return Nothing.
  */
 void remove_hash(hash *hash) {
@@ -143,8 +143,8 @@ void remove_hash(hash *hash) {
 /**
  * @brief This function removes all working hashes from
  * the hash table.
- * 
- * @return Nothing. 
+ *
+ * @return Nothing.
  */
 void remove_all_hashes() {
     struct hash *hash;
@@ -158,8 +158,8 @@ void remove_all_hashes() {
 /**
  * @brief This function instantiates a new working map,
  * but does not add it to the hash table.
- * 
- * @return A pointer to the new working map. 
+ *
+ * @return A pointer to the new working map.
  */
 map* new_map() {
     map* m = (struct map*)dogecoin_calloc(1, sizeof *m);
@@ -174,7 +174,7 @@ map* new_map() {
  * @brief This function creates a new map, places it in
  * the hash table, and returns the index of the new map,
  * starting from 1 and incrementing each subsequent call.
- * 
+ *
  * @return The index of the new map.
  */
 int start_map() {
@@ -186,9 +186,9 @@ int start_map() {
 /**
  * @brief This function takes a pointer to an existing working
  * map object and adds it to the hash table.
- * 
+ *
  * @param map The pointer to the working map.
- * 
+ *
  * @return Nothing.
  */
 void add_map(map* map_external) {
@@ -205,9 +205,9 @@ void add_map(map* map_external) {
 /**
  * @brief This function takes an index and returns the working
  * map associated with that index in the hash table.
- * 
+ *
  * @param index The index of the target working map.
- * 
+ *
  * @return The pointer to the working map associated with
  * the provided index.
  */
@@ -220,9 +220,9 @@ map* find_map(int index) {
 /**
  * @brief This function removes the specified working map
  * from the hash table and frees the maps in memory.
- * 
+ *
  * @param map The pointer to the map to remove.
- * 
+ *
  * @return Nothing.
  */
 void remove_map(map *map) {
@@ -233,8 +233,8 @@ void remove_map(map *map) {
 /**
  * @brief This function removes all working maps from
  * the hash table.
- * 
- * @return Nothing. 
+ *
+ * @return Nothing.
  */
 void remove_all_maps() {
     struct map *map;

--- a/src/mem.c
+++ b/src/mem.c
@@ -43,7 +43,7 @@ static dogecoin_mem_mapper current_mem_mapper = {dogecoin_malloc_internal, dogec
 /**
  * @brief This function sets the current memory mapper
  * to the default memory mapper.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_mem_set_mapper_default()
@@ -55,9 +55,9 @@ void dogecoin_mem_set_mapper_default()
 /**
  * @brief This function sets the current memory mapper
  * to the specified mapper.
- * 
+ *
  * @param mapper The mapper to be used.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_mem_set_mapper(const dogecoin_mem_mapper mapper)
@@ -67,12 +67,12 @@ void dogecoin_mem_set_mapper(const dogecoin_mem_mapper mapper)
 
 
 /**
- * @brief This function calls dogecoin_malloc_internal() using 
+ * @brief This function calls dogecoin_malloc_internal() using
  * the current memory mapper.
- * 
+ *
  * @param size The size of the memory block to be allocated.
- * 
- * @return A pointer to the allocated memory. 
+ *
+ * @return A pointer to the allocated memory.
  */
 void* dogecoin_malloc(size_t size)
 {
@@ -83,11 +83,11 @@ void* dogecoin_malloc(size_t size)
 /**
  * @brief This function calls dogecoin_calloc_internal() using
  * the current memory mapper.
- * 
+ *
  * @param count The number of elements to allocate.
  * @param size The size of each element.
- * 
- * @return A pointer to the allocated memory. 
+ *
+ * @return A pointer to the allocated memory.
  */
 void* dogecoin_calloc(size_t count, size_t size)
 {
@@ -98,10 +98,10 @@ void* dogecoin_calloc(size_t count, size_t size)
 /**
  * @brief This function calls dogecoin_realloc_internal() using
  * the current memory mapper.
- * 
+ *
  * @param ptr The pointer to the old memory block.
  * @param size The size of the new memory block to be reallocated.
- * 
+ *
  * @return A pointer to the reallocated memory.
  */
 void* dogecoin_realloc(void* ptr, size_t size)
@@ -113,9 +113,9 @@ void* dogecoin_realloc(void* ptr, size_t size)
 /**
  * @brief This function calls dogecoin_free_internal() using
  * the current memory mapper.
- * 
+ *
  * @param ptr The pointer to the memory block to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_free(void* ptr)
@@ -126,10 +126,10 @@ void dogecoin_free(void* ptr)
 
 /**
  * @brief This function allocates a memory block.
- * 
+ *
  * @param size The size of the memory block to be allocated.
- * 
- * @return A pointer to the allocated memory. 
+ *
+ * @return A pointer to the allocated memory.
  */
 void* dogecoin_malloc_internal(size_t size)
 {
@@ -149,11 +149,11 @@ void* dogecoin_malloc_internal(size_t size)
 /**
  * @brief This function allocates memory and initializes all
  * bytes to zero.
- * 
+ *
  * @param count The number of elements to allocate.
  * @param size The size of each element.
- * 
- * @return A pointer to the allocated memory. 
+ *
+ * @return A pointer to the allocated memory.
  */
 void* dogecoin_calloc_internal(size_t count, size_t size)
 {
@@ -173,10 +173,10 @@ void* dogecoin_calloc_internal(size_t count, size_t size)
 /**
  * @brief This function resizes the memory block pointed to
  * by ptr which was previously allocated.
- * 
+ *
  * @param ptr The pointer to the old memory block.
  * @param size The size of the new memory block to be reallocated.
- * 
+ *
  * @return A pointer to the reallocated memory.
  */
 void* dogecoin_realloc_internal(void* ptr, size_t size)
@@ -196,9 +196,9 @@ void* dogecoin_realloc_internal(void* ptr, size_t size)
 
 /**
  * @brief This function frees previously allocated memory.
- * 
+ *
  * @param ptr The pointer to the memory block to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_free_internal(void* ptr)
@@ -222,21 +222,21 @@ errno_t memset_safe(volatile void *v, rsize_t smax, int c, rsize_t n) {
   if (v == NULL) return EINVAL;
   if (smax > RSIZE_MAX) return EINVAL;
   if (n > smax) return EINVAL;
- 
+
   volatile unsigned char *p = v;
   while (smax-- && n--) {
     *p++ = c;
   }
- 
+
   return 0;
 }
 
 /**
  * "memset_safe() is a secure version of memset()."
- * 
+ *
  * The memset_safe() function is a secure version of memset() that fills the memory pointed to by dst with
  * zeros
- * 
+ *
  * @param dst The destination buffer to be zeroed.
  * @param len The length of the memory block to zero.
  */
@@ -260,9 +260,9 @@ uint32_t* dogecoin_uint32_vla(size_t size)
     return outarray;
 }
 
-uint256* dogecoin_uint256_vla(size_t size) {
-    uint256* outarray;
-    outarray = (uint256*)dogecoin_malloc(size * sizeof(uint256));
+uint256_t* dogecoin_uint256_vla(size_t size) {
+    uint256_t* outarray;
+    outarray = (uint256_t*)dogecoin_malloc(size * sizeof(uint256_t));
     return outarray;
 }
 

--- a/src/net.c
+++ b/src/net.c
@@ -769,17 +769,17 @@ int dogecoin_node_parse_message(dogecoin_node* node, dogecoin_p2p_msg_hdr* hdr, 
 }
 
 /**
- * Given a seed DNS name, return a vector of IP addresses and ports.
+ * Given a seed DNS name, return a vector_t of IP addresses and ports.
  * (utility function to get peers (ips/port as char*) from a seed)
  *
  * @param seed The seed DNS name.
- * @param ips_out A vector of strings.
+ * @param ips_out A vector_t of strings.
  * @param port The port to connect to.
  * @param family The address family of the socket. AF_INET or AF_INET6.
  *
  * @return size_t
  */
-size_t dogecoin_get_peers_from_dns(const char* seed, vector* ips_out, int port, int family)
+size_t dogecoin_get_peers_from_dns(const char* seed, vector_t* ips_out, int port, int family)
 {
     if (!seed || !ips_out || (family != AF_INET && family != AF_INET6) || port > 99999) {
         return 0;
@@ -832,7 +832,7 @@ size_t dogecoin_get_peers_from_dns(const char* seed, vector* ips_out, int port, 
 dogecoin_bool dogecoin_node_group_add_peers_by_ip_or_seed(dogecoin_node_group *group, const char *ips) {
     if (ips == NULL) {
         /* === DNS QUERY === */
-        vector* ips_dns = vector_new(10, free);
+        vector_t* ips_dns = vector_new(10, free);
         unsigned int seed_index;
         /* dogecoin_chainparams has up to 8 dns seeds */
         for (seed_index = 0; seed_index < 8; seed_index++) {
@@ -935,7 +935,7 @@ void broadcast_handshake_done(struct dogecoin_node_* node) {
     dogecoin_p2p_inv_msg inv_msg;
     dogecoin_mem_zero(&inv_msg, sizeof(inv_msg));
 
-    uint256 hash;
+    uint256_t hash;
     dogecoin_tx_hash(ctx->tx, hash);
     dogecoin_p2p_msg_inv_init(&inv_msg, DOGECOIN_INV_TYPE_TX, hash);
 
@@ -984,7 +984,7 @@ void broadcast_post_cmd(struct dogecoin_node_* node, dogecoin_p2p_msg_hdr* hdr, 
     if (strcmp(hdr->command, DOGECOIN_MSG_INV) == 0) {
         /* hash the tx */
         /* TODO: cache the hash */
-        uint256 hash;
+        uint256_t hash;
         dogecoin_tx_hash(ctx->tx, hash);
 
         uint32_t vsize;
@@ -1079,7 +1079,7 @@ dogecoin_bool broadcast_tx(const dogecoin_chainparams* chain, const dogecoin_tx*
 
     dogecoin_node_group_add_peers_by_ip_or_seed(group, ips);
 
-    uint256 txhash;
+    uint256_t txhash;
     dogecoin_tx_hash(tx, txhash);
     char hexout[sizeof(txhash) * 2 + 1];
     utils_bin_to_hex(txhash, sizeof(txhash), hexout);

--- a/src/pow.c
+++ b/src/pow.c
@@ -29,7 +29,7 @@
 
 #include <dogecoin/pow.h>
 
-dogecoin_bool uint256_cmp(const uint256 a, const uint256 b) {
+dogecoin_bool uint256_cmp(const uint256_t a, const uint256_t b) {
     for (int i = 31; i >= 0; i--) {
         if (a[i] > b[i]) {
             return true;
@@ -40,11 +40,11 @@ dogecoin_bool uint256_cmp(const uint256 a, const uint256 b) {
     return false; // Return false if all bytes are equal
 }
 
-dogecoin_bool check_pow(uint256* hash, unsigned int nbits, const dogecoin_chainparams *params, uint256* chainwork) {
+dogecoin_bool check_pow(uint256_t* hash, unsigned int nbits, const dogecoin_chainparams *params, uint256_t* chainwork) {
     dogecoin_bool f_negative, f_overflow;
     arith_uint256* target = init_arith_uint256();
     target = set_compact(target, nbits, &f_negative, &f_overflow);
-    uint8_t* target_uint256 = dogecoin_malloc(sizeof(uint256));
+    uint8_t* target_uint256 = dogecoin_malloc(sizeof(uint256_t));
     memcpy(target_uint256, target, sizeof(arith_uint256));
     if (f_negative || arith_uint256_is_zero(target) || f_overflow || uint256_cmp(target_uint256, params->pow_limit)) {
         printf("%d:%s: f_negative: %d target == 0: %d f_overflow: %d\n",
@@ -53,7 +53,7 @@ dogecoin_bool check_pow(uint256* hash, unsigned int nbits, const dogecoin_chainp
         dogecoin_free(target_uint256);
         return false;
     }
-    swap_bytes((uint8_t*)hash, sizeof(uint256));
+    swap_bytes((uint8_t*)hash, sizeof(uint256_t));
     if (uint256_cmp((const uint8_t*)hash, target_uint256)) {
         char* rtn_str = utils_uint8_to_hex((const uint8_t*)hash, 32);
         char hash_str[65] = "";
@@ -84,7 +84,7 @@ dogecoin_bool check_pow(uint256* hash, unsigned int nbits, const dogecoin_chainp
     arith_uint256* final_hashes = add_arith_uint256(hashes, one);
 
     if (chainwork != NULL) {
-        memcpy(chainwork, (const arith_uint256*) final_hashes, sizeof(uint256));
+        memcpy(chainwork, (const arith_uint256*) final_hashes, sizeof(uint256_t));
     }
 
     // Clean up

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -47,9 +47,9 @@ static const uint8_t DOGECOIN_IPV4_PREFIX[12] = {0x00, 0x00, 0x00, 0x00, 0x00, 0
 
 /**
  * If the first 12 bytes of the IP address are the same as the DOGECOIN_IPV4_PREFIX.
- * 
+ *
  * @param ipaddr the IP address in network byte order
- * 
+ *
  * @return static inline dogecoin_bool (uint8_t)
  */
 static inline dogecoin_bool is_ipv4_mapped(const unsigned char* ipaddr)
@@ -59,7 +59,7 @@ static inline dogecoin_bool is_ipv4_mapped(const unsigned char* ipaddr)
 
 /**
  * Initialize a dogecoin_p2p_address struct
- * 
+ *
  * @param addr the address structure to initialize
  */
 void dogecoin_p2p_address_init(dogecoin_p2p_address* addr)
@@ -69,12 +69,12 @@ void dogecoin_p2p_address_init(dogecoin_p2p_address* addr)
 
 /**
  * Create a new cstring object with the header information for a dogecoin p2p message
- * 
+ *
  * @param netmagic The magic number is a 4-byte value that identifies the network.
  * @param command The command string.
  * @param data The data to be sent.
  * @param data_len The length of the data payload.
- * 
+ *
  * @return A cstring object.
  */
 cstring* dogecoin_p2p_message_new(const unsigned char netmagic[4], const char* command, const void* data, uint32_t data_len)
@@ -96,7 +96,7 @@ cstring* dogecoin_p2p_message_new(const unsigned char netmagic[4], const char* c
     cstr_append_buf(s, &data_len_le, 4);
 
     /* data checksum (first 4 bytes of the double sha256 hash of the pl) */
-    uint256 msghash;
+    uint256_t msghash;
     dogecoin_hash(data, data_len, msghash);
     cstr_append_buf(s, &msghash[0], 4);
 
@@ -109,11 +109,11 @@ cstring* dogecoin_p2p_message_new(const unsigned char netmagic[4], const char* c
 
 /**
  * Deserialize an address
- * 
+ *
  * @param protocol_version The version of the protocol the node is using.
  * @param addr the address object to be filled in
  * @param buf The buffer to deserialize from.
- * 
+ *
  * @return dogecoin_bool (uint8_t)
  */
 dogecoin_bool dogecoin_p2p_deser_addr(unsigned int protocol_version, dogecoin_p2p_address* addr, struct const_buffer* buf)
@@ -135,7 +135,7 @@ dogecoin_bool dogecoin_p2p_deser_addr(unsigned int protocol_version, dogecoin_p2
 
 /**
  * Serialize a dogecoin_p2p_address struct to a cstring
- * 
+ *
  * @param protover The protocol version.
  * @param addr The address to serialize.
  * @param s The cstring to serialize to.
@@ -152,7 +152,7 @@ void dogecoin_p2p_ser_addr(unsigned int protover, const dogecoin_p2p_address* ad
 
 /**
  * Convert a sockaddr to a dogecoin_p2p_address
- * 
+ *
  * @param addr The address to convert.
  * @param addr_out the address to be filled in
  */
@@ -173,10 +173,10 @@ void dogecoin_addr_to_p2paddr(struct sockaddr* addr, dogecoin_p2p_address* addr_
 
 /**
  * Convert a dogecoin_p2p_address struct to a sockaddr struct
- * 
+ *
  * @param p2p_addr the p2p_address struct to convert
  * @param addr_out The address to write the result to.
- * 
+ *
  * @return a pointer to a dogecoin_p2p_address structure.
  */
 void dogecoin_p2paddr_to_addr(dogecoin_p2p_address* p2p_addr, struct sockaddr* addr_out)
@@ -198,7 +198,7 @@ void dogecoin_p2paddr_to_addr(dogecoin_p2p_address* p2p_addr, struct sockaddr* a
 
 /**
  * Initialize a dogecoin_p2p_version_msg struct with the given parameters
- * 
+ *
  * @param msg the message object
  * @param addrFrom The address of the node that sent the message.
  * @param addrTo The address to which the message is being sent.
@@ -229,7 +229,7 @@ void dogecoin_p2p_msg_version_init(dogecoin_p2p_version_msg* msg, const dogecoin
 
 /**
  * It serializes a dogecoin_p2p_version_msg object into a cstring
- * 
+ *
  * @param msg the message object
  * @param buf the buffer to serialize into
  */
@@ -248,10 +248,10 @@ void dogecoin_p2p_msg_version_ser(dogecoin_p2p_version_msg* msg, cstring* buf)
 
 /**
  * Deserialize a version message
- * 
+ *
  * @param msg the message object to be filled
  * @param buf the buffer to deserialize from
- * 
+ *
  * @return dogecoin_bool (uint8_t)
  */
 dogecoin_bool dogecoin_p2p_msg_version_deser(dogecoin_p2p_version_msg* msg, struct const_buffer* buf)
@@ -300,12 +300,12 @@ dogecoin_bool dogecoin_p2p_msg_version_deser(dogecoin_p2p_version_msg* msg, stru
 
 /**
  * Initialize a dogecoin_p2p_inv_msg object
- * 
+ *
  * @param msg The message object to initialize.
  * @param type The type of the inventory message.
  * @param hash The hash of the item being advertised.
  */
-void dogecoin_p2p_msg_inv_init(dogecoin_p2p_inv_msg* msg, uint32_t type, uint256 hash)
+void dogecoin_p2p_msg_inv_init(dogecoin_p2p_inv_msg* msg, uint32_t type, uint256_t hash)
 {
     msg->type = type;
     memcpy_safe(&msg->hash, hash, DOGECOIN_HASH_LENGTH);
@@ -313,7 +313,7 @@ void dogecoin_p2p_msg_inv_init(dogecoin_p2p_inv_msg* msg, uint32_t type, uint256
 
 /**
  * Serialize a dogecoin_p2p_inv_msg to a cstring.
- * 
+ *
  * @param msg The message object to serialize.
  * @param buf The buffer to serialize into.
  */
@@ -325,10 +325,10 @@ void dogecoin_p2p_msg_inv_ser(dogecoin_p2p_inv_msg* msg, cstring* buf)
 
 /**
  * Deserialize a dogecoin_p2p_inv_msg from a const_buffer
- * 
+ *
  * @param msg The message object to be filled in.
  * @param buf The buffer to deserialize from.
- * 
+ *
  * @return dogecoin_bool (uint8_t)
  */
 dogecoin_bool dogecoin_p2p_msg_inv_deser(dogecoin_p2p_inv_msg* msg, struct const_buffer* buf)
@@ -343,19 +343,19 @@ dogecoin_bool dogecoin_p2p_msg_inv_deser(dogecoin_p2p_inv_msg* msg, struct const
 
 /**
  * This function serializes a getheaders message
- * 
- * @param blocklocators a vector of block hashes
+ *
+ * @param blocklocators a vector_t of block hashes
  * @param hashstop The hash of the last block in the chain that we want to download.
  * @param s the serialized message
  */
-void dogecoin_p2p_msg_getheaders(vector* blocklocators, uint256 hashstop, cstring* s)
+void dogecoin_p2p_msg_getheaders(vector_t* blocklocators, uint256_t hashstop, cstring* s)
 {
     unsigned int i;
 
     ser_u32(s, DOGECOIN_PROTOCOL_VERSION);
     ser_varlen(s, blocklocators->len);
     for (i = 0; i < blocklocators->len; i++) {
-        uint256 *hash = vector_idx(blocklocators, i);
+        uint256_t *hash = vector_idx(blocklocators, i);
         ser_bytes(s, hash, DOGECOIN_HASH_LENGTH);
     }
     if (hashstop)
@@ -366,14 +366,14 @@ void dogecoin_p2p_msg_getheaders(vector* blocklocators, uint256 hashstop, cstrin
 
 /**
  * Deserialize a getheaders message
- * 
- * @param blocklocators a vector of block hashes
+ *
+ * @param blocklocators a vector_t of block hashes
  * @param hashstop The hash of the last block that we want to request.
  * @param buf the buffer to deserialize from
- * 
+ *
  * @return dogecoin_bool (uint8_t)
  */
-dogecoin_bool dogecoin_p2p_deser_msg_getheaders(vector* blocklocators, uint256 hashstop, struct const_buffer* buf)
+dogecoin_bool dogecoin_p2p_deser_msg_getheaders(vector_t* blocklocators, uint256_t hashstop, struct const_buffer* buf)
 {
     int32_t version;
     uint32_t vsize;
@@ -383,7 +383,7 @@ dogecoin_bool dogecoin_p2p_deser_msg_getheaders(vector* blocklocators, uint256 h
         return false;
     vector_resize(blocklocators, vsize);
     for (unsigned int i = 0; i < vsize; i++) {
-        uint256 *hash = dogecoin_malloc(DOGECOIN_HASH_LENGTH);
+        uint256_t *hash = dogecoin_malloc(DOGECOIN_HASH_LENGTH);
         if (!deser_u256(*hash, buf)) {
             dogecoin_free(hash);
             return false;
@@ -397,7 +397,7 @@ dogecoin_bool dogecoin_p2p_deser_msg_getheaders(vector* blocklocators, uint256 h
 
 /**
  * Deserialize the dogecoin_p2p_msg_hdr structure
- * 
+ *
  * @param hdr The dogecoin_p2p_msg_hdr struct that we're deserializing into.
  * @param buf The buffer to deserialize from.
  */

--- a/src/random.c
+++ b/src/random.c
@@ -225,7 +225,7 @@ dogecoin_bool dogecoin_random_bytes_internal(uint8_t* buf, uint32_t len, const u
 void random_seed(struct fast_random_context* this)
 {
     dogecoin_random_init();
-    uint256 seed;
+    uint256_t seed;
     dogecoin_mem_zero(seed, 32);
     dogecoin_random_bytes(seed, 32, 0);
     this->rng->setkey(this->rng, seed, 32);
@@ -241,12 +241,12 @@ void fill_byte_buffer(struct fast_random_context* this)
     this->bytebuf_size = sizeof(this->bytebuf);
 }
 
-uint256* rand256(struct fast_random_context* this)
+uint256_t* rand256(struct fast_random_context* this)
 {
     if (this->bytebuf_size < 32) {
         fill_byte_buffer(this);
     }
-    uint256* ret = dogecoin_uint256_vla(1);
+    uint256_t* ret = dogecoin_uint256_vla(1);
     memcpy(ret, this->bytebuf + 64 - this->bytebuf_size, 32);
     this->bytebuf_size -= 32;
     return ret;
@@ -301,7 +301,7 @@ uint32_t rand32(struct fast_random_context* this) { return randbits(this, 32); }
 /** Generate a random boolean. */
 dogecoin_bool randbool(struct fast_random_context* this) { return randbits(this, 1); }
 
-struct fast_random_context* init_fast_random_context(dogecoin_bool f_deterministic, const uint256* seed) {
+struct fast_random_context* init_fast_random_context(dogecoin_bool f_deterministic, const uint256_t* seed) {
     struct fast_random_context* this = dogecoin_calloc(1, sizeof(*this));
     this->requires_seed = false;
     this->random_seed = random_seed;

--- a/src/rest.c
+++ b/src/rest.c
@@ -67,7 +67,7 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
         koinu_to_coins_str(balance, balance_str);
         evbuffer_add_printf(evb, "Wallet balance: %s\n", balance_str);
     } else if (strcmp(path, "/getAddresses") == 0) {
-        vector* addresses = vector_new(10, dogecoin_free);
+        vector_t* addresses = vector_new(10, dogecoin_free);
         dogecoin_wallet_get_addresses(wallet, addresses);
         for (unsigned int i = 0; i < addresses->len; i++) {
             char* address = vector_idx(addresses, i);

--- a/src/script.c
+++ b/src/script.c
@@ -24,7 +24,7 @@
  OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  OTHER DEALINGS IN THE SOFTWARE.
- 
+
 */
 
 
@@ -39,12 +39,12 @@
 
 
 /**
- * @brief This function copies a script without the 
+ * @brief This function copies a script without the
  * OP_CODESEPARATOR opcode.
- * 
+ *
  * @param script_in The pointer to the cstring which holds the script to be copied.
  * @param script_out The pointer to the cstring to hold the script to be created.
- * 
+ *
  * @return 1 if copied successfully, 0 otherwise.
  */
 dogecoin_bool dogecoin_script_copy_without_op_codeseperator(const cstring* script_in, cstring* script_out)
@@ -110,7 +110,7 @@ err_out:
 /**
  * @brief This function allocates the memory for a new
  * dogecoin_script_op object.
- * 
+ *
  * @return A pointer to the new script operation.
  */
 dogecoin_script_op* dogecoin_script_op_new()
@@ -125,9 +125,9 @@ dogecoin_script_op* dogecoin_script_op_new()
 /**
  * @brief This function frees the pointer to a dogecoin_script_op
  * object and sets the pointer to NULL.
- * 
+ *
  * @param script_op The pointer to the script operation to be freed.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_script_op_free(dogecoin_script_op* script_op)
@@ -145,9 +145,9 @@ void dogecoin_script_op_free(dogecoin_script_op* script_op)
  * @brief This function casts data from a channel buffer to
  * a dogecoin_script_op object and then frees it by calling
  * dogecoin_script_op_free().
- * 
+ *
  * @param data The pointer to the data that must be cast.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_script_op_free_cb(void* data)
@@ -161,14 +161,14 @@ void dogecoin_script_op_free_cb(void* data)
 
 /**
  * @brief This function converts a cstring script into a
- * vector of dogecoin_script_op objects.
- * 
+ * vector_t of dogecoin_script_op objects.
+ *
  * @param script_in The pointer to the cstring holding the script to be parsed.
- * @param ops_out The pointer to a vector that will store the parsed script operations.
- * 
+ * @param ops_out The pointer to a vector_t that will store the parsed script operations.
+ *
  * @return 1 if converted successfully, 0 otherwise.
  */
-dogecoin_bool dogecoin_script_get_ops(const cstring* script_in, vector* ops_out)
+dogecoin_bool dogecoin_script_get_ops(const cstring* script_in, vector_t* ops_out)
 {
     if (script_in->len == 0)
         return false; /* EOF */
@@ -232,12 +232,12 @@ err_out:
 
 
 /**
- * @brief This function checks whether an opcode is a 
+ * @brief This function checks whether an opcode is a
  * pushdata opcode.
- * 
+ *
  * @param op The opcode to check.
- * 
- * @return 1 if opcode is a pushdata opcode, 0 otherwise. 
+ *
+ * @return 1 if opcode is a pushdata opcode, 0 otherwise.
  */
 static inline dogecoin_bool dogecoin_script_is_pushdata(const enum opcodetype op)
 {
@@ -246,12 +246,12 @@ static inline dogecoin_bool dogecoin_script_is_pushdata(const enum opcodetype op
 
 
 /**
- * @brief This function checks whether the opcode of a 
+ * @brief This function checks whether the opcode of a
  * given script operation matches the specified opcode.
- * 
+ *
  * @param op The pointer to the script operation whose opcode will be checked.
  * @param opcode The reference opcode.
- * 
+ *
  * @return 1 if the opcodes match, 0 otherwise.
  */
 static dogecoin_bool dogecoin_script_is_op(const dogecoin_script_op* op, enum opcodetype opcode)
@@ -261,14 +261,14 @@ static dogecoin_bool dogecoin_script_is_op(const dogecoin_script_op* op, enum op
 
 
 /**
- * @brief This function checks whether a given script 
- * operation pushes a pubkey to the stack. This is 
+ * @brief This function checks whether a given script
+ * operation pushes a pubkey to the stack. This is
  * true if the script operation has a pushdata opcode
  * and that its data is the same length as a compressed
  * or uncompressed EC key.
- * 
+ *
  * @param op The pointer to the script operation to be checked.
- * 
+ *
  * @return 1 if the script resembles the pubkey template, 0 otherwise.
  */
 static dogecoin_bool dogecoin_script_is_op_pubkey(const dogecoin_script_op* op)
@@ -287,11 +287,11 @@ static dogecoin_bool dogecoin_script_is_op_pubkey(const dogecoin_script_op* op)
 /**
  * @brief This function checks whether the given script
  * operation pushes a pubkey hash to the stack. This is
- * true if the script operation has a pushdata opcode 
+ * true if the script operation has a pushdata opcode
  * and that its data is 20 bytes in size.
- * 
+ *
  * @param op The pointer to the script operation to be checked.
- * 
+ *
  * @return 1 if the script resembles the pubkey hash template, 0 otherwise.
  */
 static dogecoin_bool dogecoin_script_is_op_pubkeyhash(const dogecoin_script_op* op)
@@ -307,21 +307,21 @@ static dogecoin_bool dogecoin_script_is_op_pubkeyhash(const dogecoin_script_op* 
 /**
  * @brief This function checks whether the script matches
  * the template for a pubkey script, which is composed of
- * a push pubkey operation followed by an OP_CHECKSIG. 
+ * a push pubkey operation followed by an OP_CHECKSIG.
  * The pubkey is then loaded into data_out.
- * 
- * @param ops The pointer to a vector storing script data to be checked.
- * @param data_out The pointer to a vector which will hold the pubkey data.
- * 
+ *
+ * @param ops The pointer to a vector_t storing script data to be checked.
+ * @param data_out The pointer to a vector_t which will hold the pubkey data.
+ *
  * @return 1 if the script is the correct format, 0 otherwise.
  */
-dogecoin_bool dogecoin_script_is_pubkey(const vector* ops, vector* data_out)
+dogecoin_bool dogecoin_script_is_pubkey(const vector_t* ops, vector_t* data_out)
 {
     if ((ops->len == 2) &&
         dogecoin_script_is_op(vector_idx(ops, 1), OP_CHECKSIG) &&
         dogecoin_script_is_op_pubkey(vector_idx(ops, 0))) {
         if (data_out) {
-            //copy the full pubkey (33 or 65) in case of a non empty vector
+            //copy the full pubkey (33 or 65) in case of a non empty vector_t
             const dogecoin_script_op* op = vector_idx(ops, 0);
             uint8_t* buffer = dogecoin_calloc(1, op->datalen);
             memcpy_safe(buffer, op->data, op->datalen);
@@ -335,16 +335,16 @@ dogecoin_bool dogecoin_script_is_pubkey(const vector* ops, vector* data_out)
 /**
  * @brief This function checks whether the script matches
  * the template for a pubkey hash script, which is composed
- * of an OP_DUP, an OP_HASH160, a push pubkey hash operation, 
+ * of an OP_DUP, an OP_HASH160, a push pubkey hash operation,
  * an OP_EQUALVERIFY, and an OP_CHECKSIG, in that order. The
  * pubkey hash is then loaded into data_out.
- * 
- * @param ops The pointer to a vector storing script data to be checked.
- * @param data_out The pointer to a vector where script data will be copied to.
- * 
+ *
+ * @param ops The pointer to a vector_t storing script data to be checked.
+ * @param data_out The pointer to a vector_t where script data will be copied to.
+ *
  * @return 1 if the script is a valid pubkey hash, 0 otherwise.
  */
-dogecoin_bool dogecoin_script_is_pubkeyhash(const vector* ops, vector* data_out)
+dogecoin_bool dogecoin_script_is_pubkeyhash(const vector_t* ops, vector_t* data_out)
 {
     if ((ops->len == 5) &&
         dogecoin_script_is_op(vector_idx(ops, 0), OP_DUP) &&
@@ -353,10 +353,10 @@ dogecoin_bool dogecoin_script_is_pubkeyhash(const vector* ops, vector* data_out)
         dogecoin_script_is_op(vector_idx(ops, 3), OP_EQUALVERIFY) &&
         dogecoin_script_is_op(vector_idx(ops, 4), OP_CHECKSIG)) {
         if (data_out) {
-            //copy the data (hash160) in case of a non empty vector
+            //copy the data (hash160) in case of a non empty vector_t
             const dogecoin_script_op* op = vector_idx(ops, 2);
-            uint8_t* buffer = dogecoin_calloc(1, sizeof(uint160));
-            memcpy_safe(buffer, op->data, sizeof(uint160));
+            uint8_t* buffer = dogecoin_calloc(1, sizeof(uint160_t));
+            memcpy_safe(buffer, op->data, sizeof(uint160_t));
             vector_add(data_out, buffer);
         }
         return true;
@@ -370,23 +370,23 @@ dogecoin_bool dogecoin_script_is_pubkeyhash(const vector* ops, vector* data_out)
  * the template for a script hash, which is composed of an
  * OP_HASH160, a push pubkey hash operation, and an OP_EQUAL,
  * in that order. The script hash is then loaded into data_out.
- * 
- * @param ops The pointer to the vector storing script data to be checked.
- * @param data_out The pointer to a vector where script data will be copied to.
- * 
+ *
+ * @param ops The pointer to the vector_t storing script data to be checked.
+ * @param data_out The pointer to a vector_t where script data will be copied to.
+ *
  * @return 1 if the script is a script hash, 0 otherwise.
  */
-dogecoin_bool dogecoin_script_is_scripthash(const vector* ops, vector* data_out)
+dogecoin_bool dogecoin_script_is_scripthash(const vector_t* ops, vector_t* data_out)
 {
     if ((ops->len == 3) &&
         dogecoin_script_is_op(vector_idx(ops, 0), OP_HASH160) &&
         dogecoin_script_is_op_pubkeyhash(vector_idx(ops, 1)) &&
         dogecoin_script_is_op(vector_idx(ops, 2), OP_EQUAL)) {
         if (data_out) {
-            //copy the data (hash160) in case of a non empty vector
+            //copy the data (hash160) in case of a non empty vector_t
             const dogecoin_script_op* op = vector_idx(ops, 1);
-            uint8_t* buffer = dogecoin_calloc(1, sizeof(uint160));
-            memcpy_safe(buffer, op->data, sizeof(uint160));
+            uint8_t* buffer = dogecoin_calloc(1, sizeof(uint160_t));
+            memcpy_safe(buffer, op->data, sizeof(uint160_t));
             vector_add(data_out, buffer);
         }
 
@@ -399,9 +399,9 @@ dogecoin_bool dogecoin_script_is_scripthash(const vector* ops, vector* data_out)
 /**
  * @brief The function checks whether the script operation
  * has an opcode label of less than or equal to 16.
- * 
+ *
  * @param op The pointer to the operation to be checked.
- * 
+ *
  * @return 1 if it has a small int opcode, 0 otherwise.
  */
 static dogecoin_bool dogecoin_script_is_op_smallint(const dogecoin_script_op* op)
@@ -413,17 +413,17 @@ static dogecoin_bool dogecoin_script_is_op_smallint(const dogecoin_script_op* op
 
 /**
  * @brief This function checks whether a script is a multisig
- * script, which is true if the vector is composed of between 
- * 3 and 19 scripts (inclusive), the first operation has a small 
- * int opcode, the second-to-last operation has a small int 
- * opcode, the last operation is OP_CHECKMULTISIG, and all 
+ * script, which is true if the vector_t is composed of between
+ * 3 and 19 scripts (inclusive), the first operation has a small
+ * int opcode, the second-to-last operation has a small int
+ * opcode, the last operation is OP_CHECKMULTISIG, and all
  * operations in between push pubkeys to the stack.
- * 
- * @param ops The pointer to the vector storing the script.
- * 
+ *
+ * @param ops The pointer to the vector_t storing the script.
+ *
  * @return 1 if the script is a multisig script, 0 otherwise.
  */
-dogecoin_bool dogecoin_script_is_multisig(const vector* ops)
+dogecoin_bool dogecoin_script_is_multisig(const vector_t* ops)
 {
     if ((ops->len < 3) || (ops->len > (16 + 3)) ||
         !dogecoin_script_is_op_smallint(vector_idx(ops, 0)) ||
@@ -443,12 +443,12 @@ dogecoin_bool dogecoin_script_is_multisig(const vector* ops)
 /**
  * @brief This function classifies a script as one of four
  * types: pubkey, pubkey hash, script hash, or multisig.
- * 
- * @param ops The pointer to the vector storing the script.
- * 
+ *
+ * @param ops The pointer to the vector_t storing the script.
+ *
  * @return The type of script.
  */
-enum dogecoin_tx_out_type dogecoin_script_classify_ops(const vector* ops)
+enum dogecoin_tx_out_type dogecoin_script_classify_ops(const vector_t* ops)
 {
     if (dogecoin_script_is_pubkeyhash(ops, NULL))
         return DOGECOIN_TX_PUBKEYHASH;
@@ -466,21 +466,21 @@ enum dogecoin_tx_out_type dogecoin_script_classify_ops(const vector* ops)
 /**
  * @brief This function takes a cstring representation of
  * a script, classifies it as one of the four script types
- * and loads the script data into data_out if it is not a 
+ * and loads the script data into data_out if it is not a
  * multisig script.
- * 
+ *
  * @param script The pointer to the cstring script to be parsed and classified.
- * @param data_out The pointer to the vector that will contain the parsed scripts.
- * 
+ * @param data_out The pointer to the vector_t that will contain the parsed scripts.
+ *
  * @return The script type.
  */
-enum dogecoin_tx_out_type dogecoin_script_classify(const cstring* script, vector* data_out)
+enum dogecoin_tx_out_type dogecoin_script_classify(const cstring* script, vector_t* data_out)
 {
-    //INFO: could be speed up by not forming a vector
+    //INFO: could be speed up by not forming a vector_t
     //      and directly parse the script cstring
 
     enum dogecoin_tx_out_type tx_out_type = DOGECOIN_TX_NONSTANDARD;
-    vector* ops = vector_new(10, dogecoin_script_op_free_cb);
+    vector_t* ops = vector_new(10, dogecoin_script_op_free_cb);
     dogecoin_script_get_ops(script, ops);
 
     if (dogecoin_script_is_pubkeyhash(ops, data_out))
@@ -500,9 +500,9 @@ enum dogecoin_tx_out_type dogecoin_script_classify(const cstring* script, vector
 /**
  * @brief This function takes an int and translates it to a
  * small int opcode if it is between 0 and 16, inclusive.
- * 
+ *
  * @param n The number of the desired small int opcode.
- * 
+ *
  * @return The small int opcode.
  */
 enum opcodetype dogecoin_encode_op_n(const int n)
@@ -518,10 +518,10 @@ enum opcodetype dogecoin_encode_op_n(const int n)
  * @brief This function takes an existing script in cstring
  * form and appends another script operation to it. No data
  * is pushed to the stack.
- * 
+ *
  * @param script_in The pointer to the cstring containing the script.
  * @param op The opcode to append.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_script_append_op(cstring* script_in, enum opcodetype op)
@@ -534,11 +534,11 @@ void dogecoin_script_append_op(cstring* script_in, enum opcodetype op)
  * @brief This function takes an existing script in cstring
  * form and appends an operation to push a specified buffer
  * of data to the stack.
- * 
+ *
  * @param script_in The pointer to the cstring containing the script.
  * @param data The buffer to be pushed in the push operation.
  * @param datalen The size in bytes of the buffer.
- * 
+ *
  * @return Nothing.
  */
 void dogecoin_script_append_pushdata(cstring* script_in, const unsigned char* data, const size_t datalen)
@@ -561,17 +561,17 @@ void dogecoin_script_append_pushdata(cstring* script_in, const unsigned char* da
 }
 
 /**
- * @brief This function takes a vector of dogecoin_pubkeys
- * and builds a multisig script which pushes all pubkeys 
+ * @brief This function takes a vector_t of dogecoin_pubkeys
+ * and builds a multisig script which pushes all pubkeys
  * to the stack and checks that each one is valid.
- * 
+ *
  * @param script_in The pointer to the cstring where the new multisig script will be built.
  * @param required_signatures The number of required signatures.
- * @param pubkeys_chars The pointer to the vector of pubkey push operations to combine into the multisig.
- * 
+ * @param pubkeys_chars The pointer to the vector_t of pubkey push operations to combine into the multisig.
+ *
  * @return 1 if the script was built successfully, 0 if more than 16 pubkeys are given.
  */
-dogecoin_bool dogecoin_script_build_multisig(cstring* script_in, const unsigned int required_signatures, const vector* pubkeys_chars)
+dogecoin_bool dogecoin_script_build_multisig(cstring* script_in, const unsigned int required_signatures, const vector_t* pubkeys_chars)
 {
     cstr_resize(script_in, 0); //clear script
 
@@ -600,15 +600,15 @@ dogecoin_bool dogecoin_script_build_multisig(cstring* script_in, const unsigned 
  * @brief This function builds a pay-to-public-key-hash script
  * which duplicates the value at the top of the stack (a public
  * key), hashes this value, checks that this hash equals the
- * given uint160 object, and verifies the signature. This script
+ * given uint160_t object, and verifies the signature. This script
  * is then loaded into the cstring script_in.
- * 
+ *
  * @param script_in The pointer to the cstring where the p2pkh script will be built.
  * @param hash160 The hash160 of a public key.
- * 
+ *
  * @return 1 if the p2pkh script was built successfully.
  */
-dogecoin_bool dogecoin_script_build_p2pkh(cstring* script_in, const uint160 hash160)
+dogecoin_bool dogecoin_script_build_p2pkh(cstring* script_in, const uint160_t hash160)
 {
     cstr_resize(script_in, 0); //clear script
 
@@ -616,7 +616,7 @@ dogecoin_bool dogecoin_script_build_p2pkh(cstring* script_in, const uint160 hash
     dogecoin_script_append_op(script_in, OP_HASH160);
 
 
-    dogecoin_script_append_pushdata(script_in, (unsigned char*)hash160, sizeof(uint160));
+    dogecoin_script_append_pushdata(script_in, (unsigned char*)hash160, sizeof(uint160_t));
     dogecoin_script_append_op(script_in, OP_EQUALVERIFY);
     dogecoin_script_append_op(script_in, OP_CHECKSIG);
 
@@ -627,19 +627,19 @@ dogecoin_bool dogecoin_script_build_p2pkh(cstring* script_in, const uint160 hash
 /**
  * @brief This function builds a pay-to-script-hash script
  * which hashes the value on the top of the stack (script
- * data) and ensures that this equals the uint160 object given. 
+ * data) and ensures that this equals the uint160_t object given.
  * The script is then loaded into the cstring script_in.
- * 
+ *
  * @param script_in The pointer to the cstring where the p2sh script will be built.
  * @param hash160 The hash160 of a public key.
- * 
+ *
  * @return 1 if the p2sh script was built successfully.
  */
-dogecoin_bool dogecoin_script_build_p2sh(cstring* script_in, const uint160 hash160)
+dogecoin_bool dogecoin_script_build_p2sh(cstring* script_in, const uint160_t hash160)
 {
     cstr_resize(script_in, 0); //clear script
     dogecoin_script_append_op(script_in, OP_HASH160);
-    dogecoin_script_append_pushdata(script_in, (unsigned char*)hash160, sizeof(uint160));
+    dogecoin_script_append_pushdata(script_in, (unsigned char*)hash160, sizeof(uint160_t));
     dogecoin_script_append_op(script_in, OP_EQUAL);
 
     return true;
@@ -647,20 +647,20 @@ dogecoin_bool dogecoin_script_build_p2sh(cstring* script_in, const uint160 hash1
 
 
 /**
- * @brief This function takes a script, computes its hash, 
- * and returns it as a uint160 object.
- * 
+ * @brief This function takes a script, computes its hash,
+ * and returns it as a uint160_t object.
+ *
  * @param script_in The pointer to the cstring which holds the script.
- * @param scripthash The uint160 object that will hold the hash of the script.
- * 
+ * @param scripthash The uint160_t object that will hold the hash of the script.
+ *
  * @return 1 if the script was hashed correctly, 0 if a null cstring was provided.
  */
-dogecoin_bool dogecoin_script_get_scripthash(const cstring* script_in, uint160 scripthash)
+dogecoin_bool dogecoin_script_get_scripthash(const cstring* script_in, uint160_t scripthash)
 {
     if (!script_in) {
         return false;
     }
-    uint256 hash;
+    uint256_t hash;
     dogecoin_hash_sngl_sha256((const unsigned char*)script_in->str, script_in->len, hash);
     rmd160(hash, sizeof(hash), scripthash);
 
@@ -671,9 +671,9 @@ dogecoin_bool dogecoin_script_get_scripthash(const cstring* script_in, uint160 s
 /**
  * @brief This function takes a script type and translates
  * it into string format.
- * 
+ *
  * @param type The type of script.
- * 
+ *
  * @return The string representation of the script.
  */
 const char* dogecoin_tx_out_type_to_str(const enum dogecoin_tx_out_type type)

--- a/src/sign.c
+++ b/src/sign.c
@@ -38,7 +38,7 @@
 
 const char* msg_magic = "Dogecoin Signed Message:\n";
 
-void hash_message(char* msg, uint256 message_bytes) {
+void hash_message(char* msg, uint256_t message_bytes) {
     size_t msg_magic_len = strlen(msg_magic), msg_len = strlen(msg);
     char* tmp_msg = dogecoin_char_vla(msg_magic_len + msg_len + 7);
     tmp_msg[0] = msg_magic_len;
@@ -61,7 +61,7 @@ void hash_message(char* msg, uint256 message_bytes) {
 char* sign_message(char* privkey, char* msg) {
     if (!privkey || !msg) return false;
 
-    uint256 message_bytes;
+    uint256_t message_bytes;
     hash_message(msg, message_bytes);
 
     size_t compact_signature_length = 65;
@@ -102,7 +102,7 @@ char* sign_message(char* privkey, char* msg) {
 int verify_message(char* sig, char* msg, char* address) {
     if (!(sig || msg || address)) return false;
 
-    uint256 message_bytes;
+    uint256_t message_bytes;
     hash_message(msg, message_bytes);
 
     size_t encoded_length = strlen((const char*)sig);

--- a/src/spv.c
+++ b/src/spv.c
@@ -333,14 +333,14 @@ static dogecoin_bool dogecoin_net_spv_node_timer_callback(dogecoin_node *node, u
 }
 
 /**
- * Fill up the blocklocators vector with the blocklocators from the headers database
+ * Fill up the blocklocators vector_t with the blocklocators from the headers database
  *
  * @param client the spv client
- * @param blocklocators a vector of block hashes that we want to scan from
+ * @param blocklocators a vector_t of block hashes that we want to scan from
  *
  * @return The blocklocators are being returned.
  */
-void dogecoin_net_spv_fill_block_locator(dogecoin_spv_client *client, vector *blocklocators) {
+void dogecoin_net_spv_fill_block_locator(dogecoin_spv_client *client, vector_t *blocklocators) {
     int64_t min_timestamp = client->oldest_item_of_interest - BLOCK_GAP_TO_DEDUCT_TO_START_SCAN_FROM * BLOCKS_DELTA_IN_S; /* ensure we going back ~300 blocks */
     if (client->headers_db->getchaintip(client->headers_db_ctx)->height == 0) {
         if (client->use_checkpoints && client->oldest_item_of_interest > BLOCK_GAP_TO_DEDUCT_TO_START_SCAN_FROM * BLOCKS_DELTA_IN_S) {
@@ -351,7 +351,7 @@ void dogecoin_net_spv_fill_block_locator(dogecoin_spv_client *client, vector *bl
             int i;
             for (i = length - 1; i >= 0; i--) {
                 if (checkpoint[i].timestamp < min_timestamp) {
-                    uint256 *hash = dogecoin_calloc(1, sizeof(uint256));
+                    uint256_t *hash = dogecoin_calloc(1, sizeof(uint256_t));
                     utils_uint256_sethex((char *)checkpoint[i].hash, (uint8_t *)hash);
                     vector_add(blocklocators, (void *)hash);
                     if (!client->headers_db->has_checkpoint_start(client->headers_db_ctx)) {
@@ -361,8 +361,8 @@ void dogecoin_net_spv_fill_block_locator(dogecoin_spv_client *client, vector *bl
             }
             if (blocklocators->len > 0) return; // return if we could fill up the blocklocator with checkpoints
         }
-        uint256 *hash = dogecoin_calloc(1, sizeof(uint256));
-        memcpy_safe(hash, &client->chainparams->genesisblockhash, sizeof(uint256));
+        uint256_t *hash = dogecoin_calloc(1, sizeof(uint256_t));
+        memcpy_safe(hash, &client->chainparams->genesisblockhash, sizeof(uint256_t));
         vector_add(blocklocators, (void *)hash);
         client->nodegroup->log_write_cb("Setting blocklocator with genesis block\n");
     } else {
@@ -380,7 +380,7 @@ void dogecoin_net_spv_fill_block_locator(dogecoin_spv_client *client, vector *bl
 void dogecoin_net_spv_node_request_headers_or_blocks(dogecoin_node *node, dogecoin_bool blocks)
 {
     // request next headers
-    vector *blocklocators = vector_new(1, free);
+    vector_t *blocklocators = vector_new(1, free);
 
     dogecoin_net_spv_fill_block_locator((dogecoin_spv_client *)node->nodegroup->ctx, blocklocators);
 

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -292,7 +292,7 @@ int add_utxo(int txindex, char* hex_utxo_txid, int vout) {
     // instantiate empty dogecoin_tx_in object to set previous output txid and output n:
     dogecoin_tx_in* tx_in = dogecoin_tx_in_new();
 
-    // add prevout hash to tx_in->prevout.hash in prep of adding to tx->transaction-vin vector
+    // add prevout hash to tx_in->prevout.hash in prep of adding to tx->transaction-vin vector_t
     utils_uint256_sethex((char *)hex_utxo_txid, (uint8_t *)tx_in->prevout.hash);
 
     // set index of utxo we want to spend
@@ -518,7 +518,7 @@ int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, i
     utils_hex_to_bin(scripthex, script_data, strlen(scripthex), &outlength);
     cstring* script = cstr_new_buf(script_data, outlength);
 
-    uint256 sighash;
+    uint256_t sighash;
     dogecoin_mem_zero(sighash, sizeof(sighash));
     free(script_data);
 

--- a/src/tx.c
+++ b/src/tx.c
@@ -487,7 +487,7 @@ int dogecoin_tx_deserialize(const unsigned char* tx_serialized, size_t inlen, do
             }
         }
     }
-    
+
     unsigned int i;
     for (i = 0; i < vlen; i++) {
         dogecoin_tx_in* tx_in = dogecoin_tx_in_new();
@@ -625,7 +625,7 @@ void dogecoin_tx_serialize(cstring* s, const dogecoin_tx* tx)
  *
  * @return Nothing.
  */
-void dogecoin_tx_hash(const dogecoin_tx* tx, uint256 hashout)
+void dogecoin_tx_hash(const dogecoin_tx* tx, uint256_t hashout)
 {
     cstring* txser = cstr_new_sz(1024);
     dogecoin_tx_serialize(txser, tx);
@@ -749,7 +749,7 @@ void dogecoin_tx_copy(dogecoin_tx* dest, const dogecoin_tx* src)
  *
  * @return Nothing.
  */
-void dogecoin_tx_prevout_hash(const dogecoin_tx* tx, uint256 hash)
+void dogecoin_tx_prevout_hash(const dogecoin_tx* tx, uint256_t hash)
 {
     cstring* s = cstr_new_sz(512);
     unsigned int i;
@@ -774,7 +774,7 @@ void dogecoin_tx_prevout_hash(const dogecoin_tx* tx, uint256 hash)
  *
  * @return Nothing.
  */
-void dogecoin_tx_sequence_hash(const dogecoin_tx* tx, uint256 hash)
+void dogecoin_tx_sequence_hash(const dogecoin_tx* tx, uint256_t hash)
 {
     cstring* s = cstr_new_sz(512);
     unsigned int i;
@@ -797,7 +797,7 @@ void dogecoin_tx_sequence_hash(const dogecoin_tx* tx, uint256 hash)
  *
  * @return Nothing.
  */
-void dogecoin_tx_outputs_hash(const dogecoin_tx* tx, uint256 hash)
+void dogecoin_tx_outputs_hash(const dogecoin_tx* tx, uint256_t hash)
 {
     if (!tx->vout || !hash) return;
     cstring* s = cstr_new_sz(512);
@@ -825,7 +825,7 @@ void dogecoin_tx_outputs_hash(const dogecoin_tx* tx, uint256 hash)
  *
  * @return 1 if signature hash is generated successfully, 0 otherwise.
  */
-dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, size_t in_num, int hashtype, uint256 hash)
+dogecoin_bool dogecoin_tx_sighash(const dogecoin_tx* tx_to, const cstring* fromPubKey, size_t in_num, int hashtype, uint256_t hash)
 {
     if (in_num >= tx_to->vin->len || !tx_to->vout) {
         return false;
@@ -1008,7 +1008,7 @@ dogecoin_bool dogecoin_tx_add_address_out(dogecoin_tx* tx, const dogecoin_chainp
  *
  * @return 1 if the output is added successfully.
  */
-dogecoin_bool dogecoin_tx_add_p2pkh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160 hash160)
+dogecoin_bool dogecoin_tx_add_p2pkh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160_t hash160)
 {
     dogecoin_tx_out* tx_out = dogecoin_tx_out_new();
     tx_out->script_pubkey = cstr_new_sz(1024);
@@ -1029,7 +1029,7 @@ dogecoin_bool dogecoin_tx_add_p2pkh_hash160_out(dogecoin_tx* tx, int64_t amount,
  *
  * @return 1 if the output is added successfully.
  */
-dogecoin_bool dogecoin_tx_add_p2sh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160 hash160)
+dogecoin_bool dogecoin_tx_add_p2sh_hash160_out(dogecoin_tx* tx, int64_t amount, uint160_t hash160)
 {
     dogecoin_tx_out* tx_out = dogecoin_tx_out_new();
     tx_out->script_pubkey = cstr_new_sz(1024);
@@ -1053,7 +1053,7 @@ dogecoin_bool dogecoin_tx_add_p2sh_hash160_out(dogecoin_tx* tx, int64_t amount, 
  */
 dogecoin_bool dogecoin_tx_add_p2pkh_out(dogecoin_tx* tx, int64_t amount, const dogecoin_pubkey* pubkey)
 {
-    uint160 hash160;
+    uint160_t hash160;
     dogecoin_pubkey_get_hash160(pubkey, hash160);
     return dogecoin_tx_add_p2pkh_hash160_out(tx, amount, hash160);
 }
@@ -1164,14 +1164,14 @@ enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, cons
 
     cstring* script_sign = cstr_new_cstr(script); //copy the script because we may modify it
     dogecoin_tx_in* tx_in = vector_idx(tx_in_out->vin, inputindex);
-    vector* script_pushes = vector_new(1, free);
+    vector_t* script_pushes = vector_new(1, free);
 
     enum dogecoin_tx_out_type type = dogecoin_script_classify(script, script_pushes);
     if (type == DOGECOIN_TX_PUBKEYHASH && script_pushes->len == 1) {
         // check if given private key matches the script
-        uint160 hash160;
+        uint160_t hash160;
         dogecoin_pubkey_get_hash160(&pubkey, hash160);
-        uint160* hash160_in_script = vector_idx(script_pushes, 0);
+        uint160_t* hash160_in_script = vector_idx(script_pushes, 0);
         if (memcmp(hash160_in_script, hash160, sizeof(hash160)) != 0) {
             res = DOGECOIN_SIGN_NO_KEY_MATCH; //sign anyways
         }
@@ -1181,7 +1181,7 @@ enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, cons
     }
     vector_free(script_pushes, true);
 
-    uint256 sighash;
+    uint256_t sighash;
     dogecoin_mem_zero(sighash, sizeof(sighash));
     if (!dogecoin_tx_sighash(tx_in_out, script_sign, inputindex, sighashtype, sighash)) {
         cstr_free(script_sign, true);

--- a/src/utils.c
+++ b/src/utils.c
@@ -305,7 +305,7 @@ signed char utils_hex_digit(char c)
  */
 void utils_uint256_sethex(char* psz, uint8_t* out)
 {
-    dogecoin_mem_zero(out, sizeof(uint256));
+    dogecoin_mem_zero(out, sizeof(uint256_t));
 
     // skip leading space
     while ((unsigned int)*psz == ' ' || (unsigned int)(*psz - 0x09) < 5u) {
@@ -324,7 +324,7 @@ void utils_uint256_sethex(char* psz, uint8_t* out)
         }
     psz--;
     unsigned char* p1 = (unsigned char*)out;
-    unsigned char* pend = p1 + sizeof(uint256);
+    unsigned char* pend = p1 + sizeof(uint256_t);
     while (psz >= pbegin && p1 < pend) {
         *p1 = utils_hex_digit(*psz--);
         if (psz >= pbegin) {
@@ -334,9 +334,9 @@ void utils_uint256_sethex(char* psz, uint8_t* out)
         }
     }
 
-uint256* uint256S(const char *str)
+uint256_t* uint256S(const char *str)
 {
-    return (uint256*)utils_hex_to_uint8(str);
+    return (uint256_t*)utils_hex_to_uint8(str);
 }
 
 unsigned char* parse_hex(const char* psz)

--- a/src/validation.c
+++ b/src/validation.c
@@ -40,7 +40,7 @@
  *
  * @return True.
  */
-dogecoin_bool dogecoin_block_header_scrypt_hash(cstring* s, uint256* hash) {
+dogecoin_bool dogecoin_block_header_scrypt_hash(cstring* s, uint256_t* hash) {
     char scratchpad[SCRYPT_SCRATCHPAD_SIZE];
 #if defined(USE_SSE2)
     scrypt_1024_1_1_256_sp_sse2((const char*)s->str, (char *) hash, scratchpad);
@@ -64,7 +64,7 @@ dogecoin_bool is_legacy(uint32_t version) {
         || (version == 2 && get_chainid(version) == 0);
 }
 
-dogecoin_bool check_auxpow(dogecoin_auxpow_block* block, dogecoin_chainparams* params, uint256* chainwork) {
+dogecoin_bool check_auxpow(dogecoin_auxpow_block* block, dogecoin_chainparams* params, uint256_t* chainwork) {
     /* Except for legacy blocks with full version 1, ensure that
        the chain ID is correct.  Legacy blocks are not allowed since
        the merge-mining start, which is checked in AcceptBlockHeader
@@ -80,7 +80,7 @@ dogecoin_bool check_auxpow(dogecoin_auxpow_block* block, dogecoin_chainparams* p
     /* If there is no auxpow, just check the block hash.  */
     if (!block->header->auxpow->is) {
 
-        uint256 hash = {0};
+        uint256_t hash = {0};
         cstring* s = cstr_new_sz(64);
         dogecoin_block_header_serialize(s, block->header);
         dogecoin_block_header_scrypt_hash(s, &hash);
@@ -95,7 +95,7 @@ dogecoin_bool check_auxpow(dogecoin_auxpow_block* block, dogecoin_chainparams* p
     }
 
     /* We have auxpow.  Check it.  */
-    uint256 block_header_hash;
+    uint256_t block_header_hash;
     dogecoin_block_header_hash(block->header, block_header_hash);
     uint32_t chainid = get_chainid(block->header->version);
     if (!block->header->auxpow->check(block, &block_header_hash, chainid, params)) {
@@ -103,7 +103,7 @@ dogecoin_bool check_auxpow(dogecoin_auxpow_block* block, dogecoin_chainparams* p
         return false;
     }
 
-    uint256 parent_hash;
+    uint256_t parent_hash;
     cstring* s2 = cstr_new_sz(64);
     dogecoin_block_header_serialize(s2, block->parent_header);
     dogecoin_block_header_scrypt_hash(s2, &parent_hash);

--- a/src/vector.c
+++ b/src/vector.c
@@ -31,17 +31,17 @@
 
 
 /**
- * @brief This function creates a new vector object
+ * @brief This function creates a new vector_t object
  * and initializes it to 0.
  *
- * @param res The size of memory to allocate for the vector's contents.
- * @param free_f The function that will be called when a vector element is freed.
+ * @param res The size of memory to allocate for the vector_t's contents.
+ * @param free_f The function that will be called when a vector_t element is freed.
  *
- * @return A pointer to the new vector object.
+ * @return A pointer to the new vector_t object.
  */
-vector* vector_new(size_t res, void (*free_f)(void*))
+vector_t* vector_new(size_t res, void (*free_f)(void*))
 {
-    vector* vec = dogecoin_calloc(1, sizeof(vector));
+    vector_t* vec = dogecoin_calloc(1, sizeof(vector_t));
     if (!vec)
         return NULL;
 
@@ -61,16 +61,16 @@ vector* vector_new(size_t res, void (*free_f)(void*))
 
 
 /**
- * @brief This function frees all of a vector's elements,
+ * @brief This function frees all of a vector_t's elements,
  * calling the function associated with its free operation
- * set during vector creation. The vector object itself
+ * set during vector_t creation. The vector_t object itself
  * is not freed.
  *
- * @param vec The pointer to the vector to be freed.
+ * @param vec The pointer to the vector_t to be freed.
  *
  * @return Nothing.
  */
-static void vector_free_data(vector* vec)
+static void vector_free_data(vector_t* vec)
 {
     if (!vec->data)
         return;
@@ -92,15 +92,15 @@ static void vector_free_data(vector* vec)
 
 
 /**
- * @brief This function frees an entire vector
+ * @brief This function frees an entire vector_t
  * object and all of its elements if specified.
  *
- * @param vec The pointer to the vector to be freed.
- * @param free_array The flag denoting whether to free the vector's elements.
+ * @param vec The pointer to the vector_t to be freed.
+ * @param free_array The flag denoting whether to free the vector_t's elements.
  *
  * @return Nothing.
  */
-void vector_free(vector* vec, dogecoin_bool free_array)
+void vector_free(vector_t* vec, dogecoin_bool free_array)
 {
     if (!vec) {
         return;
@@ -116,15 +116,15 @@ void vector_free(vector* vec, dogecoin_bool free_array)
 
 
 /**
- * @brief This function grows the vector by doubling
+ * @brief This function grows the vector_t by doubling
  * in size until it is larger than the size specified.
  *
- * @param vec The pointer to the vector to be grown.
- * @param min_sz The minimum size the vector must be grown to.
+ * @param vec The pointer to the vector_t to be grown.
+ * @param min_sz The minimum size the vector_t must be grown to.
  *
- * @return 1 if the vector is grown successfully, 0 if it reaches the max size allowed.
+ * @return 1 if the vector_t is grown successfully, 0 if it reaches the max size allowed.
  */
-static dogecoin_bool vector_grow(vector* vec, size_t min_sz)
+static dogecoin_bool vector_grow(vector_t* vec, size_t min_sz)
 {
     size_t new_alloc = vec->alloc;
     while (new_alloc < min_sz) {
@@ -148,14 +148,14 @@ static dogecoin_bool vector_grow(vector* vec, size_t min_sz)
 
 /**
  * @brief This function finds and returns the first element
- * in the vector whose data matches the data specified.
+ * in the vector_t whose data matches the data specified.
  *
- * @param vec The pointer to the vector to search.
+ * @param vec The pointer to the vector_t to search.
  * @param data The data to match.
  *
- * @return The index of the data if it exists in the vector, -1 otherwise.
+ * @return The index of the data if it exists in the vector_t, -1 otherwise.
  */
-ssize_t vector_find(vector* vec, void* data)
+ssize_t vector_find(vector_t* vec, void* data)
 {
     if (vec && vec->len) {
         size_t i;
@@ -172,14 +172,14 @@ ssize_t vector_find(vector* vec, void* data)
 
 /**
  * @brief This function adds an element to an existing
- * vector, growing it by one if necessary.
+ * vector_t, growing it by one if necessary.
  *
- * @param vec The pointer to the vector to add to.
- * @param data The data to be added into the vector.
+ * @param vec The pointer to the vector_t to add to.
+ * @param data The data to be added into the vector_t.
  *
  * @return 1 if the element was added successfully, 0 otherwise.
  */
-dogecoin_bool vector_add(vector* vec, void* data)
+dogecoin_bool vector_add(vector_t* vec, void* data)
 {
     if (vec->len == vec->alloc) {
         if (!vector_grow(vec, vec->len + 1)) {
@@ -195,15 +195,15 @@ dogecoin_bool vector_add(vector* vec, void* data)
 
 /**
  * @brief This function deletes a range of consecutive
- * elements from the specified vector.
+ * elements from the specified vector_t.
  *
- * @param vec The pointer to the vector to edit.
+ * @param vec The pointer to the vector_t to edit.
  * @param pos The index of the first item to remove.
  * @param len The number of consecutive elements to remove.
  *
  * @return Nothing.
  */
-void vector_remove_range(vector* vec, size_t pos, size_t len)
+void vector_remove_range(vector_t* vec, size_t pos, size_t len)
 {
     if (!vec || ((pos + len) > vec->len)) {
         return;
@@ -223,12 +223,12 @@ void vector_remove_range(vector* vec, size_t pos, size_t len)
 
 /**
  * @brief This function removes a single element from
- * the specified vector.
+ * the specified vector_t.
  *
- * @param vec The pointer to the vector to edit.
+ * @param vec The pointer to the vector_t to edit.
  * @param pos The index of the element to remove.
  */
-void vector_remove_idx(vector* vec, size_t pos)
+void vector_remove_idx(vector_t* vec, size_t pos)
 {
     vector_remove_range(vec, pos, 1);
 }
@@ -239,12 +239,12 @@ void vector_remove_idx(vector* vec, size_t pos)
  * matches the data specified and removes it if it
  * exists.
  *
- * @param vec The pointer to the vector to edit.
+ * @param vec The pointer to the vector_t to edit.
  * @param data The data to match.
  *
  * @return 1 if the element was removed successfully, 0 if the data was not found.
  */
-dogecoin_bool vector_remove(vector* vec, void* data)
+dogecoin_bool vector_remove(vector_t* vec, void* data)
 {
     ssize_t idx = vector_find(vec, data);
     if (idx < 0) {
@@ -257,18 +257,18 @@ dogecoin_bool vector_remove(vector* vec, void* data)
 
 
 /**
- * @brief This function resizes the vector to be newsz
- * elements long. If the new size is bigger, the vector
+ * @brief This function resizes the vector_t to be newsz
+ * elements long. If the new size is bigger, the vector_t
  * is grown and the new elements are left empty. If the
- * new size is smaller, vector elements will be truncated.
+ * new size is smaller, vector_t elements will be truncated.
  * If the new size is the same, do nothing.
  *
- * @param vec The pointer to the vector to resize.
- * @param newsz The new desired size of the vector.
+ * @param vec The pointer to the vector_t to resize.
+ * @param newsz The new desired size of the vector_t.
  *
- * @return 1 if the vector was resized successfully, 0 otherwise.
+ * @return 1 if the vector_t was resized successfully, 0 otherwise.
  */
-dogecoin_bool vector_resize(vector* vec, size_t newsz)
+dogecoin_bool vector_resize(vector_t* vec, size_t newsz)
 {
     size_t i;
 
@@ -306,16 +306,16 @@ dogecoin_bool vector_resize(vector* vec, size_t newsz)
 }
 
 /**
- * @brief This function serializes a vector into a string.
+ * @brief This function serializes a vector_t into a string.
  *
- * @param vec The vector to serialize.
+ * @param vec The vector_t to serialize.
  * @param out The output buffer.
  * @param outlen The length of the output buffer.
  * @param written The number of bytes written to the output buffer.
  *
- * @return 1 if the vector was serialized successfully, 0 otherwise.
+ * @return 1 if the vector_t was serialized successfully, 0 otherwise.
  */
-dogecoin_bool serializeVector(vector* vec, char* out, size_t outlen, size_t* written) {
+dogecoin_bool serializeVector(vector_t* vec, char* out, size_t outlen, size_t* written) {
     if (!out || !outlen || !vec || !written) {
         return false;
     }
@@ -341,16 +341,16 @@ dogecoin_bool serializeVector(vector* vec, char* out, size_t outlen, size_t* wri
 }
 
 /**
- * @brief This function deserializes a string into a vector.
+ * @brief This function deserializes a string into a vector_t.
  *
- * @param vec The vector to deserialize into.
+ * @param vec The vector_t to deserialize into.
  * @param in The input buffer.
  * @param inlen The length of the input buffer.
  * @param read The number of bytes read from the input buffer.
  *
- * @return 1 if the vector was deserialized successfully, 0 otherwise.
+ * @return 1 if the vector_t was deserialized successfully, 0 otherwise.
  */
-dogecoin_bool deserializeVector(vector* vec, const char* in, size_t inlen, size_t* read) {
+dogecoin_bool deserializeVector(vector_t* vec, const char* in, size_t inlen, size_t* read) {
     if (!in || inlen > MAX_SERIALIZE_SIZE || !vec || !read) {
         return false;
     }
@@ -370,7 +370,7 @@ dogecoin_bool deserializeVector(vector* vec, const char* in, size_t inlen, size_
         }
 
         if (!vector_add(vec, str)) {
-            free(str); // Free the string if adding to the vector fails
+            free(str); // Free the string if adding to the vector_t fails
             return false;
         }
 

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -84,7 +84,7 @@ int dogecoin_wallet_addr_compare(const void *l, const void *r)
     /* byte per byte compare */
     /* TODO: switch to memcmp */
     unsigned int i;
-    for (i = 0; i < sizeof(uint160); i++) {
+    for (i = 0; i < sizeof(uint160_t); i++) {
         uint8_t iA = pubkeyA[i];
         uint8_t iB = pubkeyB[i];
         if (iA > iB)
@@ -106,7 +106,7 @@ int dogecoin_wtx_compare(const void *l, const void *r)
 
     /* byte per byte compare */
     unsigned int i;
-    for (i = 0; i < sizeof(uint256); i++) {
+    for (i = 0; i < sizeof(uint256_t); i++) {
         uint8_t iA = hashA[i];
         uint8_t iB = hashB[i];
         if (iA > iB)
@@ -127,7 +127,7 @@ int dogecoin_utxo_compare(const void *l, const void *r)
 
     /* byte per byte compare */
     unsigned int i;
-    for (i = 0; i < sizeof(uint256); i++) {
+    for (i = 0; i < sizeof(uint256_t); i++) {
         uint8_t iA = hashA[i];
         uint8_t iB = hashB[i];
         if (iA > iB)
@@ -148,7 +148,7 @@ int dogecoin_tx_outpoint_compare(const void *l, const void *r)
 
     /* byte per byte compare */
     unsigned int i;
-    for (i = 0; i < sizeof(uint256); i++) {
+    for (i = 0; i < sizeof(uint256_t); i++) {
         uint8_t iA = hashA[i];
         uint8_t iB = hashB[i];
         if (iA > iB)
@@ -305,7 +305,7 @@ void dogecoin_wallet_addr_free(dogecoin_wallet_addr* waddr)
 void dogecoin_wallet_addr_serialize(cstring* s, const dogecoin_chainparams *params, const dogecoin_wallet_addr* waddr)
 {
     (void)(params);
-    ser_bytes(s, waddr->pubkeyhash, sizeof(uint160));
+    ser_bytes(s, waddr->pubkeyhash, sizeof(uint160_t));
     ser_bytes(s, (unsigned char *)&waddr->type, sizeof(uint8_t));
     ser_u32(s, waddr->childindex);
     ser_bytes(s, (unsigned char *)&waddr->ignore, sizeof(uint8_t));
@@ -313,7 +313,7 @@ void dogecoin_wallet_addr_serialize(cstring* s, const dogecoin_chainparams *para
 
 dogecoin_bool dogecoin_wallet_addr_deserialize(dogecoin_wallet_addr* waddr, const dogecoin_chainparams *params, struct const_buffer* buf) {
     (void)(params);
-    if (!deser_bytes(&waddr->pubkeyhash, buf, sizeof(uint160))) return false;
+    if (!deser_bytes(&waddr->pubkeyhash, buf, sizeof(uint160_t))) return false;
     if (!deser_bytes((unsigned char *)&waddr->type, buf, sizeof(uint8_t))) return false;
     if (!deser_u32(&waddr->childindex, buf)) return false;
     if (!deser_bytes((unsigned char *)&waddr->ignore, buf, sizeof(uint8_t))) return false;
@@ -557,8 +557,8 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
 }
 
 void print_utxos(dogecoin_wallet* wallet) {
-    /* Creating a vector of addresses and storing them in the wallet. */
-    vector* addrs = vector_new(1, free);
+    /* Creating a vector_t of addresses and storing them in the wallet. */
+    vector_t* addrs = vector_new(1, free);
     dogecoin_wallet_get_addresses(wallet, addrs);
     unsigned int i;
     for (i = 0; i < addrs->len; i++) {
@@ -626,12 +626,12 @@ void dogecoin_wallet_free(dogecoin_wallet* wallet)
     }
 
     if (wallet->waddr_vector) {
-        vector_free(wallet->waddr_vector, true); // set to 'true' if vector owns the elements
+        vector_free(wallet->waddr_vector, true); // set to 'true' if vector_t owns the elements
         wallet->waddr_vector = NULL;
     }
 
     if (wallet->vec_wtxes) {
-        vector_free(wallet->vec_wtxes, true); // set to 'true' if vector owns the elements
+        vector_free(wallet->vec_wtxes, true); // set to 'true' if vector_t owns the elements
         wallet->vec_wtxes = NULL;
     }
 
@@ -688,15 +688,15 @@ void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
     // iterate through vout's:
     for (; j < wtx->tx->vout->len; j++) {
         dogecoin_tx_out* tx_out = vector_idx(wtx->tx->vout, j);
-        // populate address vector if script_pubkey exists:
+        // populate address vector_t if script_pubkey exists:
         if (wallet->waddr_vector->len && tx_out->script_pubkey->len) {
             char p2pkh_from_script_pubkey[P2PKHLEN];
             // convert script pubkey hash to p2pkh address:
             if (!dogecoin_pubkey_hash_to_p2pkh_address(tx_out->script_pubkey->str, tx_out->script_pubkey->len, p2pkh_from_script_pubkey, wallet->chain)) {
                 printf("failed to convert pubkey hash to p2pkh address!\n");
             }
-            vector* addrs = vector_new(1, free);
-            // grab all addresses in vector:
+            vector_t* addrs = vector_new(1, free);
+            // grab all addresses in vector_t:
             dogecoin_wallet_get_addresses(wallet, addrs);
             unsigned int i, g;
             // loop through addresses:
@@ -704,14 +704,14 @@ void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
                 char* addr = vector_idx(addrs, i);
                 // compare wtx->tx->vout with address from wallet->waddr_vector:
                 if (strncmp(p2pkh_from_script_pubkey, addr, P2PKHLEN - 1)==0) {
-                    uint256 utxo_txid;
+                    uint256_t utxo_txid;
                     // make the txid:
                     dogecoin_tx_hash(wtx->tx, (uint8_t*)&utxo_txid);
                     // convert from uint8_t to char*
                     char* hexbuf = utils_uint8_to_hex((const uint8_t*)&utxo_txid, DOGECOIN_HASH_LENGTH);
                     // reverse txid with double length:
                     utils_reverse_hex(hexbuf, DOGECOIN_HASH_LENGTH*2);
-                    // copy back to utxo->txid as uint256 (uint8_t* or uint8_t[32]):
+                    // copy back to utxo->txid as uint256_t (uint8_t* or uint8_t[32]):
                     memcpy_safe(utxo_txid, utils_hex_to_uint8(hexbuf), 32);
                     g = 0;
                     dogecoin_utxo* unspent_utxo;
@@ -798,7 +798,7 @@ dogecoin_bool dogecoin_wallet_create(dogecoin_wallet* wallet, const char* file_p
     if (fwrite(&v, sizeof(v), 1, wallet->dbfile) != 1) return false;
 
     // write genesis
-    if (fwrite(wallet->chain->genesisblockhash, sizeof(uint256), 1, wallet->dbfile ) != 1) return false;
+    if (fwrite(wallet->chain->genesisblockhash, sizeof(uint256_t), 1, wallet->dbfile ) != 1) return false;
 
     dogecoin_file_commit(wallet->dbfile);
     return true;
@@ -874,7 +874,7 @@ dogecoin_bool dogecoin_wallet_load_transaction(dogecoin_wallet* wallet, uint32_t
 //     wallet->dbfile = fopen(file_path, "w+b");
 
 //     // file header magic, version and genesis lengths:
-//     size_t skip_length = 4 + sizeof(uint32_t) + sizeof(uint256);
+//     size_t skip_length = 4 + sizeof(uint32_t) + sizeof(uint256_t);
 //     fseek(wallet->dbfile, skip_length, SEEK_CUR);
 
 //     while (!feof(wallet->dbfile))
@@ -947,7 +947,7 @@ dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_pat
     }
     else {
         // check file-header-magic, version and genesis
-        uint8_t buf[sizeof(file_hdr_magic)+sizeof(current_version)+sizeof(uint256)];
+        uint8_t buf[sizeof(file_hdr_magic)+sizeof(current_version)+sizeof(uint256_t)];
         if ((uint32_t)buffer.st_size < (uint32_t)(sizeof(buf)) || fread(buf, sizeof(buf), 1, wallet->dbfile) != 1 || memcmp(buf, file_hdr_magic, sizeof(file_hdr_magic)))
         {
             fprintf(stderr, "Wallet file: error reading database file\n");
@@ -957,7 +957,7 @@ dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_pat
             fprintf(stderr, "Wallet file: unsupported file version\n");
             return false;
         }
-        if (memcmp(buf+sizeof(file_hdr_magic)+sizeof(current_version), wallet->chain->genesisblockhash, sizeof(uint256)) != 0) {
+        if (memcmp(buf+sizeof(file_hdr_magic)+sizeof(current_version), wallet->chain->genesisblockhash, sizeof(uint256_t)) != 0) {
             fprintf(stderr, "Wallet file: different network\n");
             return false;
         }
@@ -1136,7 +1136,7 @@ dogecoin_bool dogecoin_p2pkh_address_to_wallet_pubkeyhash(const char* address_in
     if (!address_in || !addr || !wallet || !wallet->masterkey) return false;
 
     // lookup to see if we have address already:
-    vector* addrs = vector_new(1, free);
+    vector_t* addrs = vector_new(1, free);
     dogecoin_wallet_get_addresses(wallet, addrs);
     dogecoin_bool match = false;
     unsigned int i;
@@ -1154,7 +1154,7 @@ dogecoin_bool dogecoin_p2pkh_address_to_wallet_pubkeyhash(const char* address_in
 
     memcpy_safe(addr->pubkeyhash, utils_hex_to_uint8(pubkey_hash), 20);
 
-    // if no match add to rbtree, vector and db:
+    // if no match add to rbtree, vector_t and db:
     if (!match) {
         addr->childindex = wallet->next_childindex;
         dogecoin_btree_tsearch(addr, &wallet->waddr_rbtree, dogecoin_wallet_addr_compare);
@@ -1175,7 +1175,7 @@ dogecoin_wallet_addr* dogecoin_p2pkh_address_to_wallet(const char* address_in, d
     // lookup to see if we have address already:
     dogecoin_bool match = false;
     if (wallet->waddr_vector->len) {
-        vector* addrs = vector_new(1, free);
+        vector_t* addrs = vector_new(1, free);
         dogecoin_wallet_get_addresses(wallet, addrs);
         unsigned int i;
         for (i = 0; i < addrs->len; i++) {
@@ -1188,7 +1188,7 @@ dogecoin_wallet_addr* dogecoin_p2pkh_address_to_wallet(const char* address_in, d
         vector_free(addrs, true);
     }
 
-    // if no match add to rbtree, vector and db:
+    // if no match add to rbtree, vector_t and db:
     if (!match) {
         dogecoin_wallet_addr* addr = dogecoin_wallet_addr_new();
         char* pubkey_hash = dogecoin_address_to_pubkey_hash((char*)address_in);
@@ -1208,7 +1208,7 @@ dogecoin_wallet_addr* dogecoin_p2pkh_address_to_wallet(const char* address_in, d
     return NULL;
 }
 
-void dogecoin_wallet_get_addresses(dogecoin_wallet* wallet, vector* addr_out)
+void dogecoin_wallet_get_addresses(dogecoin_wallet* wallet, vector_t* addr_out)
 {
     unsigned int i;
     for (i = 0; i < wallet->waddr_vector->len; i++) {
@@ -1228,7 +1228,7 @@ dogecoin_wallet_addr* dogecoin_wallet_find_waddr_byaddr(dogecoin_wallet* wallet,
         return NULL;
 
     uint8_t hashdata[P2PKHLEN];
-    dogecoin_mem_zero(hashdata, sizeof(uint160));
+    dogecoin_mem_zero(hashdata, sizeof(uint160_t));
     int outlen = dogecoin_base58_decode_check(search_addr, hashdata, P2PKHLEN);
 
     if (outlen > 0 && hashdata[0] == wallet->chain->b58prefix_pubkey_address) {
@@ -1239,7 +1239,7 @@ dogecoin_wallet_addr* dogecoin_wallet_find_waddr_byaddr(dogecoin_wallet* wallet,
 
     dogecoin_wallet_addr* waddr_search;
     waddr_search = dogecoin_calloc(1, sizeof(*waddr_search));
-    memcpy_safe(waddr_search->pubkeyhash, hashdata+1, sizeof(uint160));
+    memcpy_safe(waddr_search->pubkeyhash, hashdata+1, sizeof(uint160_t));
 
     dogecoin_wallet_addr *needle = dogecoin_btree_tfind(waddr_search, &wallet->waddr_rbtree, dogecoin_wallet_addr_compare); /* read */
     if (needle) {
@@ -1278,13 +1278,13 @@ dogecoin_bool dogecoin_wallet_add_wtx_move(dogecoin_wallet* wallet, dogecoin_wtx
     return true;
 }
 
-dogecoin_bool dogecoin_wallet_have_key(dogecoin_wallet* wallet, uint160 hash160)
+dogecoin_bool dogecoin_wallet_have_key(dogecoin_wallet* wallet, uint160_t hash160)
 {
     if (!wallet)
         return false;
 
     dogecoin_wallet_addr waddr_search;
-    memcpy_safe(&waddr_search.pubkeyhash, hash160, sizeof(uint160));
+    memcpy_safe(&waddr_search.pubkeyhash, hash160, sizeof(uint160_t));
 
     dogecoin_wallet_addr *needle = dogecoin_btree_tfind(&waddr_search, &wallet->waddr_rbtree, dogecoin_wallet_addr_compare); /* read */
     if (needle) {
@@ -1363,10 +1363,10 @@ dogecoin_bool dogecoin_wallet_txout_is_mine(dogecoin_wallet* wallet, dogecoin_tx
 
     dogecoin_bool ismine = false;
 
-    vector* vec = vector_new(16, free);
+    vector_t* vec = vector_new(16, free);
     enum dogecoin_tx_out_type type = dogecoin_script_classify(tx_out->script_pubkey, vec);
 
-    if (type == DOGECOIN_TX_PUBKEY) { //TODO: find a better format for vector elements (not a pure pointer)
+    if (type == DOGECOIN_TX_PUBKEY) { //TODO: find a better format for vector_t elements (not a pure pointer)
         goto check;
     } else if (type == DOGECOIN_TX_PUBKEYHASH) {
         goto check;
@@ -1443,13 +1443,13 @@ dogecoin_bool dogecoin_wallet_is_from_me(dogecoin_wallet *wallet, const dogecoin
     return (dogecoin_wallet_get_debit_tx(wallet, tx) > 0);
 }
 
-dogecoin_bool dogecoin_wallet_is_spent(dogecoin_wallet* wallet, uint256 hash, uint32_t n)
+dogecoin_bool dogecoin_wallet_is_spent(dogecoin_wallet* wallet, uint256_t hash, uint32_t n)
 {
     if (!wallet)
         return false;
 
     dogecoin_tx_outpoint outpoint;
-    memcpy_safe(&outpoint.hash, hash, sizeof(uint256));
+    memcpy_safe(&outpoint.hash, hash, sizeof(uint256_t));
     outpoint.n = n;
     dogecoin_tx_outpoint* possible_found = dogecoin_btree_tfind(&outpoint, &wallet->spends_rbtree, dogecoin_tx_outpoint_compare);
     if (possible_found) {
@@ -1459,7 +1459,7 @@ dogecoin_bool dogecoin_wallet_is_spent(dogecoin_wallet* wallet, uint256 hash, ui
     return (possible_found != NULL);
 }
 
-dogecoin_wtx * dogecoin_wallet_get_wtx(dogecoin_wallet* wallet, const uint256 hash) {
+dogecoin_wtx * dogecoin_wallet_get_wtx(dogecoin_wallet* wallet, const uint256_t hash) {
     dogecoin_wtx find;
     find.tx = NULL;
     dogecoin_hash_set(find.tx_hash_cache, hash);
@@ -1470,7 +1470,7 @@ dogecoin_wtx * dogecoin_wallet_get_wtx(dogecoin_wallet* wallet, const uint256 ha
     return NULL;
 }
 
-dogecoin_bool dogecoin_wallet_get_unspents(dogecoin_wallet* wallet, vector* unspents)
+dogecoin_bool dogecoin_wallet_get_unspents(dogecoin_wallet* wallet, vector_t* unspents)
 {
     if (!wallet || !unspents) {
         return false;
@@ -1495,7 +1495,7 @@ dogecoin_bool dogecoin_wallet_get_unspents(dogecoin_wallet* wallet, vector* unsp
     return true;
 }
 
-dogecoin_bool dogecoin_wallet_get_unspent(vector* unspents)
+dogecoin_bool dogecoin_wallet_get_unspent(vector_t* unspents)
 {
     unsigned int i;
     for (i = 0; i < HASH_COUNT(utxos); i++) {
@@ -1511,7 +1511,7 @@ void dogecoin_wallet_check_transaction(void *ctx, dogecoin_tx *tx, unsigned int 
     if (dogecoin_wallet_is_mine(wallet, tx) || dogecoin_wallet_is_from_me(wallet, tx)) {
         printf("\nFound relevant transaction!\n");
         dogecoin_wtx* wtx = dogecoin_wallet_wtx_new();
-        uint256 blockhash;
+        uint256_t blockhash;
         dogecoin_block_header_hash(&pindex->header, blockhash);
         dogecoin_hash_set(wtx->blockhash, blockhash);
         wtx->height = pindex->height;
@@ -1583,7 +1583,7 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
             // rewind db to read again:
             rewind(wallet->dbfile);
             // check file-header-magic, version and genesis
-            uint8_t buf[sizeof(file_hdr_magic) + sizeof(current_version) + sizeof(uint256)];
+            uint8_t buf[sizeof(file_hdr_magic) + sizeof(current_version) + sizeof(uint256_t)];
             if (fread(buf, sizeof(buf), 1, wallet->dbfile) != 1 || memcmp(buf, file_hdr_magic, sizeof(file_hdr_magic))) {
                 fprintf(stderr, "Wallet file: error reading database file\n");
                 return false;
@@ -1592,7 +1592,7 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
                 fprintf(stderr, "Wallet file: unsupported file version\n");
                 return false;
             }
-            if (memcmp(buf+sizeof(file_hdr_magic)+sizeof(current_version), wallet->chain->genesisblockhash, sizeof(uint256)) != 0) {
+            if (memcmp(buf+sizeof(file_hdr_magic)+sizeof(current_version), wallet->chain->genesisblockhash, sizeof(uint256_t)) != 0) {
                 fprintf(stderr, "Wallet file: different network\n");
                 return false;
             }
@@ -1731,7 +1731,7 @@ copy:
     return true;
 }
 
-int dogecoin_get_utxo_vector(char* address, vector* utxo_vec) {
+int dogecoin_get_utxo_vector(char* address, vector_t* utxo_vec) {
     if (!address) return false;
     dogecoin_wallet* wallet = dogecoin_wallet_read(address);
     if (HASH_COUNT(utxos) > 0) {
@@ -1822,7 +1822,7 @@ char* dogecoin_get_utxo_txid_str(char* address, unsigned int index) {
 
 uint8_t* dogecoin_get_utxo_txid(char* address, unsigned int index) {
     if (!address) return false;
-    uint256* txid = dogecoin_uint256_vla(1);
+    uint256_t* txid = dogecoin_uint256_vla(1);
     char* txid_str = dogecoin_get_utxo_txid_str(address, index);
     memcpy_safe(txid, utils_hex_to_uint8(txid_str), DOGECOIN_HASH_LENGTH*2);
     return (uint8_t*)txid;

--- a/test/block_tests.c
+++ b/test/block_tests.c
@@ -54,8 +54,8 @@ void test_block_header()
         cstring* serialized = cstr_new_sz(80);
         const struct blockheadertest* test = &block_header_tests[i];
         uint8_t header_data[80];
-        uint256 hash_data;
-        uint256 chainwork = {0};
+        uint256_t hash_data;
+        uint256_t chainwork = {0};
         utils_hex_to_bin(test->hexheader, header_data, 160, &outlen);
 
         utils_hex_to_bin(test->hexhash, hash_data, sizeof(hash_data), &outlen);
@@ -76,7 +76,7 @@ void test_block_header()
         assert(memcmp(hexbuf, test->hexheader, 160) == 0);
 
         // Check the block hash
-        uint256 blockhash;
+        uint256_t blockhash;
         dogecoin_block_header_hash(header, blockhash);
 
         utils_bin_to_hex(blockhash, DOGECOIN_HASH_LENGTH, hexbuf);
@@ -93,7 +93,7 @@ void test_block_header()
             arith_uint256* target = init_arith_uint256();
             cstring* s = cstr_new_sz(64);
             dogecoin_bool f_negative, f_overflow;
-            uint256* hash = dogecoin_uint256_vla(1);
+            uint256_t* hash = dogecoin_uint256_vla(1);
 
             // Compute the hash of the block header
             dogecoin_block_header_serialize(s, header);
@@ -168,8 +168,8 @@ void test_block_header()
     utils_bin_to_hex((unsigned char *)blockheader_ser->str, blockheader_ser->len, headercheck);
     u_assert_str_eq(headercheck, blockheader_h371338);
 
-    uint256 checkhash;
-    uint256 chainwork;
+    uint256_t checkhash;
+    uint256_t chainwork;
     dogecoin_block_header_hash(&bheader, (uint8_t *)&checkhash);
     char hashhex[sizeof(checkhash) * 2 + 1];
     utils_bin_to_hex(checkhash, sizeof(checkhash), hashhex);

--- a/test/chacha20_tests.c
+++ b/test/chacha20_tests.c
@@ -45,7 +45,7 @@ void testchacha20(const char* hexkey, uint64_t nonce, uint64_t seek, const char*
 }
 
 void test_chacha20() {
-    // Test vector from RFC 7539
+    // Test vector_t from RFC 7539
     testchacha20("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", 0x4a000000UL, 1,
                  "224f51f3401bd9e12fde276fb8631ded8c131f823d2c06e27e4fcaec9ef3cf788a3b0aa372600a92b57974cded2b9334794cb"
                  "a40c63e34cdea212c4cf07d41b769a6749f3f630f4122cafe28ec4dc47e26d4346d70b98c73f3e9c53ac40c5945398b6eda1a"

--- a/test/hash_tests.c
+++ b/test/hash_tests.c
@@ -53,9 +53,9 @@ void test_hash()
 {
     const char data[] = "cea946542b91ca50e2afecba73cf546ce1383d82668ecb6265f79ffaa07daa49abb43e21a19c6b2b15c8882b4bc01085a8a5b00168139dcb8f4b2bbe22929ce196d43532898d98a3b0ea4d63112ba25e724bb50711e3cf55954cf30b4503b73d785253104c2df8c19b5b63e92bd6b1ff2573751ec9c508085f3f206c719aa4643776bf425344348cbf63f1450389";
     const char expected[] = "52aa8dd6c598d91d580cc446624909e52a076064ffab67a1751f5758c9f76d26";
-    uint256* digest_expected;
-    digest_expected = (uint256*)utils_hex_to_uint8(expected);
-    uint256 hashout;
+    uint256_t* digest_expected;
+    digest_expected = (uint256_t*)utils_hex_to_uint8(expected);
+    uint256_t hashout;
     dogecoin_hash((const unsigned char*)data, strlen(data), hashout);
     assert(memcmp(hashout, digest_expected, sizeof(hashout)) == 0);
 
@@ -84,7 +84,7 @@ void test_hash()
     hasher->write(hasher, 0x2F2E2D2C2B2A2928ULL);
     u_assert_uint64_eq(hasher->finalize(hasher), 0xe612a3cb9ecba951ull);
 
-    uint256* hash_in = dogecoin_uint256_vla(1);
+    uint256_t* hash_in = dogecoin_uint256_vla(1);
     utils_uint256_sethex("1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100", (uint8_t*)hash_in);
     u_assert_uint64_eq(siphash_u256(0x0706050403020100ULL, 0x0F0E0D0C0B0A0908ULL, hash_in), 0x7127512f72f27cceull);
 
@@ -114,7 +114,7 @@ void test_hash()
     // and the test would be affected by default tx version bumps if not fixed.
     tx->version = 1;
     dogecoin_tx_serialize(hw->cstr, tx);
-    u_assert_uint64_eq(siphash_u256(1, 2, (uint256*)hw->get_hash(hw)), 0x79751e980c2a0a35ULL);
+    u_assert_uint64_eq(siphash_u256(1, 2, (uint256_t*)hw->get_hash(hw)), 0x79751e980c2a0a35ULL);
 
     dogecoin_free(hash_in);
     dogecoin_free(hasher);

--- a/test/net_tests.c
+++ b/test/net_tests.c
@@ -83,7 +83,7 @@ void postcmd(struct dogecoin_node_ *node, dogecoin_p2p_msg_hdr *hdr, struct cons
     if (strcmp(hdr->command, "block") == 0)
     {
         dogecoin_block_header header;
-        uint256 chainwork;
+        uint256_t chainwork;
         if (!dogecoin_block_header_deserialize(&header, buf, node->nodegroup->chainparams, &chainwork)) return;
 
         uint32_t vsize;
@@ -129,10 +129,10 @@ void postcmd(struct dogecoin_node_ *node, dogecoin_p2p_msg_hdr *hdr, struct cons
         /* send getblock command */
 
         /* request some headers (from the genesis block) */
-        vector *blocklocators = vector_new(1, NULL);
-        uint256 from_hash;
+        vector_t *blocklocators = vector_new(1, NULL);
+        uint256_t from_hash;
         utils_uint256_sethex("c7e47980df148701d04fb81a84acce85d8fb3556c7b1ff1cd021023b7c9f9593", from_hash); // height 428694
-        uint256 stop_hash;
+        uint256_t stop_hash;
         utils_uint256_sethex("1910002ddc9705c0799236589b91304404f45728f805bac7c94fc42ac0db1248", stop_hash); // height 428695
 
         vector_add(blocklocators, from_hash);
@@ -175,7 +175,7 @@ void handshake_done(struct dogecoin_node_ *node)
     }
 
     // request some headers (from the genesis block)
-    vector *blocklocators = vector_new(1, NULL);
+    vector_t *blocklocators = vector_new(1, NULL);
     vector_add(blocklocators, (void *)node->nodegroup->chainparams->genesisblockhash);
 
     cstring *getheader_msg = cstr_new_sz(256);
@@ -197,7 +197,7 @@ void handshake_done(struct dogecoin_node_ *node)
 void test_net_basics_plus_download_block()
 {
 
-    vector *ips = vector_new(10, free);
+    vector_t *ips = vector_new(10, free);
     unsigned int seed_index;
     /* dogecoin_chainparams has up to 8 dns seeds */
     for (seed_index = 0; seed_index < 8; seed_index++) {

--- a/test/protocol_tests.c
+++ b/test/protocol_tests.c
@@ -57,7 +57,7 @@ void test_protocol()
     dogecoin_p2p_inv_msg inv_msg, inv_msg_check;
     dogecoin_mem_zero(&inv_msg, sizeof(inv_msg));
 
-    uint256 hash = {0};
+    uint256_t hash = {0};
 
     dogecoin_p2p_msg_inv_init(&inv_msg, 1, hash);
     dogecoin_p2p_msg_inv_ser(&inv_msg, inv_msg_cstr);
@@ -100,8 +100,8 @@ void test_protocol()
     cstr_free(version_msg_cstr, true);
 
     /* getheaders */
-    uint256 genesis_hash = {0x00, 0x00, 0x00, 0x00, 0x00, 0x19, 0xd6, 0x68, 0x9c, 0x08, 0x5a, 0xe1, 0x65, 0x83, 0x1e, 0x93, 0x4f, 0xf7, 0x63, 0xae, 0x46, 0xa2, 0xa6, 0xc1, 0x72, 0xb3, 0xf1, 0xb6, 0x0a, 0x8c, 0xe2, 0x6f};
-    vector *blocklocators = vector_new(1, NULL);
+    uint256_t genesis_hash = {0x00, 0x00, 0x00, 0x00, 0x00, 0x19, 0xd6, 0x68, 0x9c, 0x08, 0x5a, 0xe1, 0x65, 0x83, 0x1e, 0x93, 0x4f, 0xf7, 0x63, 0xae, 0x46, 0xa2, 0xa6, 0xc1, 0x72, 0xb3, 0xf1, 0xb6, 0x0a, 0x8c, 0xe2, 0x6f};
+    vector_t *blocklocators = vector_new(1, NULL);
     vector_add(blocklocators, genesis_hash);
     cstring *getheader_msg = cstr_new_sz(256);
     dogecoin_p2p_msg_getheaders(blocklocators, NULL, getheader_msg);
@@ -115,8 +115,8 @@ void test_protocol()
     u_assert_uint32_eq(hdr.data_len, getheader_msg->len);
 
 
-    uint256 hashstop_check;
-    vector *blocklocators_check = vector_new(1, free);
+    uint256_t hashstop_check;
+    vector_t *blocklocators_check = vector_new(1, free);
     dogecoin_p2p_deser_msg_getheaders(blocklocators_check, hashstop_check, &buf);
     u_assert_mem_eq(NULLHASH, hashstop_check, sizeof(hashstop_check));
     uint8_t *hash_loc_0 = vector_idx(blocklocators_check, 0);

--- a/test/random_tests.c
+++ b/test/random_tests.c
@@ -42,8 +42,8 @@ void test_random()
     dogecoin_bool ret64 = dogecoin_random_bytes(r_buf64, 64, 0);
     u_assert_int_eq(ret64, true);
 
-    fast_random_context* this = init_fast_random_context(true, (const uint256*)r_buf);
-    fast_random_context* this2 = init_fast_random_context(true, (const uint256*)r_buf);
+    fast_random_context* this = init_fast_random_context(true, (const uint256_t*)r_buf);
+    fast_random_context* this2 = init_fast_random_context(true, (const uint256_t*)r_buf);
     dogecoin_mem_zero(r_buf, 32);
     this->rng->output(this->rng, r_buf, 32);
     this2->rng->output(this2->rng, r_buf, 32);
@@ -52,8 +52,8 @@ void test_random()
     u_assert_int_eq(this->randbits(this, 3), this2->randbits(this2, 3));
     u_assert_uint32_eq(this->rand32(this), this2->rand32(this2));
     u_assert_uint64_eq(this->rand64(this), this->rand64(this2));
-    uint256* r256_1 = this->rand256(this);
-    uint256* r256_2 = this2->rand256(this2);
+    uint256_t* r256_1 = this->rand256(this);
+    uint256_t* r256_2 = this2->rand256(this2);
     u_assert_mem_eq(r256_1, r256_2, 32);
     dogecoin_free(r256_1);
     dogecoin_free(r256_2);
@@ -64,8 +64,8 @@ void test_random()
     fast_random_context* this4 = init_fast_random_context(false, 0);
     u_assert_uint32_not_eq(this3->rand32(this3), this4->rand32(this4));
     u_assert_uint64_not_eq(this3->rand64(this3), this4->rand64(this4));
-    uint256* r256_3 = this3->rand256(this3);
-    uint256* r256_4 = this4->rand256(this4);
+    uint256_t* r256_3 = this3->rand256(this3);
+    uint256_t* r256_4 = this4->rand256(this4);
     u_assert_mem_not_eq(r256_3, r256_4, 32);
     dogecoin_free(r256_3);
     dogecoin_free(r256_4);

--- a/test/scrypt_tests.c
+++ b/test/scrypt_tests.c
@@ -10,7 +10,7 @@ void test_scrypt() {
 #if defined(USE_SSE2)
     scrypt_detect_sse2();
 #endif
-    uint256 scrypthash;
+    uint256_t scrypthash;
     char scratchpad[SCRYPT_SCRATCHPAD_SIZE];
     int i = 0;
     for (; i < HASHCOUNT; i++) {

--- a/test/spv_tests.c
+++ b/test/spv_tests.c
@@ -207,7 +207,7 @@ void test_reorg() {
     utils_hex_to_bin(merkleroot_hex2, (uint8_t*) header5_fork->merkle_root, 64, &outlen); // merkle is a don't care
 
     // Calculate the chainwork for each header
-    uint256 chainwork1, chainwork2, chainwork3, chainwork4, chainwork2_stale, chainwork2_fork, chainwork3_fork, chainwork4_fork, chainwork5_fork;
+    uint256_t chainwork1, chainwork2, chainwork3, chainwork4, chainwork2_stale, chainwork2_fork, chainwork3_fork, chainwork4_fork, chainwork5_fork;
     arith_uint256* target1 = init_arith_uint256();
     arith_uint256* target2 = init_arith_uint256();
     arith_uint256* target3 = init_arith_uint256();
@@ -219,7 +219,7 @@ void test_reorg() {
     arith_uint256* target5_fork = init_arith_uint256();
     cstring* s = cstr_new_sz(64);
     dogecoin_bool f_negative, f_overflow;
-    uint256* hash = dogecoin_uint256_vla(1);
+    uint256_t* hash = dogecoin_uint256_vla(1);
 
     // Compute the hash of the block header 1
     dogecoin_block_header_serialize(s, header1);
@@ -282,7 +282,7 @@ void test_reorg() {
         bool pow_passed = check_pow(hash, header2_stale->bits, chain, &chainwork2_stale);
 
         // Update the arith_uint256 chainwork of the stale
-        memcpy(arith_chainwork2_stale, &chainwork2_stale, sizeof(uint256));
+        memcpy(arith_chainwork2_stale, &chainwork2_stale, sizeof(uint256_t));
 
         // Check if the chainwork of the stale is equal and the hash passes PoW
         if (arith_uint256_equal(arith_chainwork2_stale, arith_chainwork2) && pow_passed) {
@@ -319,7 +319,7 @@ void test_reorg() {
         bool pow_passed = check_pow(hash, header2_fork->bits, chain, &chainwork2_fork);
 
         // Update the arith_uint256 chainwork of the fork
-        memcpy(arith_chainwork2_fork, &chainwork2_fork, sizeof(uint256));
+        memcpy(arith_chainwork2_fork, &chainwork2_fork, sizeof(uint256_t));
 
         // Check if the chainwork of the fork is greater and the hash passes PoW
         if (arith_uint256_greater_than(arith_chainwork2_fork, arith_chainwork2) && pow_passed) {
@@ -366,7 +366,7 @@ void test_reorg() {
         bool pow_passed = check_pow(hash, header3_fork->bits, chain, &chainwork3_fork);
 
         // Update the arith_uint256 chainwork of the fork
-        memcpy(arith_chainwork3_fork, &chainwork3_fork, sizeof(uint256));
+        memcpy(arith_chainwork3_fork, &chainwork3_fork, sizeof(uint256_t));
 
         // Check if the hash passes PoW
         if (pow_passed) {
@@ -412,7 +412,7 @@ void test_reorg() {
         bool pow_passed = check_pow(hash, header4_fork->bits, chain, &chainwork4_fork);
 
         // Update the arith_uint256 chainwork of the fork
-        memcpy(arith_chainwork4_fork, &chainwork4_fork, sizeof(uint256));
+        memcpy(arith_chainwork4_fork, &chainwork4_fork, sizeof(uint256_t));
 
         // Check if the hash passes PoW
         if (pow_passed) {
@@ -458,7 +458,7 @@ void test_reorg() {
         bool pow_passed = check_pow(hash, header5_fork->bits, chain, &chainwork5_fork);
 
         // Update the arith_uint256 chainwork of the fork
-        memcpy(arith_chainwork5_fork, &chainwork5_fork, sizeof(uint256));
+        memcpy(arith_chainwork5_fork, &chainwork5_fork, sizeof(uint256_t));
 
         // Check if the hash passes PoW
         if (pow_passed) {

--- a/test/tx_tests.c
+++ b/test/tx_tests.c
@@ -835,7 +835,7 @@ void test_tx_sighash_ext()
 
         free(script_data);
 
-        uint256 hash;
+        uint256_t hash;
         dogecoin_tx_sighash(tx_sighash, str, txvalid_sighash[i].i, SIGHASH_ALL, hash);
 
         dogecoin_tx_free(tx_sighash);
@@ -869,11 +869,11 @@ void test_tx_sighash()
 
         free(script_data);
 
-        uint256 sighash;
+        uint256_t sighash;
         dogecoin_mem_zero(sighash, sizeof(sighash));
         dogecoin_tx_sighash(tx, script, test->inputindex, test->hashtype, sighash);
 
-        vector* vec = vector_new(10, dogecoin_script_op_free_cb);
+        vector_t* vec = vector_new(10, dogecoin_script_op_free_cb);
         dogecoin_script_get_ops(script, vec);
         enum dogecoin_tx_out_type type = dogecoin_script_classify_ops(vec);
         vector_free(vec, true);
@@ -933,7 +933,7 @@ void test_script_parse()
         utils_hex_to_bin(test->scripthex, script_data, strlen(test->scripthex), &outlen);
 
         cstring* script = cstr_new_buf(script_data, outlen);
-        vector* vec = vector_new(10, dogecoin_script_op_free_cb);
+        vector_t* vec = vector_new(10, dogecoin_script_op_free_cb);
         dogecoin_script_get_ops(script, vec);
         enum dogecoin_tx_out_type type = dogecoin_script_classify_ops(vec);
 
@@ -951,7 +951,7 @@ void test_script_parse()
         utils_hex_to_bin(test->script, script_data, strlen(test->script), &outlen);
 
         cstring* script = cstr_new_buf(script_data, outlen);
-        vector* vec = vector_new(10, dogecoin_script_op_free_cb);
+        vector_t* vec = vector_new(10, dogecoin_script_op_free_cb);
         u_assert_int_eq(dogecoin_script_get_ops(script, vec), true);
 
         cstring* new_script = cstr_new_sz(script->len);
@@ -964,7 +964,7 @@ void test_script_parse()
         vector_free(vec, true);
     }
 
-    vector* pubkeys = vector_new(3, free);
+    vector_t* pubkeys = vector_new(3, free);
     for (i = 0; i < 3; i++) {
         dogecoin_key key;
         dogecoin_privkey_init(&key);
@@ -1015,7 +1015,7 @@ void test_script_parse()
     cstr_free(txser, true);
     free(hexbuf);
 
-    uint256 txhash;
+    uint256_t txhash;
     dogecoin_tx_hash(tx, txhash);
     char txhashhex[sizeof(txhash) * 2 + 1];
     utils_bin_to_hex((unsigned char*)txhash, sizeof(txhash), txhashhex);
@@ -1075,8 +1075,8 @@ void test_script_parse()
     dogecoin_hdnode node;
     u_assert_int_eq(dogecoin_hdnode_deserialize(masterkey, &dogecoin_chainparams_main, &node), true);
 
-    uint256 rev_code;
-    uint256 sig_hash;
+    uint256_t rev_code;
+    uint256_t sig_hash;
     dogecoin_hash(node.private_key, DOGECOIN_ECKEY_PKEY_LENGTH, rev_code);
 
     uint8_t sigdata[38] = {0x42, 0x49, 0x50, 0x00, 0x00, 0x00, 0x00};
@@ -1290,7 +1290,7 @@ void test_scripts()
     utils_hex_to_bin(script_p2pkh, (unsigned char*)script_data_p2pkh->str, strlen(script_p2pkh), &outlen);
     script_data_p2pkh->len = outlen;
 
-    vector* vec = vector_new(16, free);
+    vector_t* vec = vector_new(16, free);
     enum dogecoin_tx_out_type type = dogecoin_script_classify(script_data_p2pk, vec);
     u_assert_int_eq(type, DOGECOIN_TX_PUBKEY);
     type = dogecoin_script_classify(script_data_p2pkh, vec);

--- a/test/vector_tests.c
+++ b/test/vector_tests.c
@@ -31,7 +31,7 @@ void test_vector()
     dogecoin_bool res;
     char str0[] = "string";
     char str1[] = "rumba";
-    vector* vec = vector_new(10, NULL);
+    vector_t* vec = vector_new(10, NULL);
     assert(vec != NULL);
     assert(vec->len == 0);
     assert(vec->alloc > 0);

--- a/test/wallet_tests.c
+++ b/test/wallet_tests.c
@@ -223,9 +223,9 @@ void test_wallet_basics()
     wallet_addr = dogecoin_wallet_next_addr(wallet);
 
     //now it should be equal
-    u_assert_mem_eq(wallet_addr->pubkeyhash, wallet_addr2->pubkeyhash, sizeof(uint160));
+    u_assert_mem_eq(wallet_addr->pubkeyhash, wallet_addr2->pubkeyhash, sizeof(uint160_t));
 
-    vector *addrs = vector_new(1, free);
+    vector_t *addrs = vector_new(1, free);
     dogecoin_wallet_get_addresses(wallet, addrs);
     u_assert_int_eq(addrs->len, 3);
     u_assert_str_eq(addrs->data[0],"DHprgyNMcy3Ct9zVbJCrezYywxTBDWPL3v");


### PR DESCRIPTION
Added `_t` suffix to `uint256`, `uint160`, and `vector` types to support core integration. Merge after #229.