### PR TITLE
Regtest support for HD keys

### DIFF
--- a/doc/address.md
+++ b/doc/address.md
@@ -148,6 +148,36 @@ int main() {
 
 ---
 
+### **generateHDMasterPubKeypairChain:**
+
+`int generateHDMasterPubKeypairChain(char* hd_privkey_master, char* p2pkh_pubkey_master, const dogecoin_chainparams *chain)`
+
+This function will populate provided string variables (privkey, pubkey) with freshly generated respective private and public keys for a hierarchical deterministic wallet, specifically for the chain you pass in. The function returns 1 on success and 0 on failure.
+
+_C usage:_
+
+```C
+#include "libdogecoin.h"
+#include <stdio.h>
+
+int main() {
+  int masterPrivkeyLen = HDKEYLEN; // enough cushion
+  int pubkeyLen = P2PKHLEN;
+
+  char masterPrivKey[masterPrivkeyLen];
+  char masterPubKey[pubkeyLen];
+
+  dogecoin_ecc_start();
+  generateHDMasterPubKeypairChain(masterPrivKey, masterPubKey, &dogecoin_chainparams_main);
+  dogecoin_ecc_stop();
+
+  printf("My private key for mainnet is: %s\n", masterPrivKey);
+  printf("My public key for mainnet is: %s\n", masterPubKey);
+}
+```
+
+---
+
 ### **generateDerivedHDPubKey:**
 
 `int generateDerivedHDPubkey(const char* hd_privkey_master, char* p2pkh_pubkey)`

--- a/include/dogecoin/address.h
+++ b/include/dogecoin/address.h
@@ -39,6 +39,9 @@ LIBDOGECOIN_API int generatePrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey
 /* generate HD master key and p2pkh public key */
 LIBDOGECOIN_API int generateHDMasterPubKeypair(char* hd_privkey_master, char* p2pkh_pubkey_master, bool is_testnet);
 
+/* generate HD master key and p2pkh public key */
+LIBDOGECOIN_API int generateHDMasterPubKeypairChain(char* hd_privkey_master, char* p2pkh_pubkey_master, const dogecoin_chainparams* chain);
+
 /* generate an extended public key */
 LIBDOGECOIN_API int generateDerivedHDPubkey(const char* hd_privkey_master, char* p2pkh_pubkey);
 

--- a/src/address.c
+++ b/src/address.c
@@ -115,6 +115,7 @@ int generatePrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testne
     return true;
 }
 
+
 /**
  * @brief This function generates a new master public-private
  * key pair for a hierarchical deterministic wallet on the
@@ -126,7 +127,26 @@ int generatePrivPubKeypair(char* wif_privkey, char* p2pkh_pubkey, bool is_testne
  *
  * @return 1 if the key pair was generated successfully.
  */
-int generateHDMasterPubKeypair(char* hd_privkey_master, char* p2pkh_pubkey_master, bool is_testnet)
+ int generateHDMasterPubKeypair(char* hd_privkey_master, char* p2pkh_pubkey_master, bool is_testnet)
+ {
+    /* determine if mainnet or testnet/regtest */
+    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+
+    return generateHDMasterPubKeypairChain(hd_privkey_master, p2pkh_pubkey_master, chain);
+ }
+
+/**
+ * @brief This function generates a new master public-private
+ * key pair for a hierarchical deterministic wallet on the
+ * specified network.
+ *
+ * @param hd_privkey_master The generated master private key.
+ * @param p2pkh_pubkey_master The generated master public key.
+ * @param chain The chain parameters to use.
+ *
+ * @return 1 if the key pair was generated successfully.
+ */
+int generateHDMasterPubKeypairChain(char* hd_privkey_master, char* p2pkh_pubkey_master, const dogecoin_chainparams* chain)
 {
     char hd_privkey_master_local[HDKEYLEN];
     char hd_pubkey_master[P2PKHLEN];
@@ -138,9 +158,6 @@ int generateHDMasterPubKeypair(char* hd_privkey_master, char* p2pkh_pubkey_maste
     if (p2pkh_pubkey_master) {
         memcpy_safe(hd_pubkey_master, p2pkh_pubkey_master, sizeof(hd_pubkey_master));
     }
-
-    /* determine if mainnet or testnet/regtest */
-    const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
 
     /* generate a new hd master key */
     if (!hd_gen_master(chain, hd_privkey_master_local, sizeof(hd_privkey_master_local))) {

--- a/test/address_tests.c
+++ b/test/address_tests.c
@@ -56,12 +56,16 @@ void test_address()
 
     char* masterkey_main = dogecoin_char_vla(masterkeylen);
     char* masterkey_test=dogecoin_char_vla(masterkeylen);
+    char* masterkey_regtest=dogecoin_char_vla(masterkeylen);
     char* p2pkh_master_pubkey_main=dogecoin_char_vla(pubkeylen);
     char* p2pkh_master_pubkey_test=dogecoin_char_vla(pubkeylen);
+    char* p2pkh_master_pubkey_regtest=dogecoin_char_vla(pubkeylen);
     dogecoin_mem_zero(masterkey_main, masterkeylen);
     dogecoin_mem_zero(masterkey_test, masterkeylen);
+    dogecoin_mem_zero(masterkey_regtest, masterkeylen);
     dogecoin_mem_zero(p2pkh_master_pubkey_main, pubkeylen);
     dogecoin_mem_zero(p2pkh_master_pubkey_test, pubkeylen);
+    dogecoin_mem_zero(p2pkh_master_pubkey_regtest, pubkeylen);
 
     /* test generation ability */
     u_assert_int_eq(generateHDMasterPubKeypair(masterkey_main, NULL, false), true)
@@ -69,11 +73,15 @@ void test_address()
     u_assert_int_eq(generateHDMasterPubKeypair(NULL, NULL, true), true)
     u_assert_int_eq(generateHDMasterPubKeypair(masterkey_main, p2pkh_master_pubkey_main, false), true);
     u_assert_int_eq(generateHDMasterPubKeypair(masterkey_test, p2pkh_master_pubkey_test, true), true);
+    u_assert_int_eq(generateHDMasterPubKeypairChain(masterkey_main, p2pkh_master_pubkey_main, &dogecoin_chainparams_main), true);
+    u_assert_int_eq(generateHDMasterPubKeypairChain(masterkey_test, p2pkh_master_pubkey_test, &dogecoin_chainparams_test), true);
+    u_assert_int_eq(generateHDMasterPubKeypairChain(masterkey_regtest, p2pkh_master_pubkey_regtest, &dogecoin_chainparams_regtest), true);
 
     /* test master keypair basic external validity */
     //TODO: public keys
     u_assert_int_eq(strncmp(masterkey_main,   "dgpv", 4), 0);
     u_assert_int_eq(strncmp(masterkey_test,   "tprv", 1), 0);
+    u_assert_int_eq(strncmp(masterkey_regtest,   "rprv", 1), 0);
 
     /* test master keypair association */
     u_assert_int_eq(verifyHDMasterPubKeypair(masterkey_main, p2pkh_master_pubkey_main, false), true);


### PR DESCRIPTION
I am changing just the HD key generation for the moment to support chainparams, so we can pass in regtest or any chain we want to configure. I think in the longer term we should deprecate the `is_testnet` in favor of passing in the chain params, these are constants anyway. 