### PR TITLE
headersdb_file, wallet: add conversion, prompt text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
             run-tests: true
           - name: x86_64-win-native
             host: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2022
             packages: cmake
             postinstall: |
               choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
@@ -150,7 +150,7 @@ jobs:
             goal: install
           - name: x86_64-win-native-rel
             host: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2022
             packages: cmake
             postinstall: |
               choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
@@ -160,7 +160,7 @@ jobs:
             goal: install
           - name: x86_64-win-native-notpm
             host: x86_64-pc-windows-msvc
-            os: windows-latest
+            os: windows-2022
             packages: cmake
             postinstall: |
               choco install visualstudio2019buildtools --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
@@ -605,7 +605,7 @@ jobs:
 
   sign-x86_64-win:
     needs: build
-    runs-on: windows-latest
+    runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download artifacts
@@ -631,21 +631,21 @@ jobs:
         shell: pwsh
 
       - name: Sign spvnode.exe (x86_64-win)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: bin/spvnode.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
           certificate-password: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_PASSWORD }}
 
       - name: Sign such.exe (x86_64-win)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: bin/such.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
           certificate-password: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_PASSWORD }}
 
       - name: Sign sendtx.exe (x86_64-win)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: bin/sendtx.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
@@ -666,7 +666,7 @@ jobs:
 
   sign-x86_64-win-native:
     needs: build
-    runs-on: windows-latest
+    runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download artifacts
@@ -690,21 +690,21 @@ jobs:
         shell: pwsh
 
       - name: Sign spvnode.exe (x86_64-win-native)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: Debug/spvnode.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
           certificate-password: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_PASSWORD }}
 
       - name: Sign such.exe (x86_64-win-native)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: Debug/such.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
           certificate-password: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_PASSWORD }}
 
       - name: Sign sendtx.exe (x86_64-win-native)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: Debug/sendtx.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
@@ -720,7 +720,7 @@ jobs:
 
   sign-x86_64-win-native-rel:
     needs: build
-    runs-on: windows-latest
+    runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download artifacts
@@ -744,21 +744,21 @@ jobs:
         shell: pwsh
 
       - name: Sign spvnode.exe (x86_64-win-native-rel)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: Release/spvnode.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
           certificate-password: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_PASSWORD }}
 
       - name: Sign such.exe (x86_64-win-native-rel)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: Release/such.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
           certificate-password: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_PASSWORD }}
 
       - name: Sign sendtx.exe (x86_64-win-native-rel)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: Release/sendtx.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
@@ -774,7 +774,7 @@ jobs:
 
   sign-x86_64-win-native-notpm:
     needs: build
-    runs-on: windows-latest
+    runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download artifacts
@@ -797,21 +797,21 @@ jobs:
         shell: pwsh
 
       - name: Sign spvnode.exe (x86_64-win-native-notpm)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: Release/spvnode.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
           certificate-password: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_PASSWORD }}
 
       - name: Sign such.exe (x86_64-win-native-notpm)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: Release/such.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
           certificate-password: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_PASSWORD }}
 
       - name: Sign sendtx.exe (x86_64-win-native-notpm)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: Release/sendtx.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
@@ -827,7 +827,7 @@ jobs:
 
   sign-i686-win:
     needs: build
-    runs-on: windows-latest
+    runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Download artifacts
@@ -851,21 +851,21 @@ jobs:
         shell: pwsh
 
       - name: Sign spvnode.exe (i686-win)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: bin/spvnode.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
           certificate-password: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_PASSWORD }}
 
       - name: Sign such.exe (i686-win)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: bin/such.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}
           certificate-password: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_PASSWORD }}
 
       - name: Sign sendtx.exe (i686-win)
-        uses: lando/code-sign-action@v2
+        uses: lando/code-sign-action@v3
         with:
           file: bin/sendtx.exe
           certificate-data: ${{ secrets.LIBDOGECOIN_DEV_WINDOWS_CERT_DATA }}

--- a/src/headersdb_file.c
+++ b/src/headersdb_file.c
@@ -160,7 +160,7 @@ dogecoin_bool dogecoin_headers_db_load(dogecoin_headers_db* db, const char *file
         create = false; // Set create to false as file already exists
 
         if (prompt) {
-            printf("\nLoad %s? ", file_path_local);
+            printf("\nLoad %s? (Enter) or (o)verwrite:", file_path_local);
             char response[MAX_LEN];
             if (!fgets(response, MAX_LEN, stdin)) {
                 printf("Error reading input.\n");

--- a/src/sha2.c
+++ b/src/sha2.c
@@ -189,8 +189,10 @@ typedef uint64_t sha2_word64; /* Exactly 8 bytes */
 static void sha512_last(sha512_context*);
 static void sha256_transform(sha256_context*, const sha2_word32*);
 static void sha512_transform(sha512_context*, const sha2_word64*);
+#if defined(USE_ARMV8) || defined(USE_ARMV82)
 static void sha256_transform_armv8(uint32_t* s, const unsigned char* chunk);
 static void sha512_transform_armv82(uint64_t* s, const unsigned char* chunk);
+#endif
 
 /*** SHA-XYZ EXTERN FUNCTION DEFINITIONS ******************************/
 /* NOTE: These functions are assembled from Intel's MB IPSEC library

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -498,7 +498,7 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
                 return NULL;
             }
             if (prompt_ok) {
-                printf("Store seed in encrypted file? (Y/n): ");
+                printf("No mnemonic/key, store random seed in encrypted file? (Y/n): ");
 
                 char buffer[MAX_LEN];
                 int file_id = 0; // Variable to store file ID, defaulting to 0
@@ -762,7 +762,7 @@ void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
                         dogecoin_utxo* existing_utxo;
                         dogecoin_utxo* tmp;
                         HASH_ITER(hh, utxos, existing_utxo, tmp) {
-                            if (memcmp(existing_utxo->txid, &utxo_txid, 32) == 0 && existing_utxo->vout == j) {
+                            if (memcmp(existing_utxo->txid, &utxo_txid, 32) == 0 && (size_t)existing_utxo->vout == j) {
                                 existing_utxo->height = wtx->height;
                                 break;
                             }

--- a/test/wallet_tests.c
+++ b/test/wallet_tests.c
@@ -287,12 +287,12 @@ void test_wallet_reorg_utxo_update() {
     out->value = 100000000;
 
     cstring* script = cstr_new_sz(25);
-    cstr_append_c(script, OP_DUP);
-    cstr_append_c(script, OP_HASH160);
+    cstr_append_c(script, (unsigned char)OP_DUP);
+    cstr_append_c(script, (unsigned char)OP_HASH160);
     cstr_append_c(script, 20);
     cstr_append_buf(script, waddr->pubkeyhash, 20);
-    cstr_append_c(script, OP_EQUALVERIFY);
-    cstr_append_c(script, OP_CHECKSIG);
+    cstr_append_c(script, (unsigned char)OP_EQUALVERIFY);
+    cstr_append_c(script, (unsigned char)OP_CHECKSIG);
     out->script_pubkey = script;
     vector_add(tx->vout, out);
 


### PR DESCRIPTION
Add prompt text, type conversions, and arm guard to address warnings, and update windows signing in ci.

Merge after #275 and #276. 