### PR TITLE
spv, wallet, ci: quit on q/Q, skip prompts with address, refresh macOS cmake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
         run: |
           if ([ "${{ matrix.host }}" != "x86_64-pc-windows-msvc" ]); then
             if ([ "${{ matrix.name }}" == "x86_64-macos" ] || [ "${{ matrix.name }}" == "arm64-macos" ]); then
+                brew uninstall cmake
                 brew update
                 brew install automake coreutils ${{ matrix.packages }}
                 echo PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH" >> ~/.bashrc

--- a/src/spv.c
+++ b/src/spv.c
@@ -55,6 +55,7 @@
 #include <dogecoin/spv.h>
 #include <dogecoin/tx.h>
 #include <dogecoin/utils.h>
+#include <event2/event.h>
 
 static const unsigned int HEADERS_MAX_RESPONSE_TIME = 120;
 static const unsigned int MIN_TIME_DELTA_FOR_STATE_CHECK = 5;
@@ -214,6 +215,15 @@ void dogecoin_spv_client_free(dogecoin_spv_client *client)
 {
     if (!client)
         return;
+
+#ifndef _WIN32
+    // set stdin to back to blocking
+    int stdin_flags = fcntl(STDIN_FILENO, F_GETFL);
+    if (stdin_flags != -1 && (stdin_flags & O_NONBLOCK))
+    {
+        fcntl(STDIN_FILENO, F_SETFL, stdin_flags & ~O_NONBLOCK);
+    }
+#endif
 
     if (client->headers_db)
     {
@@ -702,6 +712,10 @@ void dogecoin_net_spv_post_cmd(dogecoin_node *node, dogecoin_p2p_msg_hdr *hdr, s
         if (c == 'Q' || c == 'q') {
             printf("Disconnecting...\n");
             dogecoin_node_group_shutdown(client->nodegroup);
+
+        // exit the event loop immediately
+        if (client->nodegroup && client->nodegroup->event_base)
+            event_base_loopbreak(client->nodegroup->event_base);
         }
     }
 #else
@@ -713,6 +727,10 @@ void dogecoin_net_spv_post_cmd(dogecoin_node *node, dogecoin_p2p_msg_hdr *hdr, s
 
         printf("Disconnecting...\n");
         dogecoin_node_group_shutdown(client->nodegroup);
+
+        // exit the event loop immediately
+        if (client->nodegroup && client->nodegroup->event_base)
+            event_base_loopbreak(client->nodegroup->event_base);
     }
 #endif
 }

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -392,6 +392,8 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
     char* wallet_prefix = (char*)chain->chainname;
     char* walletfile = NULL;
     dogecoin_bool res = false;
+    // no prompts when an address is passed
+    dogecoin_bool prompt_ok = prompt && (address == NULL);
     if (mnemonic_in) {
         char* wallet_type = "_mnemonic";
         char* wallet_type_prefix = concat(wallet_prefix, wallet_type);
@@ -487,7 +489,7 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
                 dogecoin_wallet_free(wallet);
                 return NULL;
             }
-            if (prompt) {
+            if (prompt_ok) {
                 printf("Store seed in encrypted file? (Y/n): ");
 
                 char buffer[MAX_LEN];
@@ -790,16 +792,16 @@ dogecoin_bool dogecoin_wallet_create(dogecoin_wallet* wallet, const char* file_p
     if (!wallet)
         return false;
 
-    struct stat buffer;
-    if (stat(file_path, &buffer) != 0) {
-        *error = 1;
-        return false;
-    }
-
     // open wallet file if not already open
     if (!wallet->dbfile) {
-        memcpy_safe((char*)wallet->filename, file_path, strlen(file_path));
         wallet->dbfile = fopen(file_path, "a+b");
+        if (wallet->dbfile) {
+            snprintf((char*)wallet->filename, sizeof(wallet->filename), "%s", file_path);
+        }
+        else {
+            *error = 1;
+            return false;
+        }
     }
 
     // write file-header-magic
@@ -951,8 +953,11 @@ dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_pat
     }
 
     wallet->dbfile = fopen(file_path, *created ? "a+b" : "r+b");
-
+    if (wallet->dbfile) {
+        snprintf((char*)wallet->filename, sizeof(wallet->filename), "%s", file_path);
+    }
     if (*created) {
+
         if (!dogecoin_wallet_create(wallet, file_path, error)) {
             return false;
         }


### PR DESCRIPTION
This updates spv to quit immediately on q/Q and restore stdin blocking, updates wallet to skip prompts when given an address and sync filenames, and fixes macOS CI by refreshing cmake.