### PR TITLE
wallet: update init params to opts, utxo height on reorg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
         run: |
           if ([ "${{ matrix.host }}" != "x86_64-pc-windows-msvc" ]); then
             if ([ "${{ matrix.name }}" == "x86_64-macos" ] || [ "${{ matrix.name }}" == "arm64-macos" ]); then
+                brew uninstall cmake
                 brew update
                 brew install automake coreutils ${{ matrix.packages }}
                 echo PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH" >> ~/.bashrc

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -70,6 +70,17 @@ DISABLE_WARNING(-Wunused-variable)
 static dogecoin_utxo* utxos = NULL;
 DISABLE_WARNING_POP
 
+/** wallet init options */
+typedef struct dogecoin_wallet_opts_ {
+    const char* mnemonic_in;     // BIP39 mnemonic (optional)
+    const char* pass;            // BIP39 passphrase (optional)
+    dogecoin_bool encrypted;     // using encrypted storage?
+    dogecoin_bool tpm;           // use TPM-backed decrypt?
+    int file_num;                // encrypted slot/file id
+    dogecoin_bool master_key;    // encrypted material is master key vs mnemonic
+    dogecoin_bool prompt;        // interactive prompt/confirmations
+} dogecoin_wallet_opts;
+
 /** single key/value record */
 typedef struct dogecoin_wallet_ {
     const char filename[311]; // max path length
@@ -141,7 +152,7 @@ LIBDOGECOIN_API void dogecoin_wallet_output_free(dogecoin_output* output);
 /** ------------------------------------ */
 
 LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_new(const dogecoin_chainparams *params);
-LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const char* address, const char* name, const char* mnemonic_in, const char* pass, const dogecoin_bool encrypted, const dogecoin_bool tpm, const int file_num, const dogecoin_bool master_key, const dogecoin_bool prompt);
+LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const char* address, const char* name, const dogecoin_wallet_opts* opts);
 LIBDOGECOIN_API void print_utxos(dogecoin_wallet* wallet);
 LIBDOGECOIN_API void dogecoin_wallet_free(dogecoin_wallet* wallet);
 
