### PR TITLE
transaction: added wrappers

### DIFF
--- a/doc/transaction.md
+++ b/doc/transaction.md
@@ -15,6 +15,7 @@
     - [**add_utxo**](#add_utxo)
     - [**add_output**](#add_output)
     - [**finalize_transaction**](#finalize_transaction)
+    - [**finalize_transaction_ex**](#finalize_transaction_ex)
     - [**get_raw_transaction**](#get_raw_transaction)
     - [**get_raw_transaction_ex**](#get_raw_transaction_ex)
     - [**clear_transaction**](#clear_transaction)
@@ -216,6 +217,38 @@ int main() {
     char* rawhex = finalize_transaction(index, external_address, "0.00226", "12.0", my_address);
     printf("Finalized transaction hex is %s.", rawhex);
     clear_transaction(index);
+}
+```
+
+---
+
+### **finalize_transaction_ex**
+
+```c
+int finalize_transaction_ex(int txindex, const char* destinationaddress, const char* subtractedfee, const char* total_in_doge, const char* changeaddress, char* out_hex, size_t out_cap);
+```
+
+`finalize_transaction_ex` one-shots the *“close & return change”* step while **avoiding a heap allocation**: it finalizes the working transaction at `txindex`, figures out fees / change exactly as `finalize_transaction()` does, hex-serialises the result straight into the caller-supplied buffer `out_hex` (whose capacity in bytes is `out_cap`), then returns the number of characters written (not counting the terminating `'\0'`).
+If any argument is invalid or the buffer is too small the function returns 0.
+
+*C usage:*
+
+```c
+// build the TX (add_utxo / add_output)
+
+char txhex[TXHEXMAXLEN + 1];          // +1 for the NUL
+int n = finalize_transaction_ex(idx,
+                                "nbGfXLskPh7eM1iG5zz5EfDkkNTo9TRmde", // destination
+                                "0.00226",                            // fee
+                                "12.0",                               // total inputs
+                                "noxKJyGPugPRN4wqvrwsrtYXuQCk7yQEsy", // change back here
+                                txhex,
+                                sizeof(txhex));
+
+if (n == 0) {
+    // handle error
+} else {
+    printf("Finalised TX (%d chars):\n%s\n", n, txhex);
 }
 ```
 

--- a/doc/transaction.md
+++ b/doc/transaction.md
@@ -23,6 +23,9 @@
     - [**sign_raw_transaction_ex**](#sign_raw_transaction_ex)
     - [**sign_transaction**](#sign_transaction)
     - [**store_raw_transaction**](#store_raw_transaction)
+    - [**sign_indexed_raw_transaction_ex**](#sign_indexed_raw_transaction_ex)
+    - [**sign_transaction_ex**](#sign_transaction_ex)
+    - [**sign_transaction_w_privkey_ex**](#sign_transaction_w_privkey_ex)
 
 ## Introduction
 
@@ -458,5 +461,74 @@ int main() {
     int index = store_raw_transaction(hex_to_store);
     printf("The transaction hex at index %d is %s.\n", index, get_raw_transaction(index));
     clear_transaction(index);
+}
+```
+
+---
+
+### **sign_indexed_raw_transaction_ex**
+
+```c
+int sign_indexed_raw_transaction_ex(int txindex,
+                                    int inputindex,
+                                    const char* scripthex,
+                                    int sighashtype,
+                                    const char* privkey,
+                                    char* buf,
+                                    size_t buf_cap);
+```
+
+Signs **one** specific input (`inputindex`) of the working transaction stored at `txindex`, writes the fully-updated raw-hex straight into the caller-supplied buffer `buf` (capacity `buf_cap`) and returns the number of hex characters written (not counting the terminating `'\0'`).
+If the buffer is too small or any argument is invalid the function returns 0.
+
+```c
+char signedhex[TXHEXMAXLEN + 1];
+int n = sign_indexed_raw_transaction_ex(idx,        /* tx we're editing   */
+                                        0,          /* which vin to sign  */
+                                        scripthex,  /* utxo's scriptPubKey*/
+                                        1,          /* SIGHASH_ALL        */
+                                        wif,        /* signing key        */
+                                        signedhex,
+                                        sizeof signedhex);
+if (n == 0) { /* error */ }
+```
+
+### **sign_transaction_ex**
+
+```c
+int sign_transaction_ex(int txindex,
+                         const char* script_pubkey,
+                         const char* privkey,
+                         char* buf,
+                         size_t buf_cap);
+```
+
+High-level helper that iterates over **all** inputs of the working transaction at `txindex`, signing each one with the same `script_pubkey` / `privkey` pair, then emits the completely-signed transaction hex into `buf`.
+Return-value semantics are identical to the previous function.
+
+```c
+char finalhex[TXHEXMAXLEN + 1];
+if (!sign_transaction_ex(idx, scripthex, wif, finalhex, sizeof finalhex)) {
+    /* signing failed */
+}
+printf("fully-signed tx:\n%s\n", finalhex);
+```
+
+### **sign_transaction_w_privkey_ex**
+
+```c
+int sign_transaction_w_privkey_ex(int txindex,
+                                  const char* privkey,
+                                  char* buf,
+                                  size_t buf_cap);
+```
+
+Single-key convenience wrapper: derives the P2PKH `scriptPubKey` from `privkey`, signs **every** input of the transaction at `txindex`, and streams the result into `buf`.
+Ideal for the common *all inputs belong to the same wallet* scenario.
+
+```c
+char txhex[TXHEXMAXLEN + 1];
+if (!sign_transaction_w_privkey_ex(idx, wif, txhex, sizeof txhex)) {
+    /* error */
 }
 ```

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -431,6 +431,15 @@ char* get_raw_transaction(int txindex);
 /* clear the transaction at (txindex) in memory */
 void clear_transaction(int txindex);
 
+/* retrieve the raw transaction at (txindex) as a hex string (char*) in a buffer (buf) of size (buf_cap) */
+int get_raw_transaction_ex(int txindex, char* buf, size_t buf_cap);
+
+/* sign a raw transaction in memory at (txindex), sign (inputindex) with (scripthex) of (sighashtype), with (privkey) in a buffer (signedrawtx) of size (signed_size) */
+int sign_raw_transaction_ex(int inputindex, const char* incomingrawtx, char* signedrawtx, size_t* signed_size, const char* scripthex, int sighashtype, const char* privkey);
+
+/* finalize the transaction being worked on at (txindex), with the (destinationaddress) paying a fee of (subtractedfee) in a buffer (buf) of size (buf_cap) */
+int finalize_transaction_ex(int txindex, char* destinationaddress, char* subtractedfee, char* out_dogeamount_for_verification, char* changeaddress, char* buf, size_t buf_cap);
+
 /* QR Code Generation Functions
 ---------------------------------
 */

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -440,6 +440,15 @@ int sign_raw_transaction_ex(int inputindex, const char* incomingrawtx, char* sig
 /* finalize the transaction being worked on at (txindex), with the (destinationaddress) paying a fee of (subtractedfee) in a buffer (buf) of size (buf_cap) */
 int finalize_transaction_ex(int txindex, char* destinationaddress, char* subtractedfee, char* out_dogeamount_for_verification, char* changeaddress, char* buf, size_t buf_cap);
 
+/* sign and store one vin of the working tx at (txindex); writes signed hex into (buf) with capacity (buf_cap) */
+int sign_indexed_raw_transaction_ex(int txindex, int inputindex, const char* scripthex, int sighashtype, const char* privkey, char* buf, size_t buf_cap);
+
+/* sign all inputs of the working tx at (txindex) with (script_pubkey)/(privkey); writes signed hex into (buf) with capacity (buf_cap) */
+int sign_transaction_ex(int txindex, const char* script_pubkey, const char* privkey, char* buf, size_t buf_cap);
+
+/* convenience wrapper: sign a single-key p2pkh tx at (txindex) using (privkey); writes signed hex into (buf) with capacity (buf_cap) */
+int sign_transaction_w_privkey_ex(int txindex, const char* privkey, char* buf, size_t buf_cap);
+
 /* QR Code Generation Functions
 ---------------------------------
 */

--- a/include/dogecoin/transaction.h
+++ b/include/dogecoin/transaction.h
@@ -105,6 +105,8 @@ LIBDOGECOIN_API int get_raw_transaction_ex(int txindex, char* buf, size_t buf_ca
 
 LIBDOGECOIN_API int sign_raw_transaction_ex(int inputindex, const char* incomingrawtx, char* signedrawtx, size_t* signed_size, const char* scripthex, int sighashtype, const char* privkey);
 
+LIBDOGECOIN_API int finalize_transaction_ex(int txindex, char* destinationaddress, char* subtractedfee, char* out_dogeamount_for_verification, char* changeaddress, char* buf, size_t buf_cap);
+
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_TRANSACTION_H__

--- a/include/dogecoin/transaction.h
+++ b/include/dogecoin/transaction.h
@@ -107,6 +107,12 @@ LIBDOGECOIN_API int sign_raw_transaction_ex(int inputindex, const char* incoming
 
 LIBDOGECOIN_API int finalize_transaction_ex(int txindex, char* destinationaddress, char* subtractedfee, char* out_dogeamount_for_verification, char* changeaddress, char* buf, size_t buf_cap);
 
+LIBDOGECOIN_API int sign_indexed_raw_transaction_ex(int txindex, int inputindex, const char* scripthex, int sighashtype, const char* privkey, char* buf, size_t buf_cap);
+
+LIBDOGECOIN_API int sign_transaction_ex(int txindex, const char* script_pubkey, const char* privkey, char* buf, size_t buf_cap);
+
+LIBDOGECOIN_API int sign_transaction_w_privkey_ex(int txindex, const char* privkey, char* buf, size_t buf_cap);
+
 LIBDOGECOIN_END_DECL
 
 #endif // __LIBDOGECOIN_TRANSACTION_H__

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -977,3 +977,105 @@ int finalize_transaction_ex(int   txindex,
     // stream final hex into caller buffer
     return get_raw_transaction_ex(txindex, buf, buf_cap);
 }
+
+/**
+ * @brief This function signs a single vin (`inputindex`) of the working
+ * transaction at `txindex` without allocating heap memory for the hex.
+ * It:
+ *   1. Serialises the transaction into `buf`,
+ *   2. Calls `sign_raw_transaction_ex()` **in-place** on that buffer,
+ *   3. Persists the signed hex back to the hash-table slot.
+ *
+ * @param txindex     The index of the working transaction in memory.
+ * @param inputindex  The vin to sign.
+ * @param scripthex   The script PubKey (hex) that locks the referenced UTXO.
+ * @param sighashtype Signature hash type (e.g. 1 = SIGHASH_ALL).
+ * @param privkey     WIF-encoded private key to sign with.
+ * @param buf         Caller-supplied output buffer for the hex.
+ * @param buf_cap     Capacity of `buf` in bytes.
+ *
+ * @return 1 on success, 0 on error.
+ */
+int sign_indexed_raw_transaction_ex(int  txindex,
+                                    int  inputindex,
+                                    const char* scripthex,
+                                    int  sighashtype,
+                                    const char* privkey,
+                                    char* buf,
+                                    size_t buf_cap)
+{
+    if (!buf || buf_cap == 0) return 0;
+    if (!get_raw_transaction_ex(txindex, buf, buf_cap))                 /* (1) */
+        return 0;
+
+    size_t cap = buf_cap;
+    if (!sign_raw_transaction_ex(inputindex, buf, buf, &cap,            /* (2) */
+                                 scripthex, sighashtype, privkey))
+        return 0;
+
+    return save_raw_transaction(txindex, buf);                          /* (3) */
+}
+
+
+/**
+ * @brief Signs **all** inputs of the working transaction at `txindex`
+ * into the caller-provided buffer `buf`. No heap strings are created.
+ *
+ * @param txindex        Index of the working transaction.
+ * @param script_pubkey  The common script PubKey for all inputs (hex).
+ * @param privkey        WIF private key.
+ * @param buf            Output buffer receiving the final signed hex.
+ * @param buf_cap        Capacity of `buf` in bytes.
+ *
+ * @return 1 if the transaction was fully signed & stored, 0 otherwise.
+ */
+int sign_transaction_ex(int  txindex,
+                        const char* script_pubkey,
+                        const char* privkey,
+                        char* buf,
+                        size_t buf_cap)
+{
+    if (!buf || buf_cap == 0 || !script_pubkey || !privkey) return 0;
+
+    working_transaction* tx = find_transaction(txindex);
+    if (!tx) return 0;
+    size_t vin_cnt = tx->transaction->vin->len;
+
+    if (!get_raw_transaction_ex(txindex, buf, buf_cap))                 /* initial */
+        return 0;
+
+    for (size_t i = 0; i < vin_cnt; ++i) {
+        size_t cap = buf_cap;
+        if (!sign_raw_transaction_ex((int)i, buf, buf, &cap,
+                                     script_pubkey, 1, privkey))
+            return 0;
+    }
+    return save_raw_transaction(txindex, buf);
+}
+
+
+/**
+ * @brief Convenience wrapper around `sign_transaction_ex()` that derives
+ * the P2PKH script PubKey from the supplied WIF key.
+ *
+ * @param txindex  Index of the working transaction.
+ * @param privkey  WIF-encoded private key (used for both script derivation
+ *                 and signing).
+ * @param buf      Output buffer for the fully-signed hex.
+ * @param buf_cap  Capacity of `buf` in bytes.
+ *
+ * @return 1 on success, 0 on error.
+ */
+int sign_transaction_w_privkey_ex(int  txindex,
+                                  const char* privkey,
+                                  char* buf,
+                                  size_t buf_cap)
+{
+    if (!privkey) return 0;
+    char* script_pubkey = dogecoin_private_key_wif_to_pubkey_hash((char*)privkey);
+    if (!script_pubkey) return 0;
+
+    int ok = sign_transaction_ex(txindex, script_pubkey, privkey, buf, buf_cap);
+    dogecoin_free(script_pubkey);
+    return ok;
+}

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -27,6 +27,7 @@
 
 #include <assert.h>
 
+#include <dogecoin/dogecoin.h>
 #include <dogecoin/base58.h>
 #include <dogecoin/koinu.h>
 #include <dogecoin/transaction.h>
@@ -913,4 +914,66 @@ int sign_raw_transaction_ex(int    inputindex,
     dogecoin_free(hexout);
 
     return 1;
+}
+
+/**
+ * @brief  This function 'closes the inputs' by returning change to the recipient
+ * after the total amount and desired fee is confirmed. It uses the same logic as finalize_transaction,
+ * but writes the result into a caller-provided buffer.
+ *
+ * @param txindex The index of the working transaction to finalize.
+ * @param destinationaddress The address where the funds are being sent.
+ * @param subtractedfee The amount to set aside as a fee to the miner.
+ * @param out_dogeamount_for_verification An echo of the total amount to send.
+ * @param changeaddress The address of the sender to receive the change.
+ * @param buf Buffer to receive the hex string.
+ * @param buf_cap Capacity of buf in bytes.
+ *
+ * @return Number of bytes written on success, or 0 on error.
+ */
+int finalize_transaction_ex(int   txindex,
+                            char* destinationaddress,
+                            char* subtractedfee,
+                            char* out_dogeamount_for_verification,
+                            char* changeaddress,
+                            char* buf,
+                            size_t buf_cap)
+{
+    working_transaction* tx = find_transaction(txindex);
+    if (!tx || !buf || buf_cap == 0) return 0;
+
+    // fee / totals
+    int      is_testnet     = chain_from_b58_prefix_bool(destinationaddress);
+    uint64_t fee_koinu      = coins_to_koinu_str(subtractedfee);
+    uint64_t total_in_koinu = coins_to_koinu_str(out_dogeamount_for_verification);
+    uint64_t expected_total = total_in_koinu - fee_koinu;
+    uint64_t tx_out_total   = 0;
+    int      p2pkh_hits     = 0;
+
+    int vout_len = (int)tx->transaction->vout->len;
+    for (int i = 0; i < vout_len; ++i) {
+        dogecoin_tx_out* tout = vector_idx(tx->transaction->vout, i);
+        tx_out_total += tout->value;
+
+        char addr[P2PKHLEN]; dogecoin_mem_zero(addr, sizeof addr);
+        p2pkh_hits += dogecoin_tx_out_pubkey_hash_to_p2pkh_address(
+                          tout, addr, is_testnet);
+
+        // last output: maybe append change
+        if (i == vout_len - 1 && changeaddress) {
+            if (make_change(txindex, changeaddress, fee_koinu,
+                            total_in_koinu - tx_out_total)) {
+                dogecoin_tx_out* ch =
+                    vector_idx(tx->transaction->vout,
+                               tx->transaction->vout->len - 1);
+                tx_out_total += ch->value;
+                ++p2pkh_hits;
+            }
+        }
+    }
+
+    if (p2pkh_hits < 1 || tx_out_total != expected_total) return 0;
+
+    // stream final hex into caller buffer
+    return get_raw_transaction_ex(txindex, buf, buf_cap);
 }

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -562,18 +562,24 @@ void test_transaction()
     u_assert_not_null(raw_hexadecimal_transaction);
     u_assert_str_not_eq(raw_hexadecimal_transaction, "");
 
-    // test get_raw_transaction_ex on the large transaction
+    // test finalize_transaction_ex on the large transaction
+    char txhex_large[TXHEXMAXLEN + 1];
+    u_assert_true(finalize_transaction_ex(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "0.08679272", "97687.23256696", "DMVMYSajAj7qQ7L6D81KiGxTMx8mrB9cgc", txhex_large, sizeof(txhex_large)) > 0);
+    u_assert_str_not_eq(txhex_large, "");
+
+    // get_raw_transaction_ex must produce identical hex
     char buf2[TXHEXMAXLEN + 1];
     int len2 = get_raw_transaction_ex(working_transaction_index, buf2, sizeof(buf2));
     u_assert_true(len2 > 0);
-    u_assert_str_eq(buf2, get_raw_transaction(working_transaction_index));
+    u_assert_str_eq(buf2, txhex_large);
 
     // test sign_raw_transaction_ex on input 0 of the large transaction
     size_t need2 = 0;
-    u_assert_int_eq(sign_raw_transaction_ex(0, raw_hexadecimal_transaction, NULL, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
+    u_assert_int_eq(sign_raw_transaction_ex(0, txhex_large, NULL, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
+
     char* out2 = malloc(need2);
     u_assert_not_null(out2);
-    u_assert_int_eq(sign_raw_transaction_ex(0, raw_hexadecimal_transaction, out2, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
+    u_assert_int_eq(sign_raw_transaction_ex(0, txhex_large, out2, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
     u_assert_true(strlen(out2) > 0);
     dogecoin_free(out2);
 }

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -582,4 +582,20 @@ void test_transaction()
     u_assert_int_eq(sign_raw_transaction_ex(0, txhex_large, out2, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
     u_assert_true(strlen(out2) > 0);
     dogecoin_free(out2);
+
+    // sign just vin-0 and store it
+    char buf3[TXHEXMAXLEN + 1];
+    u_assert_true(sign_indexed_raw_transaction_ex(working_transaction_index, 0, utxo_scriptpubkey, 1, private_key_wif, buf3, sizeof(buf3)));
+    u_assert_str_eq(buf3, get_raw_transaction(working_transaction_index));
+
+    // sign all remaining inputs in one shot
+    char buf4[TXHEXMAXLEN + 1];
+    u_assert_true(sign_transaction_ex(working_transaction_index, utxo_scriptpubkey, private_key_wif, buf4, sizeof(buf4)));
+    u_assert_str_eq(buf4, get_raw_transaction(working_transaction_index));
+
+    // convenience wrapper that does the same with just the priv-key
+    char buf5[TXHEXMAXLEN + 1];
+    u_assert_true(sign_transaction_w_privkey_ex(working_transaction_index, private_key_wif, buf5, sizeof(buf5)));
+    u_assert_str_eq(buf5, get_raw_transaction(working_transaction_index));
+
 }


### PR DESCRIPTION
Add external-buffer signing wrappers (`sign_indexed_raw_transaction_ex`, `sign_transaction_ex`, `sign_transaction_w_privkey_ex`); update docs, headers, and tests.
