### PR TITLE
utils: updated buffer length for max tx

### DIFF
--- a/include/dogecoin/utils.h
+++ b/include/dogecoin/utils.h
@@ -39,7 +39,8 @@
 #include <dogecoin/mem.h>
 #include <dogecoin/vector.h>
 
-#define TO_UINT8_HEX_BUF_LEN 2048
+/* 100 000-byte standard-tx → 200 000 hex chars + NUL */
+#define TO_UINT8_HEX_BUF_LEN 200001
 #define VARINT_LEN 20
 #define MAX_LEN 128
 

--- a/include/test/utest.h
+++ b/include/test/utest.h
@@ -313,7 +313,7 @@
             if (!r_) {                                                   \
                 printf("FAILED - %s() - Line %d\n", __func__, __LINE__); \
                 printf("\tExpect: \tnot NULL\n");                        \
-                printf("\tReceive:\tNULL\n", r_);                        \
+                printf("\tReceive:\tNULL\n");                            \
                 U_TESTS_FAIL++;                                          \
                 return;                                                  \
             };                                                           \

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -466,4 +466,77 @@ void test_transaction()
     // Call isMainnetFromB58Prefix
     u_assert_true(isMainnetFromB58Prefix("D6vSSr6ftnicfpSNARqezdehAL5Abe2LQw"));
 