@@ -172,6 +183,9 @@ LIBDOGECOIN_API dogecoin_wallet_addr* dogecoin_wallet_find_waddr_byaddr(dogecoin
 
 /** adds transaction to the wallet (hands over memory management) */
 LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_add_wtx_move(dogecoin_wallet* wallet, dogecoin_wtx* wtx);
+
+/** copy a given transaction object */
+LIBDOGECOIN_API dogecoin_wtx* dogecoin_wallet_wtx_copy(dogecoin_wtx* wtx);
 
 /** gets credit from given transaction */
 LIBDOGECOIN_API int64_t dogecoin_wallet_get_balance(dogecoin_wallet* wallet);

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -419,7 +419,20 @@ int main(int argc, char* argv[]) {
         signal(SIGINT, handle_sigint);
 
 #if WITH_WALLET
-        dogecoin_wallet* wallet = dogecoin_wallet_init(chain, address, name, mnemonic_in, pass, encrypted, tpm, file_num, master_key, prompt);
+        dogecoin_wallet_opts wopts = {
+            .mnemonic_in = mnemonic_in,
+            .pass = pass,
+            .encrypted = encrypted,
+            .tpm = tpm,
+            .file_num = file_num,
+            .master_key = master_key,
+            .prompt = prompt
+        };
+        dogecoin_wallet* wallet = dogecoin_wallet_init(
+            chain,
+            address,
+            name,
+            &wopts);
         if (!wallet) {
             printf("Could not initialize wallet...\n");
             // clear and free the passphrase

--- a/src/rest.c
+++ b/src/rest.c
@@ -93,6 +93,7 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
                     evbuffer_add_printf(evb, "script_pubkey:  %s\n", utxo->script_pubkey);
                     evbuffer_add_printf(evb, "amount:         %s\n", utxo->amount);
                     evbuffer_add_printf(evb, "confirmations:  %d\n", utxo->confirmations);
+                    evbuffer_add_printf(evb, "height:         %d\n", utxo->height);
                     evbuffer_add_printf(evb, "spendable:      %d\n", utxo->spendable);
                     evbuffer_add_printf(evb, "solvable:       %d\n", utxo->solvable);
                     wallet_total_u64 += coins_to_koinu_str(utxo->amount);
@@ -122,6 +123,7 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
                 evbuffer_add_printf(evb, "script_pubkey:  %s\n", utxo->script_pubkey);
                 evbuffer_add_printf(evb, "amount:         %s\n", utxo->amount);
                 evbuffer_add_printf(evb, "confirmations:  %d\n", utxo->confirmations);
+                evbuffer_add_printf(evb, "height:         %d\n", utxo->height);
                 evbuffer_add_printf(evb, "spendable:      %d\n", utxo->spendable);
                 evbuffer_add_printf(evb, "solvable:       %d\n", utxo->solvable);
                 wallet_total_u64_unspent += coins_to_koinu_str(utxo->amount);

--- a/src/spv.c
+++ b/src/spv.c
@@ -55,6 +55,7 @@
 #include <dogecoin/spv.h>
 #include <dogecoin/tx.h>
 #include <dogecoin/utils.h>
+#include <event2/event.h>
 
 static const unsigned int HEADERS_MAX_RESPONSE_TIME = 120;
 static const unsigned int MIN_TIME_DELTA_FOR_STATE_CHECK = 5;
@@ -214,6 +215,15 @@ void dogecoin_spv_client_free(dogecoin_spv_client *client)
 {
     if (!client)
         return;
+
+#ifndef _WIN32
+    // set stdin to back to blocking
+    int stdin_flags = fcntl(STDIN_FILENO, F_GETFL);
+    if (stdin_flags != -1 && (stdin_flags & O_NONBLOCK))
+    {
+        fcntl(STDIN_FILENO, F_SETFL, stdin_flags & ~O_NONBLOCK);
+    }
+#endif
 
     if (client->headers_db)
     {
@@ -702,6 +712,10 @@ void dogecoin_net_spv_post_cmd(dogecoin_node *node, dogecoin_p2p_msg_hdr *hdr, s
         if (c == 'Q' || c == 'q') {
             printf("Disconnecting...\n");
             dogecoin_node_group_shutdown(client->nodegroup);
+
+        // exit the event loop immediately
+        if (client->nodegroup && client->nodegroup->event_base)
+            event_base_loopbreak(client->nodegroup->event_base);
         }
     }
 #else
@@ -713,6 +727,10 @@ void dogecoin_net_spv_post_cmd(dogecoin_node *node, dogecoin_p2p_msg_hdr *hdr, s
 
         printf("Disconnecting...\n");
         dogecoin_node_group_shutdown(client->nodegroup);
+
+        // exit the event loop immediately
+        if (client->nodegroup && client->nodegroup->event_base)
+            event_base_loopbreak(client->nodegroup->event_base);
     }
 #endif
 }

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -392,6 +392,8 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
     char* wallet_prefix = (char*)chain->chainname;
     char* walletfile = NULL;
     dogecoin_bool res = false;
+    // no prompts when an address is passed
+    dogecoin_bool prompt_ok = prompt && (address == NULL);
     if (mnemonic_in) {
         char* wallet_type = "_mnemonic";
         char* wallet_type_prefix = concat(wallet_prefix, wallet_type);
@@ -487,7 +489,7 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
                 dogecoin_wallet_free(wallet);
                 return NULL;
             }
-            if (prompt) {
+            if (prompt_ok) {
                 printf("Store seed in encrypted file? (Y/n): ");
 
                 char buffer[MAX_LEN];
@@ -790,16 +792,16 @@ dogecoin_bool dogecoin_wallet_create(dogecoin_wallet* wallet, const char* file_p
     if (!wallet)
         return false;
 
-    struct stat buffer;
-    if (stat(file_path, &buffer) != 0) {
-        *error = 1;
-        return false;
-    }
-
     // open wallet file if not already open
     if (!wallet->dbfile) {
-        memcpy_safe((char*)wallet->filename, file_path, strlen(file_path));
         wallet->dbfile = fopen(file_path, "a+b");
+        if (wallet->dbfile) {
+            snprintf((char*)wallet->filename, sizeof(wallet->filename), "%s", file_path);
+        }
+        else {
+            *error = 1;
+            return false;
+        }
     }
 
     // write file-header-magic
@@ -951,8 +953,11 @@ dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_pat
     }
 
     wallet->dbfile = fopen(file_path, *created ? "a+b" : "r+b");
-
+    if (wallet->dbfile) {
+        snprintf((char*)wallet->filename, sizeof(wallet->filename), "%s", file_path);
+    }
     if (*created) {
+
         if (!dogecoin_wallet_create(wallet, file_path, error)) {
             return false;
         }

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -384,7 +384,15 @@ dogecoin_wallet* dogecoin_wallet_new(const dogecoin_chainparams *params)
     return wallet;
 }
 
-dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const char* address, const char* name, const char* mnemonic_in, const char* pass, const dogecoin_bool encrypted, const dogecoin_bool tpm, const int file_num, const dogecoin_bool master_key, const dogecoin_bool prompt) {
+dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const char* address, const char* name, const dogecoin_wallet_opts* opts) {
+    /* local aliases with sane defaults to keep body changes minimal */
+    const char* mnemonic_in   = opts ? opts->mnemonic_in   : NULL;
+    const char* pass          = opts ? opts->pass          : NULL;
+    dogecoin_bool encrypted   = opts ? opts->encrypted     : false;
+    dogecoin_bool tpm         = opts ? opts->tpm           : false;
+    int file_num              = opts ? opts->file_num      : -1;
+    dogecoin_bool master_key  = opts ? opts->master_key    : false;
+    dogecoin_bool prompt      = opts ? opts->prompt        : false;
     dogecoin_wallet* wallet = dogecoin_wallet_new(chain);
     int error;
     dogecoin_bool created;
@@ -584,6 +592,7 @@ void print_utxos(dogecoin_wallet* wallet) {
                 printf("script_pubkey:  %s\n", utxo->script_pubkey);
                 printf("amount:         %s\n", utxo->amount);
                 debug_print("confirmations:  %d\n", utxo->confirmations);
+                printf("height:         %d\n", utxo->height);
                 printf("spendable:      %d\n", utxo->spendable);
                 printf("solvable:       %d\n", utxo->solvable);
                 wallet_total_u64 += coins_to_koinu_str(utxo->amount);
@@ -602,6 +611,7 @@ void print_utxos(dogecoin_wallet* wallet) {
                 printf("script_pubkey:  %s\n", utxo->script_pubkey);
                 printf("amount:         %s\n", utxo->amount);
                 debug_print("confirmations:  %d\n", utxo->confirmations);
+                printf("height:         %d\n", utxo->height);
                 printf("spendable:      %d\n", utxo->spendable);
                 printf("solvable:       %d\n", utxo->solvable);
                 wallet_total_u64 += coins_to_koinu_str(utxo->amount);
@@ -747,6 +757,17 @@ void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
                         // finally add utxo to rbtree:
                         dogecoin_btree_tfind(utxo, &wallet->unspent_rbtree, dogecoin_utxo_compare);
                         add_dogecoin_utxo(utxo);
+                    }
+                    else {
+                        // update existing utxo height for re-mined tx during reorg
+                        dogecoin_utxo* existing_utxo;
+                        dogecoin_utxo* tmp;
+                        HASH_ITER(hh, utxos, existing_utxo, tmp) {
+                            if (memcmp(existing_utxo->txid, &utxo_txid, 32) == 0 && existing_utxo->vout == j) {
+                                existing_utxo->height = wtx->height;
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -1539,7 +1560,13 @@ void dogecoin_wallet_check_transaction(void *ctx, dogecoin_tx *tx, unsigned int 
 
 dogecoin_wallet* dogecoin_wallet_read(char* address) {
     dogecoin_chainparams* chain = (dogecoin_chainparams*)chain_from_b58_prefix(address);
-    dogecoin_wallet* wallet = dogecoin_wallet_init(chain, address, NULL, 0, 0, false, false, -1, false, false);
+    dogecoin_wallet_opts opts = {
+        .mnemonic_in = NULL,
+        .pass = NULL,
+        .encrypted = false, .tpm = false, .file_num = -1,
+        .master_key = false, .prompt = false
+    };
+    dogecoin_wallet* wallet = dogecoin_wallet_init(chain, address, NULL, &opts);
     return wallet;
 }
 

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -91,6 +91,7 @@ extern void test_examples();
 #ifdef WITH_WALLET
 extern void test_wallet_basics();
 extern void test_wallet();
+extern void test_wallet_reorg_utxo_update();
 #endif
 
 #ifdef WITH_TOOLS
@@ -176,6 +177,7 @@ int main()
 #ifdef WITH_WALLET
     u_run_test(test_wallet_basics);
     u_run_test(test_wallet);
+    u_run_test(test_wallet_reorg_utxo_update);
 #endif
 
 #ifdef WITH_TOOLS

--- a/test/wallet_tests.c
+++ b/test/wallet_tests.c
@@ -26,6 +26,8 @@ static const char *wallettmpfile = "/tmp/dummy";
 #include <dogecoin/base58.h>
 #include <dogecoin/utils.h>
 #include <dogecoin/wallet.h>
+#include <dogecoin/script.h>
+#define is_spent(x) (((dogecoin_utxo*)x)->spendable == false)
 
 /* this are the tx_valid test vectors from Bitcoin Core 0.15, run through Bitcoin Core's SignatureHash function */
 static const char * wallet_txns[] = {
@@ -255,4 +257,67 @@ void test_wallet_basics()
 
     dogecoin_wallet_flush(wallet);
     dogecoin_wallet_free(wallet);
+}
+
+void test_wallet_reorg_utxo_update() {
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    unlink(wallettmpfile);
+    dogecoin_wallet* wallet = dogecoin_wallet_new(chain);
+
+    int error;
+    dogecoin_bool created;
+    dogecoin_wallet_load(wallet, wallettmpfile, &error, &created, false);
+
+    dogecoin_hdnode* node = dogecoin_hdnode_new();
+    dogecoin_hdnode_deserialize("xpub6CUGWU4RiVtKr1jD7Ttd4p8nRBF8VPid9ntCLGviZG6h8hacj7k9cZxKyhT3bs9bPg9h9tK8rb6P2qfE3w8c3d5kJxr4K8xW6CnJgf2gYg", chain, node);
+    dogecoin_wallet_set_master_key_copy(wallet, node);
+
+    dogecoin_wallet_addr* waddr = dogecoin_wallet_next_addr(wallet);
+
+    char addr[P2PKHLEN];
+    dogecoin_p2pkh_addr_from_hash160(waddr->pubkeyhash, chain, addr, P2PKHLEN);
+
+    dogecoin_wtx* wtx = dogecoin_wallet_wtx_new();
+    wtx->height = 100;
+
+    dogecoin_tx* tx = wtx->tx;
+
+    dogecoin_tx_out* out = dogecoin_tx_out_new();
+    out->value = 100000000;
+
+    cstring* script = cstr_new_sz(25);
+    cstr_append_c(script, OP_DUP);
+    cstr_append_c(script, OP_HASH160);
+    cstr_append_c(script, 20);
+    cstr_append_buf(script, waddr->pubkeyhash, 20);
+    cstr_append_c(script, OP_EQUALVERIFY);
+    cstr_append_c(script, OP_CHECKSIG);
+    out->script_pubkey = script;
+    vector_add(tx->vout, out);
+
+    dogecoin_wallet_scrape_utxos(wallet, wtx);
+
+    dogecoin_utxo* u;
+    dogecoin_utxo* tmp;
+    HASH_ITER(hh, utxos, u, tmp) {
+        if (!is_spent(u)) {
+            u_assert_int_eq(u->height, 100);
+        }
+    }
+   dogecoin_wtx* wtx_new = dogecoin_wallet_wtx_new();
+   dogecoin_tx_copy(wtx_new->tx, tx);
+   wtx_new->height = 105;
+   dogecoin_wallet_scrape_utxos(wallet, wtx_new);
+   HASH_ITER(hh, utxos, u, tmp) {
+        if (!is_spent(u)) {
+            u_assert_int_eq(u->height, 105);
+        }
+    }
+
+    dogecoin_wallet_flush(wallet);
+    dogecoin_wallet_wtx_free(wtx_new);
+    dogecoin_wallet_free(wallet);
+    dogecoin_hdnode_free(node);
+    remove_all_utxos();
 }


### PR DESCRIPTION
Updates wallet init to a opts struct and spvnode calls. Also updates utxo height on reorg and display in rest and print. Adds a utxo reorg test.

Merge after #272 