### PR TITLE
rest, spv, doc: added /stats and /chainStats for metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,7 @@ jobs:
                         --subkey-version 1 && \
 
                     # Build and test the OP-TEE OS and client
-                    make -j\"$(getconf _NPROCESSORS_ONLN)\" && \
+                    make -j\"$(getconf _NPROCESSORS_ONLN)\" TPL_BIN=\$(BINARIES_PATH)/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.19.bin && \
                     cd /src && \
                     git clone https://github.com/OP-TEE/optee_client.git && \
                     cd optee_client && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
           cache-name: ccache
         with:
           path: ~/.ccache
-          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('**/configure.ac') }}
+          key: ${{ matrix.name }}-${{ env.cache-name }}-${{ hashFiles('configure.ac') }}
 
       - name: configure libdogecoin
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,6 +296,7 @@ TARGET_SOURCES(${LIBDOGECOIN_NAME} PRIVATE
     src/cli/tool.c
     src/transaction.c
     src/tx.c
+    src/utf8proc.c
     src/utils.c
     src/validation.c
     src/vector.c

--- a/doc/rest.md
+++ b/doc/rest.md
@@ -16,6 +16,8 @@
     - [GET /getLastBlockInfo](#get-getlastblockinfo)
     - [GET /getRawTx](#get-getrawtx)
     - [GET /viewTx](#get-viewtx)
+    - [GET /stats](#get-stats)
+    - [GET /chainStats](#get-chainstats)
 
 ## Abstract
 
@@ -448,6 +450,102 @@ curl "http://localhost:<port>/viewTx?txid=7c6728205d56b2b625463a10ade9c9a7ab2bf1
 
 ---
 
+### GET **/stats**
+
+Aggregates recent on-chain activity seen by the SPV session.
+
+#### **Request**
+
+* **Method:** `GET`
+* **URL:** `/stats`
+* **Query params (optional):**
+
+  * `secs=<N>` time window in seconds (default `86400`)
+  * `blocks=<M>` use last M blocks instead of a time window (overrides `secs` if provided)
+  * Alias: `/stats24h` (equivalent to `/stats?secs=86400`)
+
+#### **Response**
+
+* **Content-Type:** `text/plain`
+* **Body (key: value per line):**
+
+  ```
+  === Stats (window=<secs> s) ===
+  blocks: <uint>
+  transactions: <uint64>
+  tps: <float>
+  volume: <DOGE-string>
+  volume_koinu: <uint64>
+  median_fee_per_block: <DOGE-string>
+  avg_fee_per_block: <DOGE-string>
+  outputs: <uint64>
+  bytes: <uint64>
+  tip_height: <int>
+  tip_bits: 0x<hex>
+  ```
+
+#### **Example**
+
+```bash
+curl "http://localhost:<port>/stats?blocks=11&secs=86400"
+```
+
+#### **Sample Response**
+
+```
+=== Stats (window=86400 s) ===
+blocks: 11
+transactions: 368
+tps: 0.0043
+volume: 115806761.13803503
+volume_koinu: 11580676113803503
+median_fee_per_block: 4.08844296
+avg_fee_per_block: 10.61592847
+outputs: 791
+bytes: 325765
+tip_height: 5870150
+tip_bits: 0x196beff5
+```
+
+---
+
+### GET **/chainStats**
+
+Session totals and on-disk sizes observed by the SPV node for this run.
+
+#### **Request**
+
+* **Method:** `GET`
+* **URL:** `/chainStats`
+
+#### **Response**
+
+* **ontent-Type:** `text/plain`
+* **Body (key: value per line):**
+
+  ```
+  === Chain Stats (SPV session) ===
+  tip_height: <int>
+  tip_time: <YYYY-MM-DD HH:MM:SS|unknown>
+  tip_bits: 0x<hex>
+  headers_bytes: <uint64>
+  blocks_total: <uint64>
+  transactions_total: <uint64>
+  outputs_total: <uint64>
+  output_value_total: <DOGE-string>
+  fees_total: <DOGE-string>
+  block_bytes_total: <uint64>
+  approx_chain_bytes: <uint64>
+  ```
+
+#### **Example**
+
+```bash
+curl "http://localhost:<port>/chainStats"
+```
+
+---
+
 ## Additional Information
 
 - **Server Address:** Replace `<port>` in the examples with the port number where your Libdogecoin SPV node is running.
@@ -472,4 +570,3 @@ curl "http://localhost:<port>/viewTx?txid=7c6728205d56b2b625463a10ade9c9a7ab2bf1
     ```
 
 - **Concurrency:** The SPV node should handle multiple concurrent requests gracefully. However, ensure that shared resources like the wallet and UTXO set are managed in a thread-safe manner.
-

--- a/include/dogecoin/spv.h
+++ b/include/dogecoin/spv.h
@@ -35,12 +35,24 @@
 #include <dogecoin/net.h>
 #include <dogecoin/tx.h>
 
+#define SPV_STATS_RING 4096
+
 LIBDOGECOIN_BEGIN_DECL
 
 enum SPV_CLIENT_STATE {
     SPV_HEADER_SYNC_FLAG        = (1 << 0),
     SPV_FULLBLOCK_SYNC_FLAG	    = (1 << 1),
 };
+
+typedef struct spv_block_sample_
+{
+    uint32_t ts;        // block timestamp
+    uint32_t txs;       // number of transactions
+    uint32_t outputs;   // number of outputs
+    uint64_t out_value; // total output value
+    uint32_t size;      // block size
+    uint64_t fees;      // total fees
+} spv_block_sample;
 
 typedef struct dogecoin_spv_client_
 {
@@ -57,6 +69,15 @@ typedef struct dogecoin_spv_client_
     uint64_t last_block_size;
     uint64_t last_block_tx_count;
     uint64_t last_block_total_tx_size;
+    spv_block_sample stats_ring[SPV_STATS_RING];
+    int stats_ring_len;
+    int stats_ring_head;
+    uint64_t stats_blocks_total;
+    uint64_t stats_txs_total;
+    uint64_t stats_outputs_total;
+    uint64_t stats_out_value_total;
+    uint64_t stats_fees_total;
+    uint64_t stats_block_bytes_total;
 
     /* callbacks */
     /* ========= */

--- a/src/rest.c
+++ b/src/rest.c
@@ -35,6 +35,14 @@
 
 #define TIMESTAMP_MAX_LEN 32
 
+#include <stdlib.h>   // qsort
+#include <stdint.h>   // uint64_t
+
+static int cmp_u64(const void *a, const void *b) {
+    uint64_t va = *(const uint64_t*)a, vb = *(const uint64_t*)b;
+    return (va > vb) - (va < vb);
+}
+
 /**
  * This function is called when an http request is received
  * It handles the request and sends a response
@@ -327,6 +335,139 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
             evbuffer_add_printf(evb, "No matching UTXOs for txid\n");
         }
 
+    } else if (strcmp(path, "/stats24h") == 0 || strncmp(path, "/stats", 6) == 0) {
+    // params: secs=N (default 86400), blocks=M (optional: use last M blocks instead of time)
+    uint32_t window = 86400;
+    uint32_t limit_blocks = 0;
+    const char* q = evhttp_uri_get_query(uri);
+    if (q) {
+        const char* p = strstr(q, "secs=");
+        if (p) {
+            p += 5;
+            window = (uint32_t)atoi(p);
+            if (window == 0) window = 86400;
+        }
+        const char* b = strstr(q, "blocks=");
+        if (b) {
+            b += 7;
+            limit_blocks = (uint32_t)atoi(b);
+        }
+    }
+
+    dogecoin_blockindex* tip = client->headers_db->getchaintip(client->headers_db_ctx);
+    uint32_t tip_ts = tip ? tip->header.timestamp : (uint32_t)time(NULL);
+    uint32_t cutoff = tip_ts > window ? (tip_ts - window) : 0;
+
+    // if stats ring is empty/short and we're headers-only, nudge block sync to backfill recent blocks
+    if ((client->stats_ring_len < (limit_blocks ? (int)limit_blocks : 11)) &&
+        ((client->stateflags & SPV_FULLBLOCK_SYNC_FLAG) == 0))
+    {
+        client->stateflags &= ~SPV_HEADER_SYNC_FLAG;
+        client->stateflags |=  SPV_FULLBLOCK_SYNC_FLAG;
+        client->oldest_item_of_interest = cutoff;        // aim for the requested window
+        dogecoin_net_spv_request_headers(client);        // kick the downloader
+    }
+
+    // aggregate from ring, newest -> older until cutoff or block limit hit
+    uint64_t sum_txs = 0, sum_outputs = 0, sum_out_value = 0, sum_fees = 0, sum_size = 0;
+    uint32_t blocks = 0;
+    uint64_t fees_buf[SPV_STATS_RING];
+    size_t fees_n = 0;
+
+    for (int i = 0; i < client->stats_ring_len; i++) {
+        int idx = (client->stats_ring_head - 1 - i + SPV_STATS_RING) % SPV_STATS_RING;
+        spv_block_sample *s = &client->stats_ring[idx];
+        if (!limit_blocks) {
+            if (s->ts < cutoff) break;                  // time window mode
+        } else {
+            if (blocks >= limit_blocks) break;          // last-N-blocks mode
+        }
+        blocks++;
+        sum_txs      += s->txs;
+        sum_outputs  += s->outputs;
+        sum_out_value+= s->out_value;
+        sum_fees     += s->fees;
+        sum_size     += s->size;
+        if (fees_n < SPV_STATS_RING) fees_buf[fees_n++] = s->fees;
+    }
+
+    double tps = window ? ((double)sum_txs / (double)window) : 0.0;
+
+    // median/avg fee per block (in koinu)
+    uint64_t median_fee = 0;
+    if (fees_n) {
+        qsort(fees_buf, fees_n, sizeof(uint64_t), cmp_u64);
+        median_fee = (fees_n & 1) ? fees_buf[fees_n/2]
+                                  : (fees_buf[fees_n/2 - 1] + fees_buf[fees_n/2]) / 2;
+    }
+    uint64_t avg_fee = fees_n ? (sum_fees / fees_n) : 0;
+
+    // stringify (zero-init to avoid garbage)
+    char vol_str[32]      = {0};
+    char med_fee_str[32]  = {0};
+    char avg_fee_str[32]  = {0};
+    koinu_to_coins_str(sum_out_value, vol_str);
+    koinu_to_coins_str(median_fee,    med_fee_str);
+    koinu_to_coins_str(avg_fee,       avg_fee_str);
+
+    evbuffer_add_printf(evb, "=== Stats (window=%u s) ===\n", window);
+    evbuffer_add_printf(evb, "blocks: %u\n", blocks);
+    evbuffer_add_printf(evb, "transactions: %llu\n", (unsigned long long)sum_txs);
+    evbuffer_add_printf(evb, "tps: %.4f\n", tps);
+    evbuffer_add_printf(evb, "volume: %s\n", vol_str);
+    evbuffer_add_printf(evb, "volume_koinu: %llu\n", (unsigned long long)sum_out_value);
+    evbuffer_add_printf(evb, "median_fee_per_block: %s\n", med_fee_str);
+    evbuffer_add_printf(evb, "avg_fee_per_block: %s\n", avg_fee_str);
+    evbuffer_add_printf(evb, "outputs: %llu\n", (unsigned long long)sum_outputs);
+    evbuffer_add_printf(evb, "bytes: %llu\n", (unsigned long long)sum_size);
+    if (tip) {
+        evbuffer_add_printf(evb, "tip_height: %d\n", tip->height);
+        evbuffer_add_printf(evb, "tip_bits: 0x%08x\n", (unsigned int)tip->header.bits);
+    }
+    } else if (strcmp(path, "/chainStats") == 0) {
+        dogecoin_blockindex* tip = client->headers_db->getchaintip(client->headers_db_ctx);
+
+        // headers file size if available
+        long headers_bytes = 0;
+        {
+            dogecoin_headers_db* hdb = (dogecoin_headers_db*)client->headers_db_ctx;
+            FILE* hf = hdb ? hdb->headers_tree_file : NULL;
+            if (hf) {
+                long cur = ftell(hf);
+                fseek(hf, 0, SEEK_END);
+                headers_bytes = ftell(hf);
+                if (cur >= 0) fseek(hf, cur, SEEK_SET);
+            }
+        }
+
+        char total_out_str[32], total_fees_str[32];
+        koinu_to_coins_str(client->stats_out_value_total, total_out_str);
+        koinu_to_coins_str(client->stats_fees_total, total_fees_str);
+
+        evbuffer_add_printf(evb, "=== Chain Stats (SPV session) ===\n");
+        if (tip) {
+            char ts[32] = {0};
+            time_t t = tip->header.timestamp;
+            struct tm *p = localtime(&t);
+            if (p) strftime(ts, sizeof(ts), "%F %T", p);
+            evbuffer_add_printf(evb, "tip_height: %d\n", tip->height);
+            evbuffer_add_printf(evb, "tip_time: %s\n", ts[0]?ts:"unknown");
+            evbuffer_add_printf(evb, "tip_bits: 0x%08x\n", (unsigned int)tip->header.bits);
+        }
+        evbuffer_add_printf(evb, "headers_bytes: %ld\n", headers_bytes);
+
+        // totals reflect blocks we actually parsed this run
+        evbuffer_add_printf(evb, "blocks_total: %llu\n", (unsigned long long)client->stats_blocks_total);
+        evbuffer_add_printf(evb, "transactions_total: %llu\n", (unsigned long long)client->stats_txs_total);
+        evbuffer_add_printf(evb, "outputs_total: %llu\n", (unsigned long long)client->stats_outputs_total);
+        evbuffer_add_printf(evb, "output_value_total: %s\n", total_out_str);
+        evbuffer_add_printf(evb, "fees_total: %s\n", total_fees_str);
+        evbuffer_add_printf(evb, "block_bytes_total: %llu\n", (unsigned long long)client->stats_block_bytes_total);
+
+        // simple approximate on-disk 'size' visible to SPV
+        unsigned long long approx_chain_bytes =
+            (unsigned long long)headers_bytes + (unsigned long long)client->stats_block_bytes_total;
+        evbuffer_add_printf(evb, "approx_chain_bytes: %llu\n", approx_chain_bytes);
     } else {
         evhttp_send_error(req, HTTP_NOTFOUND, "Not Found");
         evbuffer_free(evb);

--- a/src/spv.c
+++ b/src/spv.c
@@ -44,6 +44,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <math.h>
 
 #include <dogecoin/block.h>
 #include <dogecoin/blockchain.h>
@@ -56,6 +57,10 @@
 #include <dogecoin/tx.h>
 #include <dogecoin/utils.h>
 #include <event2/event.h>
+
+#define DOGECOIN_KOINU_PER_COIN 100000000ULL
+/* Dogecoin block subsidy has been 10,000 DOGE for years; good for 24h stats */
+#define DOGECOIN_CURRENT_SUBSIDY_KOINU (10000ULL * DOGECOIN_KOINU_PER_COIN)
 
 static const unsigned int HEADERS_MAX_RESPONSE_TIME = 120;
 static const unsigned int MIN_TIME_DELTA_FOR_STATE_CHECK = 5;
@@ -171,6 +176,15 @@ dogecoin_spv_client* dogecoin_spv_client_new(const dogecoin_chainparams *params,
         client->nodegroup->log_write_cb("HTTP server initialized\n");
         free(http_server_copy);
     }
+
+    client->stats_ring_len = 0;
+    client->stats_ring_head = 0;
+    client->stats_blocks_total = 0;
+    client->stats_txs_total = 0;
+    client->stats_outputs_total = 0;
+    client->stats_out_value_total = 0;
+    client->stats_fees_total = 0;
+    client->stats_block_bytes_total = 0;
 
     return client;
 }
@@ -598,6 +612,11 @@ void dogecoin_net_spv_post_cmd(dogecoin_node *node, dogecoin_p2p_msg_hdr *hdr, s
 
             uint64_t total_tx_size = 0;
 
+            // per-block accumulation for stats
+            uint64_t block_outputs_value = 0;
+            uint32_t block_outputs_count = 0;
+            uint64_t coinbase_value = 0;
+
             size_t consumedlength = 0;
             unsigned int i;
             for (i = 0; i < amount_of_txs; i++)
@@ -616,9 +635,52 @@ void dogecoin_net_spv_post_cmd(dogecoin_node *node, dogecoin_p2p_msg_hdr *hdr, s
                 deser_skip(buf, consumedlength);
                 if (client->sync_transaction) { client->sync_transaction(client->sync_transaction_ctx, tx, i, pindex); }
                 total_tx_size += consumedlength;
+
+                // accumulate outputs for this tx
+                uint64_t tx_out_sum = 0;
+                unsigned int oi;
+                for (oi = 0; oi < tx->vout->len; oi++)
+                {
+                    dogecoin_tx_out *txout = vector_idx(tx->vout, oi);
+                    tx_out_sum += txout->value;
+                    block_outputs_value += txout->value;
+                    block_outputs_count++;
+                }
+                if (i == 0 && dogecoin_tx_is_coinbase(tx)) {
+                    coinbase_value = tx_out_sum; // coinbase tx is always the first tx in a block
+                }
                 dogecoin_tx_free(tx);
             }
             client->last_block_total_tx_size = total_tx_size;
+
+            // approximate fees (OK for recent blocks where subsidy is 10k0 DOGE)
+            uint64_t block_fees = 0;
+            if (coinbase_value > DOGECOIN_CURRENT_SUBSIDY_KOINU) {
+                block_fees = coinbase_value - DOGECOIN_CURRENT_SUBSIDY_KOINU;
+            }
+
+            // session totals
+            client->stats_blocks_total++;
+            client->stats_txs_total += amount_of_txs;
+            client->stats_outputs_total += block_outputs_count;
+            client->stats_out_value_total += block_outputs_value;
+            client->stats_fees_total += block_fees;
+            client->stats_block_bytes_total += hdr->data_len;
+
+            // ring insert (latest)
+            spv_block_sample *smp = &client->stats_ring[client->stats_ring_head];
+            smp->ts = pindex->header.timestamp;
+            smp->txs = amount_of_txs;
+            smp->outputs = block_outputs_count;
+            smp->out_value = block_outputs_value;
+            smp->size = hdr->data_len;
+            smp->fees = block_fees;
+
+            client->stats_ring_head = (client->stats_ring_head + 1) % SPV_STATS_RING;
+            if (client->stats_ring_len < SPV_STATS_RING) {
+                client->stats_ring_len++;
+            }
+
             client->nodegroup->log_write_cb("done (took %lld secs)\n", (unsigned long long)(time(NULL) - start));
         }
         else


### PR DESCRIPTION
Adds `/stats` and `/chainStats` REST endpoints exposing SPV metrics (TPS, volume, fees, outputs, bytes) and updates `rest.md`.