### PR TITLE
build, ci: use YUBIKEY flag, add ci target, drop gitian overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - aarch64-android
           - x86_64-nixos
           - x86_64-linux-dbg
+          - x86_64-linux-yubikey
           - x86_64-linux-openenclave
           - x86_64-linux-raccoon-g
           - x86_64-linux-zk-carrier
@@ -66,7 +67,7 @@ jobs:
             run-tests: true
             run-container: true
             packages: g++-aarch64-linux-gnu qemu-user-static qemu-user
-            dep-opts: "CROSS_COMPILE='yes' SPEED=slow V=1"
+            dep-opts: "CROSS_COMPILE='yes' YUBIKEY=y SPEED=slow V=1"
             config-opts: "LIBS=-levent_pthreads --enable-static --disable-shared --enable-optee CFLAGS=-Wp,-D_FORTIFY_SOURCE=0"
             goal: install
           - name: aarch64-android
@@ -96,13 +97,21 @@ jobs:
             dep-opts: "DEBUG=1 SPEED=slow V=1"
             config-opts: "--enable-debug --enable-test-passwd"
             goal: install
+          - name: x86_64-linux-yubikey
+            host: x86_64-pc-linux-gnu
+            os: ubuntu-22.04
+            run-tests: false
+            packages: libykpiv-dev libpcsclite-dev
+            dep-opts: "SPEED=slow V=1"
+            config-opts: "--enable-static --disable-shared --enable-yubikey"
+            goal: install
           - name: x86_64-linux-openenclave
             host: x86_64-pc-linux-gnu
             os: ubuntu-22.04
             run-tests: true
             run-container: true
             packages: python3-dev python3-dbg
-            dep-opts: "DEBUG=1 SPEED=slow V=1"
+            dep-opts: "DEBUG=1 YUBIKEY=y SPEED=slow V=1"
             config-opts: "--enable-openenclave CFLAGS=-Wp,-D_FORTIFY_SOURCE=0"
             goal: install
           - name: x86_64-macos
@@ -560,7 +569,7 @@ jobs:
               elif ([ "${{ matrix.name }}" == "x86_64-linux-openenclave" ]); then
                 make install && \
                 mkdir -p src/openenclave/build && \
-                make -j 4 -C depends HOST=x86_64-pc-linux-gnu/host && \
+                make -j 4 -C depends HOST=x86_64-pc-linux-gnu/host ${{ matrix.dep-opts }} && \
                 ./configure --prefix=${{ github.workspace }}/depends/x86_64-pc-linux-gnu/host && \
                 make && \
                 make install && \

--- a/configure.ac
+++ b/configure.ac
@@ -325,7 +325,7 @@ if test "x$use_optee" = xyes; then
 fi
 
 if test "x$use_yubikey" = xyes; then
-  AC_CHECK_LIB([ykpiv],[main],LIBYKPIV=-lykpiv,AC_MSG_ERROR(libpkpiv missing))
+  AC_CHECK_LIB([ykpiv],[ykpiv_init],LIBYKPIV=-lykpiv,AC_MSG_ERROR(libykpiv missing))
   LIBS="$LIBS $LIBYKPIV"
   AC_DEFINE(USE_YUBIKEY, 1, [Define this symbol if Yubikey works])
 fi

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -108,7 +108,6 @@ script: |
   done
 
   cd libdogecoin
-  export NO_YUBIKEY=y
   BASEPREFIX=`pwd`/depends
   # Build dependencies for each host
   for i in $HOSTS; do

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -79,7 +79,6 @@ script: |
   export PATH=${WRAP_DIR}:${PATH}
 
   cd libdogecoin
-  export NO_YUBIKEY=y
   BASEPREFIX=`pwd`/depends
 
   mkdir -p ${BASEPREFIX}/SDKs

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -99,7 +99,6 @@ script: |
   export PATH=${WRAP_DIR}:${PATH}
 
   cd libdogecoin
-  export NO_YUBIKEY=y
   BASEPREFIX=`pwd`/depends
   # Build dependencies for each host
   for i in $HOSTS; do

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -6,11 +6,11 @@ SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
 NO_WALLET ?=
 NO_UPNP ?=
-NO_YUBIKEY ?=
 NO_LIBOQS ?=
 LIBOQS_RACCOON ?=
 RACCOON_G ?=
 ZK_CARRIER ?=
+YUBIKEY ?=
 MULTIPROCESS ?=
 FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
 
@@ -118,7 +118,7 @@ qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch
 
 wallet_packages_$(NO_WALLET) = $(wallet_packages)
 upnp_packages_$(NO_UPNP) = $(upnp_packages)
-yubikey_packages_$(NO_YUBIKEY) = $(yubikey_packages)
+yubikey_packages_$(YUBIKEY) = $(yubikey_packages)
 liboqs_packages_$(NO_LIBOQS) = $(liboqs_packages)
 # raccoon_g_packages (gmp, mpfr) are only built when RACCOON_G=y is passed.
 # They provide the mpmath-equivalent arbitrary-precision FP arithmetic that the
@@ -132,7 +132,7 @@ ifeq ($(ZK_CARRIER),1)
 packages += $(zk_carrier_packages)
 endif
 
-packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_) $(yubikey_packages_) $(liboqs_packages_) $(raccoon_g_packages_) $(qrencode_packages_)
+packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_) $(yubikey_packages_y) $(liboqs_packages_) $(raccoon_g_packages_) $(qrencode_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
 
 ifneq ($(qt_packages_),)

--- a/depends/README.md
+++ b/depends/README.md
@@ -52,6 +52,7 @@ The following can be set when running make: make FOO=bar
     DEBUG: disable some optimizations and enable more runtime checking
     HOST_ID_SALT: Optional salt to use when generating host package ids
     BUILD_ID_SALT: Optional salt to use when generating build package ids
+    YUBIKEY: set to 'y' to include yubikey packages for the enclave hosts
 
 If some packages are not built, the appropriate
 options will be passed to libdogecoin's configure. In this case, `--disable-net`.

--- a/doc/yubikey.md
+++ b/doc/yubikey.md
@@ -1,5 +1,11 @@
 ### YubiKey Storage of Encrypted Keys
 
+> **Scope.** This document covers libdogecoin's **PIV-based** YubiKey integration, used by the `seal` module for encrypted seed/key storage.
+>
+> - **Enabled by:** `./configure --enable-yubikey`
+> - **Links against:** system `libykpiv` + `libpcsclite`
+> - **YubiKey application used:** PIV (Personal Identity Verification)
+
 The YubiKey is a hardware security key that provides strong two-factor authentication and secure cryptographic operations. By integrating the YubiKey with libdogecoin, users can enhance the security of their wallets and transactions. While the integration is tested with YubiKey 5 NFC, it also works with other YubiKey models that support PIV (Personal Identity Verification).
 
 YubiKey supports numerous cryptographic operations; for libdogecoin, we are primarily interested in the PIV application. The PIV application provides a secure way to store private keys. The YubiKey acts as secure key storage, protecting the private keys from unauthorized access.


### PR DESCRIPTION
Don’t build yubikey packages by default. Add ci target and remove gitian overrides.