+    // ----------------------------------------------------------------
+    // test a large transaction that caused problems in finalize_transaction
+
+    working_transaction_index = start_transaction();
+
+    // add inputs
+    u_assert_int_eq(add_utxo(working_transaction_index, "00df9507524acbf5ccc1c00d152216c984192f1fc6edad81406b4371a7d91038", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "5d08f2928cefd155e377fe40a521cf66317bcde0a24c0d9094090306196dbbf8", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9b9f872cbebff7d2242cbbde8d0fe7ca108be55bdde4a7e6905001f51bce2fc6", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "c9ef9105f0af21bef3df7affb68a8ccbf140b57bb3d880feafa98ff4a5ce7681", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9e31e81fcb20f493affd2e3d4ec6cc7438021253b6e8869407479ed1b999ead3", 2), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "78314092f843b6b78347c87c7d43c1591586d56bfe6de800a10ed6ac600d330d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "78cf3fc573cdd7b2226717ec697d5f9e813479194ba18aaf5ae715aa8a8d4427", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "a1cba23b31985476f25514b6593efd0fd0c625ceab071e90c3815521af385d4d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "62fea417be4c37db98c220fe96f4753518d0422e6c6727d66162648c9c169bbd", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d395def4e5590af657be7abc71549492e5d4f3679a60c758c20bf44c7daa5a51", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "55ea0e1b6612ae80e1b3f197dcf109e17d04bd9cd9853d4e826eac5cdd71b43a", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9c58ce226db9e0595d49e1c1673d93a01f40afe92f6d588bc74b4a17decfe253", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "53a0bd6ea2d02d40323b6e1ea11357367a0d4632b2f8404632330e8c89c3ded6", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d25dfc12e402124e7fe69488c9b330c6034ec7913d540b70c0539282d5000732", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "649b00be10ab02d6e884bb32946b682b03d2ed24d8c73a21a902d2c9f6731176", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "698f5b6e17a0c98266142276cfaf26776681275c9f7496a551ecfdb5dfad1960", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "15ffbba4111326cd0648c93c1b611d96a629e712e1ad849c9336bf3d99ec2767", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "27c6bd41f6146f5bfb690598e3c845603d9ada3b8ff468e8a4b4a9664b29c569", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9ebd232f9e707ed0022a5367a519570f6df22b8e50eebc0a6874a5e4ab0ef3f2", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d0af485f0930a91806916ee1ff815e0edf97aa4f9fda8bc6704e83dcfe00a0b4", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "da3b58e9113265ce41206181ccd7f76d1c333f702138c242e1255f6f04c4bd30", 4), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "7e026ee12f2f738242676d039222c887f6866818828567ec4a9a39ebf0e6e9a0", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "8d9c6d9be6bac379cbb05fa2fcaa37a364e3e2bd3186d5ca45f699656a0f3fbe", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "fbc24b8568e222e732e8a3573848b56a508880f4c27c67135ce9a5b814732e58", 8), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "66421a7d021930ac6ca4aa0b237736a7367a0ac5a86b62a7d1edc7a624786d2f", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "bbd247c762ecf4da6d010278afe1416efbc966af7a0d84a398d18fdd81defeb4", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "c648456de8b63927111afec155757962ee13dc569b1b441e2cd49766f27a0a11", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "f5cc0ffc8f39e6f654bf0de0c9e9d163fc49b0b57f3fc654d989bbfd99b34e09", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d63e2e43e12fbb7d9478670e31ee66b3a4952d20e970b93cc1e3a534b7146b5d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "a8cabbf23f3262679728c4de3774be1ee81b730fd4736b4b9c652841729b0fce", 4), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "7952236e62d381ea8f929e002d3195c202832be7017d9de69de262b03f5a97c5", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "8413920ef9835a24d2bb12c0e2d4354b432c863ad9a9a08ff5dd2762524e8f88", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "cd3dfdbd6eb1ea4dcaa1523ac50511ed8ed085595669fa9bfebe5706c95b9560", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "717010ccb3c7e2ca8114609c5a580901a1bfcaf63d56932f0f4417eacf6d6cdc", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "662368f336ecbb37758b886f431720219c3134ab00a9a4a3a3e400d8375923ba", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "5ab35e2e591de678b10df0d5ea5b64fde69351a35e0acc3597579c1966b091cc", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "7c3e156ac8abd2ba40a6123c5ca0cd06619a7bfcd19b58623a71dfde204c2eab", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "cd30ca40690d047446538a9da5336ac59b210739f99d0b3cd197f0a06cc709ea", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "ea05d48e2166cebc99b07769ee593396554f6e7fa8e82edef653d35b8e1c63c8", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "a4ac7e4a0320aae3545e73edc40871c8a103f27e93090553fd81b3d836c0f7d1", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "34e0f4b1762e258abaefe6a56d7060d6070e7ac8d229256e3890772b988c318d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "872a896cae8669f0578f48ae5a8876923c957f35df3a5a96a4e3372498670105", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "e53023539c1be3112baba7a5ae55d5feebdd93f7131170d09346c09a46f45fc4", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "91e640201d2762b8ddd6dac653a87267c52ef2341809fa4f7b5340323a115aee", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9a390760c8f4ed07eaf8ac75ccededd6d17784951c41579bec1a13492b300a6d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "b2218023c6c9e6c41e017dfe63975acf95dd739a3a3ead13e58e6e9ab6bad28e", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "f9fb2f91935120241c59efb8c1d0d0f2994753520defbbde3e4c623c1d8f75d3", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "183c428655c9988cdf54613265ccbf8e0e082ae4534ce5f352e5fa9500974993", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "53484bf1dba5cd4d14512129af2c8088a2700e2d2c73431f121cb5971170b5db", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "b7674978eda56ee91f5003ae6ffbcda169cb016913c99562b32bc6ef91753998", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "21db9e7e6e2b72a972ad4a7e511ca7d3bce5f6bc043dbb05b8c03f8b4a97df37", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "c338e6dd38b40fe144c25a5c6d14c44f40611d3569e874beda608dc01ae658dd", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "b9638873605d5f4a8a1e5eea4a87ece8e6525c51816ca70d8dd8f650f359c19b", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "20875c96439f6248ed393da0b67cc62ef4bd463a0c42ced465e3c51caceee060", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "5be3badc9048ffc367fc8ca485a5523b0741f8748229ad560f31f6a1f1f9705e", 1), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "ed14fd5e700619b7a64413a61cbccba4861dfe30688a7cdedb322f7e562a37ef", 1), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "4ddfffea5375a08774981c0e5fec8ffab4cc4912c0d1dc5470efb35b1f0c1be6", 1), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "ab2a5bad51b793715304ffa208ca9127d20a1f1fe7892c58cdbb6c8f2b6fc5e2", 0), 1);
+
+    // add outputs
+    u_assert_int_eq(add_output(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "97687.14577424"), 1);
+
+    // bug: finalize_transaction returns NULL instead of the hex-encoded transaction
+    raw_hexadecimal_transaction = finalize_transaction(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "0.08679272", "97687.23256696", "DMVMYSajAj7qQ7L6D81KiGxTMx8mrB9cgc");
+    u_assert_not_null(raw_hexadecimal_transaction);
+    u_assert_str_not_eq(raw_hexadecimal_transaction, "");
+
 }

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -534,7 +534,7 @@ void test_transaction()
     // add outputs
     u_assert_int_eq(add_output(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "97687.14577424"), 1);
 
-    // bug: finalize_transaction returns NULL instead of the hex-encoded transaction
+    // finalize the transaction and verify its not null or empty
     raw_hexadecimal_transaction = finalize_transaction(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "0.08679272", "97687.23256696", "DMVMYSajAj7qQ7L6D81KiGxTMx8mrB9cgc");
     u_assert_not_null(raw_hexadecimal_transaction);
     u_assert_str_not_eq(raw_hexadecimal_transaction, "");


### PR DESCRIPTION
Core sets max tx weight to 400 000 and uses a witness scale factor of 4:
`static const unsigned int MAX_STANDARD_TX_WEIGHT = 400000;`
`static const int  WITNESS_SCALE_FACTOR = 4;`

This updates the buffer length to match:
400 000 ÷ 4 = 100 000 bytes → 100 000 × 2 = 200 000 hex chars, plus one for `\0`:
```c
/* 100 000-byte standard-tx → 200 000 hex chars + NUL */
#define TO_UINT8_HEX_BUF_LEN 200001
```
The performance impact is negligible. In future we’ll look into dynamic allocation for these buffers.
