### PR TITLE
src, doc: added entropy size to such

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,12 +402,12 @@ jobs:
                 if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
                   printf "%s" "${{ secrets.DEFAULT_TA_PEM }}" > rsa_private.pem
                 fi
+                sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
                 docker pull jforissier/optee_os_ci:qemu_check
                 docker run -v "$(pwd):/src" -w /src jforissier/optee_os_ci:qemu_check /bin/bash -c "\
                     # Set up the environment and build the OP-TEE SDK
                     set -e && \
                     apt update && \
-                    apt -y upgrade && \
                     apt -y install libusb-1.0-0-dev swig python3-dev python3-setuptools e2tools && \
                     curl https://storage.googleapis.com/git-repo-downloads/repo > /bin/repo && chmod a+x /bin/repo && \
                     mkdir -p optee && \

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -43,6 +43,7 @@ Most of these commands require a flag following them to denote things like exist
 | -k, --pubkey  | public_key          | yes | p2pkh -k <public_key> |
 | -m, --derived_path | derived_path        | yes | derive_child_key -p <extended_private_key> -m <derived_path> |
 | -e, --entropy  | hex_entropy | yes | generate_mnemonic -e <hex_entropy> |
+| -z, --entropy_size  | entropy_size | yes | generate_mnemonic -z <entropy_size> |
 | -n, --mnemonic  | seed_phrase | yes | mnemonic_to_key or mnemonic_to_addresses -n <seed_phrase> |
 | -a, --pass_phrase  | pass_phrase | no | mnemonic_to_key or mnemonic_to_addresses -n <seed_phrase> -a |
 | -o, --account_int  | account_int | yes | mnemonic_to_key or mnemonic_to_addresses -n <seed_phrase> -o <account_int> |
@@ -193,6 +194,14 @@ The `such` tool provides functionality to securely manage your encrypted mnemoni
 To generate a new mnemonic, which is a 24-word seed phrase, you can use the following command:
 
     ./such -c generate_mnemonic
+
+The `z` flag can be used to specify the size of the entropy used to generate the mnemonic. The default size is 256 bits, which generates a 24-word mnemonic. For example, to generate a mnemonic with 128 bits of entropy, you can use the following command:
+
+    ./such -c generate_mnemonic -z 128
+
+You can also use the `e` flag to provide your own hex-encoded entropy to generate the mnemonic. For example:
+
+    ./such -c generate_mnemonic -e FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
 
 This will output a new mnemonic that you can use to generate keys and addresses. If you want to encrypt this mnemonic to keep it safe, you can use the following command:
 

--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -615,6 +615,7 @@ static struct option long_options[] =
         {"input_index", required_argument, NULL, 'i'},
         {"raw_tx", required_argument, NULL, 'x'},
         {"entropy", required_argument, NULL, 'e'},
+        {"entropy_size", required_argument, NULL, 'z'},
         {"mnemonic", required_argument, NULL, 'n'},
         {"pass_phrase", no_argument, NULL, 'a'},
         {"account_int", required_argument, NULL, 'o'},
@@ -641,13 +642,13 @@ static void print_usage()
     printf("Usage: such -c <cmd> (-m|-derived_path <bip_derived_path>) (-k|-pubkey <publickey>) (-p|-privkey <privatekey>) (-h|-sighash <sighash type>) \
 (-s|-script <script pubkey>) (-i|-input_index <input index>) (-x|-raw_tx <raw hex tx>) (-o|-account_int <account_int>) (-g|-change_level <change_level>) \
 (-e|-entropy <hex_entropy>) (-n|-mnemonic <seed_phrase>) (-a|-pass_phrase) (-y|-encrypted_file <file_num 0-999>) (-w[--overwrite]) (-b[--silent]) \
-(-j[--use_tpm]) (-t[--testnet]) (-r[--regtest])\n");
+(-z|-entropy_size <bit_size>) (-j[--use_tpm]) (-t[--testnet]) (-r[--regtest])\n");
     printf("Available commands:\n");
     printf("generate_public_key (requires -p <wif>),\n");
     printf("p2pkh (requires -k <public key hex>),\n");
     printf("generate_private_key,\n");
     printf("bip32_extended_master_key (-y <file_num>, -j (use_tpm), -w (overwrite) and -b (silent), all optional),\n");
-    printf("generate_mnemonic (-e <hex_entropy> or -y <file_num>, -j (use_tpm), -w (overwrite) and -b (silent), all optional),\n");
+    printf("generate_mnemonic (-e <hex_entropy> or -y <file_num>, -z <bit_size>, -j (use_tpm), -w (overwrite) and -b (silent), all optional),\n");
     printf("list_encryption_keys_in_tpm,\n");
     printf("decrypt_master_key (requires -y <file_num>, -j (use_tpm) optional),\n");
     printf("decrypt_mnemonic (requires -y <file_num>, -j (use_tpm) optional),\n");
@@ -688,7 +689,7 @@ int main(int argc, char* argv[])
     char* mnemonic_in = 0;
     char* pass = 0;
     char* entropy = 0;
-    ENTROPY_SIZE entropy_size = "256";
+    char* entropy_size = "256";
     MNEMONIC mnemonic = {0};
     SEED seed = {0};
     dogecoin_bool tpm = false;
@@ -705,7 +706,7 @@ int main(int argc, char* argv[])
     const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
 
     /* get arguments */
-    while ((opt = getopt_long_only(argc, argv, "h:i:s:x:p:k:m:o:g:e:n:y:c:atrvbwj", long_options, &long_index)) != -1) {
+    while ((opt = getopt_long_only(argc, argv, "h:i:s:x:p:k:m:o:g:e:n:y:c:z:atrvbwj", long_options, &long_index)) != -1) {
         switch (opt) {
                 case 'p':
                     pkey = optarg;
@@ -732,6 +733,9 @@ int main(int argc, char* argv[])
                         sprintf(entropy_size, "%zu", strlen(entropy) / HEX_CHARS_PER_BYTE * 8);
                     }
 
+                    break;
+                case 'z':
+                    entropy_size = optarg;
                     break;
                 case 'n':
                     mnemonic_in = optarg;


### PR DESCRIPTION
Adds `-z` entropy size to the `generate_mnemonic` command in `such`, update docs and usage, and reduce op-tee ci disk use.