### PR TITLE
transaction: added external buffer functions

### DIFF
--- a/doc/transaction.md
+++ b/doc/transaction.md
@@ -268,6 +268,8 @@ int main() {
 
 This function takes in an index denoting which of the current transaction's inputs to sign (inputindex), the raw hexadecimal representation of the transaction to sign (incomingrawtx), the pubkey script in hexadecimal format (scripthex), the signature hash type (sighashtype) and the WIF-encoded private key used to sign the input (privkey). Signature hash type in normal use cases is set to 1 to denote that anyone can pay. In C, the function returns a boolean denoting success, but the actual signed transaction hex is passed back through incomingrawtx. **Important:** `sign_raw_transaction` must be run within a secp256k1 context, which can be created by calling `dogecoin_ecc_start()` and `dogecoin_ecc_stop()` as shown below.
 
+**Note:** The `incomingrawtx` buffer **must** be the buffer returned by `get_raw_transaction()`, otherwise the signed hex may overflow.
+
 _C usage:_
 
 ```C

--- a/doc/transaction.md
+++ b/doc/transaction.md
@@ -16,8 +16,10 @@
     - [**add_output**](#add_output)
     - [**finalize_transaction**](#finalize_transaction)
     - [**get_raw_transaction**](#get_raw_transaction)
+    - [**get_raw_transaction_ex**](#get_raw_transaction_ex)
     - [**clear_transaction**](#clear_transaction)
     - [**sign_raw_transaction**](#sign_raw_transaction)
+    - [**sign_raw_transaction_ex**](#sign_raw_transaction_ex)
     - [**sign_transaction**](#sign_transaction)
     - [**store_raw_transaction**](#store_raw_transaction)
 
@@ -241,6 +243,31 @@ int main() {
 
 ---
 
+
+### **get_raw_transaction_ex**
+
+```c
+int get_raw_transaction_ex(int   txindex,
+                           char* buf,
+                           size_t buf_cap);
+```
+
+The `get_raw_transaction_ex` function writes the raw hexadecimal representation of the working transaction at index `txindex` into the caller-supplied buffer `buf` (of total size `buf_cap`). On success it returns the number of characters written (not counting the terminating `'\0'`); if the index is invalid, a pointer is NULL, or the buffer is too small, it returns 0. Unlike `get_raw_transaction()`, this version avoids allocating a new string on the heap, making it ideal when you already manage your own buffer.
+
+*C usage:*
+
+```c
+char buf[TXHEXMAXLEN + 1];
+int len = get_raw_transaction_ex(index, buf, sizeof(buf));
+if (len == 0) {
+    // handle error
+} else {
+    printf("Transaction hex: %s\n", buf);
+}
+```
+
+---
+
 ### **clear_transaction**
 
 `void clear_transaction(int txindex)`
@@ -301,6 +328,41 @@ int main() {
     printf("The final signed transaction hex is: %s\n", rawhex);
     clear_transaction(index);
 }
+```
+
+---
+
+### **sign_raw_transaction_ex**
+
+```c
+int sign_raw_transaction_ex(int           inputindex,
+                            const char*   incomingrawtx,
+                            char*         signedrawtx,
+                            size_t*       signed_size,
+                            const char*   scripthex,
+                            int           sighashtype,
+                            const char*   privkey);
+```
+
+The `sign_raw_transaction_ex` function offers a two-step interface for signing a single input of a raw transaction. In **query mode**, you pass `signedrawtx == NULL`; the function writes the required buffer size (including the null terminator) into `*signed_size` and returns 1. In **write mode**, you allocate at least that many bytes, pass the buffer in `signedrawtx` (with `*signed_size` set to its capacity), and call it again. On success it writes the signed transaction hex (plus `'\0'`) into your buffer and returns 1; on failure it returns 0. This pattern avoids extra heap allocations when you want to supply your own output buffer.
+
+*C usage:*
+
+```c
+// Stage 1: query required size
+size_t need = 0;
+if (!sign_raw_transaction_ex(0, rawhex, NULL, &need, scripthex, 1, wif)) {
+    // error
+}
+
+// Stage 2: allocate and sign
+char *out = malloc(need);
+if (!out) { /* OOM */ }
+if (!sign_raw_transaction_ex(0, rawhex, out, &need, scripthex, 1, wif)) {
+    // error
+}
+printf("Signed transaction: %s\n", out);
+free(out);
 ```
 
 ---

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -397,6 +397,9 @@ int getDerivedHDAddressFromAcctPubKey(const char* ext_pubkey, const uint32_t ind
 ----------------------------------------------------------------
 */
 
+//#define TXHEXMAXLEN 200001 // Maximum length of standard tx based on relay limit (100 000).  Internally this is cited as 200001 for strings that represent it because +stringterm.
+#define TXHEXMAXLEN 200001
+
 /* create a new dogecoin transaction: Returns the (txindex) in memory of the transaction being worked on. */
 int start_transaction();
 

--- a/include/dogecoin/transaction.h
+++ b/include/dogecoin/transaction.h
@@ -1,6 +1,6 @@
 /*
  The MIT License (MIT)
- 
+
  Copyright (c) 2022 bluezr
  Copyright (c) 2022-2024 The Dogecoin Foundation
 
@@ -33,6 +33,10 @@
 #include <dogecoin/tx.h>
 
 LIBDOGECOIN_BEGIN_DECL
+
+// Maximum length of standard tx based on relay limit (100 000).
+// Internally this is cited as 200001 for strings that represent it because +stringterm.
+#define TXHEXMAXLEN 200001
 
 /* hashmap functions */
 typedef struct working_transaction {
@@ -68,7 +72,7 @@ LIBDOGECOIN_API const char *get_raw_tx(const char *prompt_tx);
 
 LIBDOGECOIN_API const char *get_private_key(const char *prompt_key);
 
-LIBDOGECOIN_API int start_transaction(); // #returns  an index of a transaction to build in memory.  (1, 2, etc) ..   
+LIBDOGECOIN_API int start_transaction(); // #returns  an index of a transaction to build in memory.  (1, 2, etc) ..
 
 LIBDOGECOIN_API int save_raw_transaction(int txindex, const char* hexadecimal_transaction);
 

--- a/include/dogecoin/transaction.h
+++ b/include/dogecoin/transaction.h
@@ -101,6 +101,10 @@ LIBDOGECOIN_API int sign_transaction_w_privkey(int txindex, int vout_index, char
 
 LIBDOGECOIN_API int store_raw_transaction(char* incomingrawtx);
 
+LIBDOGECOIN_API int get_raw_transaction_ex(int txindex, char* buf, size_t buf_cap);
+
+LIBDOGECOIN_API int sign_raw_transaction_ex(int inputindex, const char* incomingrawtx, char* signedrawtx, size_t* signed_size, const char* scripthex, int sighashtype, const char* privkey);
+
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_TRANSACTION_H__

--- a/include/dogecoin/utils.h
+++ b/include/dogecoin/utils.h
@@ -39,7 +39,8 @@
 #include <dogecoin/mem.h>
 #include <dogecoin/vector.h>
 
-#define TO_UINT8_HEX_BUF_LEN 2048
+/* 100 000-byte standard-tx → 200 000 hex chars + NUL */
+#define TO_UINT8_HEX_BUF_LEN 200001
 #define VARINT_LEN 20
 #define MAX_LEN 128
 

--- a/include/test/utest.h
+++ b/include/test/utest.h
@@ -313,7 +313,7 @@
             if (!r_) {                                                   \
                 printf("FAILED - %s() - Line %d\n", __func__, __LINE__); \
                 printf("\tExpect: \tnot NULL\n");                        \
-                printf("\tReceive:\tNULL\n", r_);                        \
+                printf("\tReceive:\tNULL\n");                            \
                 U_TESTS_FAIL++;                                          \
                 return;                                                  \
             };                                                           \

--- a/src/openenclave/host/host.c
+++ b/src/openenclave/host/host.c
@@ -590,8 +590,8 @@ int main(int argc, char* argv[])
     else if (strcmp(cmd, "sign_transaction") == 0)
     {
         printf("- Sign a transaction\n");
-        char raw_tx[1024] = {0};
-        char signed_tx[4096] = {0};
+        char raw_tx[TXHEXMAXLEN] = {0};
+        char signed_tx[TXHEXMAXLEN] = {0};
         if (!password && !yubikey && auth_token == 0) {
             password = getpass("Enter management password: ");
             if (!password) {

--- a/src/optee/host/main.c
+++ b/src/optee/host/main.c
@@ -903,8 +903,8 @@ int main(int argc, const char* argv[])
             printf("Message signed: %s\n", signature);
     } else if (strcmp(cmd, "sign_transaction") == 0) {
         printf("- Sign a transaction\n");
-        char raw_tx[1024];
-        char signed_tx[4096];
+        char raw_tx[TXHEXMAXLEN];
+        char signed_tx[TXHEXMAXLEN];
         size_t signed_tx_len = sizeof(signed_tx);
 
         // Example transaction creation process

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -573,7 +573,16 @@ int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, i
 
         char* signed_tx_hex = dogecoin_char_vla(signed_tx->len * 2 + 1);
         utils_bin_to_hex((unsigned char *)signed_tx->str, signed_tx->len, signed_tx_hex);
-        memcpy(incomingrawtx, signed_tx_hex, strlen(signed_tx_hex));
+        size_t signed_len = strlen(signed_tx_hex);
+        if (signed_len >= TO_UINT8_HEX_BUF_LEN) {
+            printf("signed tx too large (max 100 kB)\n");
+            cstr_free(signed_tx, true);
+            dogecoin_tx_free(txtmp);
+            free(signed_tx_hex);
+            return false;
+        }
+        strncpy(incomingrawtx, signed_tx_hex, TO_UINT8_HEX_BUF_LEN - 1);
+        incomingrawtx[TO_UINT8_HEX_BUF_LEN - 1] = '\0';
         debug_print("signed TX: %s\n", incomingrawtx);
         cstr_free(signed_tx, true);
         dogecoin_tx_free(txtmp);

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -243,7 +243,7 @@ int start_transaction() {
  */
 int save_raw_transaction(int txindex, const char* hexadecimal_transaction) {
     debug_print("raw_hexadecimal_transaction: %s\n", hexadecimal_transaction);
-    if (strlen(hexadecimal_transaction) > 1024*100) { //don't accept tx larger then 100kb
+    if (strlen(hexadecimal_transaction) > TXHEXMAXLEN) { //don't accept tx larger then 100kb
         printf("tx too large (max 100kb)\n");
         return false;
     }
@@ -479,7 +479,7 @@ void clear_transaction(int txindex) {
 int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, char* privkey) {
     if(!incomingrawtx || !scripthex) return false;
 
-    if (strlen(incomingrawtx) > 1024*100) { //don't accept tx larger then 100kb
+    if (strlen(incomingrawtx) > TXHEXMAXLEN) { //don't accept tx larger then 100kb
         printf("tx too large (max 100kb)\n");
         return false;
     }
@@ -699,7 +699,7 @@ int sign_transaction_w_privkey(int txindex, int vout_index, char* privkey) {
  * @return The index of the new working transaction if stored successfully, 0 otherwise.
  */
 int store_raw_transaction(char* incomingrawtx) {
-    if (strlen(incomingrawtx) > 1024*100) { //don't accept tx larger then 100kb
+    if (strlen(incomingrawtx) > TXHEXMAXLEN) { //don't accept tx larger then 100kb
         printf("tx too large (max 100kb)\n");
         return false;
     }

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -735,3 +735,182 @@ int store_raw_transaction(char* incomingrawtx) {
     dogecoin_tx_free(txtmp);
     return txindex;
 }
+
+/**
+ * @brief This function takes an index of a working transaction and writes
+ * its hex representation into a caller-provided buffer.
+ *
+ * @param txindex   The index of the working transaction.
+ * @param buf       Buffer to receive the hex string.
+ * @param buf_cap   Capacity of buf in bytes.
+ *
+ * @return Number of bytes written on success, or 0 on error.
+ */
+int get_raw_transaction_ex(int txindex, char* buf, size_t buf_cap) {
+    working_transaction* tx = find_transaction(txindex);
+    if (!tx || !buf || buf_cap == 0) return 0;
+
+    // serialize to cstring
+    cstring* serialized = cstr_new_sz(1024);
+    if (!serialized) return 0;
+    dogecoin_tx_serialize(serialized, tx->transaction);
+
+    // hex-encode into provided buffer
+    size_t hex_len = serialized->len * 2;
+    if (hex_len + 1 > buf_cap) {
+        cstr_free(serialized, true);
+        return 0;
+    }
+    utils_bin_to_hex((unsigned char*)serialized->str, serialized->len, buf);
+    cstr_free(serialized, true);
+    return (int)hex_len;
+}
+
+/**
+ * @brief This function signs the specified input of a working transaction.
+ * It supports a two-step pattern:
+ *   1) Call with signedrawtx==NULL to query needed buffer size in *signed_size.
+ *   2) Allocate signedrawtx to at least *signed_size, then call again to fill it.
+ *
+ * @param inputindex    Index of the input within the transaction to sign.
+ * @param incomingrawtx The raw transaction hex to be signed.
+ * @param signedrawtx   Buffer to receive signed hex, or NULL to query size.
+ * @param signed_size   On entry: capacity of signedrawtx; on exit (query mode): required size (including NUL).
+ * @param scripthex     The pubkey script for this input, in hex.
+ * @param sighashtype   SIGHASH type (e.g. 1 for ALL).
+ * @param privkey       WIF-encoded private key.
+ *
+ * @return 1 on success (or size-report), 0 on error.
+ */
+int sign_raw_transaction_ex(int    inputindex,
+                            const char*  incomingrawtx,
+                            char*  signedrawtx,
+                            size_t* signed_size,
+                            const char*  scripthex,
+                            int    sighashtype,
+                            const char*  privkey)
+{
+    if (!incomingrawtx || !scripthex || !signed_size || !privkey) return 0;
+    if (strlen(incomingrawtx) > TO_UINT8_HEX_BUF_LEN) {
+        printf("tx too large (max 100 KB)\n");
+        return 0;
+    }
+
+    // deserialize incomingrawtx
+    dogecoin_tx* txtmp = dogecoin_tx_new();
+    if (!txtmp) return 0;
+    size_t outlen = 0;
+    uint8_t* data = dogecoin_malloc(strlen(incomingrawtx) / 2);
+    if (!data) {
+        dogecoin_tx_free(txtmp);
+        return 0;
+    }
+    utils_hex_to_bin(incomingrawtx, data, strlen(incomingrawtx), &outlen);
+    if (outlen == 0 || !dogecoin_tx_deserialize(data, outlen, txtmp, NULL)) {
+        dogecoin_free(data);
+        dogecoin_tx_free(txtmp);
+        printf("invalid tx hex\n");
+        return 0;
+    }
+    dogecoin_free(data);
+
+    // bounds-check input index
+    if ((size_t)inputindex >= txtmp->vin->len) {
+        dogecoin_tx_free(txtmp);
+        printf("input index out of range\n");
+        return 0;
+    }
+
+    // build script cstring
+    size_t script_hex_len = strlen(scripthex) / 2;
+    uint8_t* script_data = dogecoin_malloc(script_hex_len);
+    if (!script_data) {
+        dogecoin_tx_free(txtmp);
+        return 0;
+    }
+    utils_hex_to_bin(scripthex, script_data, strlen(scripthex), &outlen);
+    if (outlen == 0) {
+        dogecoin_free(script_data);
+        dogecoin_tx_free(txtmp);
+        return 0;
+    }
+    cstring* script = cstr_new_buf(script_data, outlen);
+    dogecoin_free(script_data);
+    if (!script) {
+        dogecoin_tx_free(txtmp);
+        return 0;
+    }
+
+    // compute sighash
+    uint256_t sighash;
+    dogecoin_mem_zero(sighash, sizeof(sighash));
+    dogecoin_tx_sighash(txtmp, script, inputindex, sighashtype, sighash);
+
+    // decode private key
+    const dogecoin_chainparams* chain = (privkey[0] == 'c')
+        ? &dogecoin_chainparams_test
+        : &dogecoin_chainparams_main;
+    dogecoin_key key;
+    dogecoin_privkey_init(&key);
+    if (!dogecoin_privkey_decode_wif(privkey, chain, &key)) {
+        cstr_free(script, true);
+        dogecoin_tx_free(txtmp);
+        return 0;
+    }
+
+    // sign
+    uint8_t sigcompact[64] = {0};
+    size_t sigderlen = 75;
+    uint8_t sigder_plus_hashtype[75];
+    enum dogecoin_tx_sign_result res = dogecoin_tx_sign_input(
+        txtmp, script, &key,
+        inputindex, sighashtype,
+        sigcompact, sigder_plus_hashtype, &sigderlen
+    );
+    cstr_free(script, true);
+    if (res != DOGECOIN_SIGN_OK) {
+        dogecoin_tx_free(txtmp);
+        return 0;
+    }
+
+    // serialize signed tx
+    cstring* signed_tx = cstr_new_sz(1024);
+    if (!signed_tx) {
+        dogecoin_tx_free(txtmp);
+        return 0;
+    }
+    dogecoin_tx_serialize(signed_tx, txtmp);
+    dogecoin_tx_free(txtmp);
+
+    // hex‐encode output
+    size_t hexout_len = signed_tx->len * 2 + 1;
+    char* hexout = dogecoin_malloc(hexout_len);
+    if (!hexout) {
+        cstr_free(signed_tx, true);
+        return 0;
+    }
+    utils_bin_to_hex((unsigned char*)signed_tx->str, signed_tx->len, hexout);
+    cstr_free(signed_tx, true);
+
+    // determine buffer need
+    size_t need = strlen(hexout) + 1;
+
+    // step 1: query mode
+    if (!signedrawtx) {
+        *signed_size = need;
+        dogecoin_free(hexout);
+        return 1;
+    }
+
+    // step 2: write mode
+    if (*signed_size < need) {
+        printf("signed buffer too small (need %zu bytes)\n", need);
+        dogecoin_free(hexout);
+        return 0;
+    }
+    memcpy(signedrawtx, hexout, need - 1);
+    signedrawtx[need - 1] = '\0';
+    dogecoin_free(hexout);
+
+    return 1;
+}

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -466,4 +466,77 @@ void test_transaction()
     // Call isMainnetFromB58Prefix
     u_assert_true(isMainnetFromB58Prefix("D6vSSr6ftnicfpSNARqezdehAL5Abe2LQw"));
 
+    // ----------------------------------------------------------------
+    // test a large transaction that caused problems in finalize_transaction
+
+    working_transaction_index = start_transaction();
+
+    // add inputs
+    u_assert_int_eq(add_utxo(working_transaction_index, "00df9507524acbf5ccc1c00d152216c984192f1fc6edad81406b4371a7d91038", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "5d08f2928cefd155e377fe40a521cf66317bcde0a24c0d9094090306196dbbf8", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9b9f872cbebff7d2242cbbde8d0fe7ca108be55bdde4a7e6905001f51bce2fc6", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "c9ef9105f0af21bef3df7affb68a8ccbf140b57bb3d880feafa98ff4a5ce7681", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9e31e81fcb20f493affd2e3d4ec6cc7438021253b6e8869407479ed1b999ead3", 2), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "78314092f843b6b78347c87c7d43c1591586d56bfe6de800a10ed6ac600d330d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "78cf3fc573cdd7b2226717ec697d5f9e813479194ba18aaf5ae715aa8a8d4427", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "a1cba23b31985476f25514b6593efd0fd0c625ceab071e90c3815521af385d4d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "62fea417be4c37db98c220fe96f4753518d0422e6c6727d66162648c9c169bbd", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d395def4e5590af657be7abc71549492e5d4f3679a60c758c20bf44c7daa5a51", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "55ea0e1b6612ae80e1b3f197dcf109e17d04bd9cd9853d4e826eac5cdd71b43a", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9c58ce226db9e0595d49e1c1673d93a01f40afe92f6d588bc74b4a17decfe253", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "53a0bd6ea2d02d40323b6e1ea11357367a0d4632b2f8404632330e8c89c3ded6", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d25dfc12e402124e7fe69488c9b330c6034ec7913d540b70c0539282d5000732", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "649b00be10ab02d6e884bb32946b682b03d2ed24d8c73a21a902d2c9f6731176", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "698f5b6e17a0c98266142276cfaf26776681275c9f7496a551ecfdb5dfad1960", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "15ffbba4111326cd0648c93c1b611d96a629e712e1ad849c9336bf3d99ec2767", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "27c6bd41f6146f5bfb690598e3c845603d9ada3b8ff468e8a4b4a9664b29c569", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9ebd232f9e707ed0022a5367a519570f6df22b8e50eebc0a6874a5e4ab0ef3f2", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d0af485f0930a91806916ee1ff815e0edf97aa4f9fda8bc6704e83dcfe00a0b4", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "da3b58e9113265ce41206181ccd7f76d1c333f702138c242e1255f6f04c4bd30", 4), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "7e026ee12f2f738242676d039222c887f6866818828567ec4a9a39ebf0e6e9a0", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "8d9c6d9be6bac379cbb05fa2fcaa37a364e3e2bd3186d5ca45f699656a0f3fbe", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "fbc24b8568e222e732e8a3573848b56a508880f4c27c67135ce9a5b814732e58", 8), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "66421a7d021930ac6ca4aa0b237736a7367a0ac5a86b62a7d1edc7a624786d2f", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "bbd247c762ecf4da6d010278afe1416efbc966af7a0d84a398d18fdd81defeb4", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "c648456de8b63927111afec155757962ee13dc569b1b441e2cd49766f27a0a11", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "f5cc0ffc8f39e6f654bf0de0c9e9d163fc49b0b57f3fc654d989bbfd99b34e09", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d63e2e43e12fbb7d9478670e31ee66b3a4952d20e970b93cc1e3a534b7146b5d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "a8cabbf23f3262679728c4de3774be1ee81b730fd4736b4b9c652841729b0fce", 4), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "7952236e62d381ea8f929e002d3195c202832be7017d9de69de262b03f5a97c5", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "8413920ef9835a24d2bb12c0e2d4354b432c863ad9a9a08ff5dd2762524e8f88", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "cd3dfdbd6eb1ea4dcaa1523ac50511ed8ed085595669fa9bfebe5706c95b9560", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "717010ccb3c7e2ca8114609c5a580901a1bfcaf63d56932f0f4417eacf6d6cdc", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "662368f336ecbb37758b886f431720219c3134ab00a9a4a3a3e400d8375923ba", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "5ab35e2e591de678b10df0d5ea5b64fde69351a35e0acc3597579c1966b091cc", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "7c3e156ac8abd2ba40a6123c5ca0cd06619a7bfcd19b58623a71dfde204c2eab", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "cd30ca40690d047446538a9da5336ac59b210739f99d0b3cd197f0a06cc709ea", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "ea05d48e2166cebc99b07769ee593396554f6e7fa8e82edef653d35b8e1c63c8", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "a4ac7e4a0320aae3545e73edc40871c8a103f27e93090553fd81b3d836c0f7d1", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "34e0f4b1762e258abaefe6a56d7060d6070e7ac8d229256e3890772b988c318d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "872a896cae8669f0578f48ae5a8876923c957f35df3a5a96a4e3372498670105", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "e53023539c1be3112baba7a5ae55d5feebdd93f7131170d09346c09a46f45fc4", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "91e640201d2762b8ddd6dac653a87267c52ef2341809fa4f7b5340323a115aee", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9a390760c8f4ed07eaf8ac75ccededd6d17784951c41579bec1a13492b300a6d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "b2218023c6c9e6c41e017dfe63975acf95dd739a3a3ead13e58e6e9ab6bad28e", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "f9fb2f91935120241c59efb8c1d0d0f2994753520defbbde3e4c623c1d8f75d3", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "183c428655c9988cdf54613265ccbf8e0e082ae4534ce5f352e5fa9500974993", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "53484bf1dba5cd4d14512129af2c8088a2700e2d2c73431f121cb5971170b5db", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "b7674978eda56ee91f5003ae6ffbcda169cb016913c99562b32bc6ef91753998", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "21db9e7e6e2b72a972ad4a7e511ca7d3bce5f6bc043dbb05b8c03f8b4a97df37", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "c338e6dd38b40fe144c25a5c6d14c44f40611d3569e874beda608dc01ae658dd", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "b9638873605d5f4a8a1e5eea4a87ece8e6525c51816ca70d8dd8f650f359c19b", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "20875c96439f6248ed393da0b67cc62ef4bd463a0c42ced465e3c51caceee060", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "5be3badc9048ffc367fc8ca485a5523b0741f8748229ad560f31f6a1f1f9705e", 1), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "ed14fd5e700619b7a64413a61cbccba4861dfe30688a7cdedb322f7e562a37ef", 1), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "4ddfffea5375a08774981c0e5fec8ffab4cc4912c0d1dc5470efb35b1f0c1be6", 1), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "ab2a5bad51b793715304ffa208ca9127d20a1f1fe7892c58cdbb6c8f2b6fc5e2", 0), 1);
+
+    // add outputs
+    u_assert_int_eq(add_output(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "97687.14577424"), 1);
+
+    // bug: finalize_transaction returns NULL instead of the hex-encoded transaction
+    raw_hexadecimal_transaction = finalize_transaction(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "0.08679272", "97687.23256696", "DMVMYSajAj7qQ7L6D81KiGxTMx8mrB9cgc");
+    u_assert_not_null(raw_hexadecimal_transaction);
+    u_assert_str_not_eq(raw_hexadecimal_transaction, "");
+
 }

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -534,7 +534,7 @@ void test_transaction()
     // add outputs
     u_assert_int_eq(add_output(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "97687.14577424"), 1);
 
-    // bug: finalize_transaction returns NULL instead of the hex-encoded transaction
+    // finalize the transaction and verify its not null or empty
     raw_hexadecimal_transaction = finalize_transaction(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "0.08679272", "97687.23256696", "DMVMYSajAj7qQ7L6D81KiGxTMx8mrB9cgc");
     u_assert_not_null(raw_hexadecimal_transaction);
     u_assert_str_not_eq(raw_hexadecimal_transaction, "");

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -427,6 +427,29 @@ void test_transaction()
     // transaction with both inputs signed:
     u_assert_str_eq(raw_hexadecimal_transaction, expected_signed_raw_hexadecimal_transaction);
 
+    // test get_raw_transaction_ex with the working transaction index
+    char* buf = malloc(TXHEXMAXLEN + 1);
+    u_assert_not_null(buf);
+    int len = get_raw_transaction_ex(working_transaction_index, buf, TXHEXMAXLEN + 1);
+    u_assert_true(len > 0);
+    u_assert_str_eq(buf, get_raw_transaction(working_transaction_index));
+    dogecoin_free(buf);
+
+    // test sign_raw_transaction_ex (two-step) on the unsigned two-input TX
+    size_t needed = 0;
+
+    // query required size
+    u_assert_int_eq(sign_raw_transaction_ex(0, unsigned_hexadecimal_transaction, NULL, &needed, utxo_scriptpubkey, 1, private_key_wif), 1);
+
+    // allocate and sign
+    char* out = malloc(needed);
+    u_assert_not_null(out);
+    u_assert_int_eq(sign_raw_transaction_ex(0, unsigned_hexadecimal_transaction, out, &needed, utxo_scriptpubkey, 1, private_key_wif), 1);
+
+    // must match the expected single-input signed TX
+    u_assert_str_eq(out, expected_single_input_signed_transaction);
+    dogecoin_free(out);
+
     // ----------------------------------------------------------------
     // test conversion from p2pkh to script hash and back
 
@@ -539,4 +562,18 @@ void test_transaction()
     u_assert_not_null(raw_hexadecimal_transaction);
     u_assert_str_not_eq(raw_hexadecimal_transaction, "");
 
+    // test get_raw_transaction_ex on the large transaction
+    char buf2[TXHEXMAXLEN + 1];
+    int len2 = get_raw_transaction_ex(working_transaction_index, buf2, sizeof(buf2));
+    u_assert_true(len2 > 0);
+    u_assert_str_eq(buf2, get_raw_transaction(working_transaction_index));
+
+    // test sign_raw_transaction_ex on input 0 of the large transaction
+    size_t need2 = 0;
+    u_assert_int_eq(sign_raw_transaction_ex(0, raw_hexadecimal_transaction, NULL, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
+    char* out2 = malloc(need2);
+    u_assert_not_null(out2);
+    u_assert_int_eq(sign_raw_transaction_ex(0, raw_hexadecimal_transaction, out2, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
+    u_assert_true(strlen(out2) > 0);
+    dogecoin_free(out2);
 }


### PR DESCRIPTION
Add `get_raw_transaction_ex` and `sign_raw_transaction_ex`, update docs and tests (including large-tx case).