### PR TITLE
hd, contrib, doc: align getDerivedHDAddressByPath with P2PKH output

### DIFF
--- a/contrib/examples/example.c
+++ b/contrib/examples/example.c
@@ -123,8 +123,8 @@ int main() {
 	}
 
 	char keypath[BIP44_KEY_PATH_MAX_SIZE] = "m/44'/3'/0'/0/0";
-	if (getDerivedHDAddressByPath(masterkey_main_ext, keypath, extout, true)) {
-		printf("Derived HD Addresses:\n%s\n%s\n", extout, "dgpv5BeiZXttUioRMzXUhD3s2uE9F23EhAwFu9meZeY9G99YS6hJCsQ9u6PRsAG3qfVwB1T7aQTVGLsmpxMiczV1dRDgzpbUxR7utpTRmN41iV7");
+	if (getDerivedHDAddressByPath(masterkey_main_ext, keypath, extout)) {
+		printf("Derived P2PKH Address:\n%s\n%s\n", extout, "DCm7oSg95sxwn3sWxYUDHgKKbB2mDmuR3B");
 	} else {
 		printf("getDerivedHDAddressByPath failed!\n");
 		return -1;

--- a/doc/address.md
+++ b/doc/address.md
@@ -395,10 +395,11 @@ int main() {
 
 ### **getDerivedHDAddressByPath**
 
-`int getDerivedHDAddressByPath(const char* masterkey, const char* derived_path, char* outaddress, bool outprivkey)`
+`int getDerivedHDAddressByPath(const char* masterkey, const char* derived_path, char* outaddress)`
 
-This function derives an extended HD address by custom path in string format (derived_path).
-It returns 1 if the address is valid and 0 if it is not.
+This function derives a P2PKH address from the given master key using a custom BIP-44 derivation path in string format (`derived_path`, e.g. `m/44'/3'/0'/0/0`).
+The output written to `outaddress` is a base58-encoded P2PKH address (use a buffer of at least `P2PKHLEN` bytes).
+It returns 1 on success and 0 on failure.
 
 _C usage:_
 
@@ -408,15 +409,13 @@ _C usage:_
 #include <stdio.h>
 
 int main() {
-  size_t extoutsize = 112;
-  char* extout = dogecoin_char_vla(extoutsize);
+  char extout[P2PKHLEN];
   char* masterkey_main_ext = "dgpv51eADS3spNJh8h13wso3DdDAw3EJRqWvftZyjTNCFEG7gqV6zsZmucmJR6xZfvgfmzUthVC6LNicBeNNDQdLiqjQJjPeZnxG8uW3Q3gCA3e";
   dogecoin_ecc_start();
-  res = getDerivedHDAddressByPath(masterkey_main_ext, "m/44'/3'/0'/0/0", extout, true);
+  int res = getDerivedHDAddressByPath(masterkey_main_ext, "m/44'/3'/0'/0/0", extout);
   u_assert_int_eq(res, true);
-  u_assert_str_eq(extout, "dgpv5BeiZXttUioRMzXUhD3s2uE9F23EhAwFu9meZeY9G99YS6hJCsQ9u6PRsAG3qfVwB1T7aQTVGLsmpxMiczV1dRDgzpbUxR7utpTRmN41iV7");
+  u_assert_str_eq(extout, "DCm7oSg95sxwn3sWxYUDHgKKbB2mDmuR3B");
   dogecoin_ecc_stop();
-  free(extout);
 }
 ```
 

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -134,7 +134,7 @@ int verifyP2pkhAddress(char p2pkh_pubkey[P2PKHLEN], size_t len);
 int getDerivedHDAddress(const char masterkey[HDKEYLEN], uint32_t account, dogecoin_bool ischange, uint32_t addressindex, char outaddress[P2PKHLEN], dogecoin_bool outprivkey);
 
 /* get derived hd address by custom path */
-int getDerivedHDAddressByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[P2PKHLEN], dogecoin_bool outprivkey);
+int getDerivedHDAddressByPath(const char masterkey[HDKEYLEN], const char derived_path[KEYPATHMAXLEN], char outaddress[P2PKHLEN]);
 
 /* generate the p2pkh address from a given hex pubkey */
 dogecoin_bool addresses_from_pubkey(const dogecoin_chainparams* chain, const char pubkey_hex[PUBKEYHEXLEN], char p2pkh_address[P2PKHLEN]);

--- a/src/openenclave/enclave/enc.c
+++ b/src/openenclave/enclave/enc.c
@@ -226,8 +226,8 @@ void enclave_libdogecoin_run_example()
         oe_result_str(OE_FAILURE);
     }
 
-    if (getDerivedHDAddressByPath(masterkey_main_ext, "m/44'/3'/0'/0/0", extout, true)) {
-        printf("Derived HD Addresses:\n%s\n%s\n", extout, "dgpv5BeiZXttUioRMzXUhD3s2uE9F23EhAwFu9meZeY9G99YS6hJCsQ9u6PRsAG3qfVwB1T7aQTVGLsmpxMiczV1dRDgzpbUxR7utpTRmN41iV7");
+    if (getDerivedHDAddressByPath(masterkey_main_ext, "m/44'/3'/0'/0/0", extout)) {
+        printf("Derived P2PKH Address:\n%s\n%s\n", extout, "DCm7oSg95sxwn3sWxYUDHgKKbB2mDmuR3B");
     } else {
         printf("getDerivedHDAddressByPath failed!\n");
         oe_result_str(OE_FAILURE);
@@ -807,7 +807,7 @@ void enclave_libdogecoin_generate_address(const data_t* encrypted_blob, char* cu
     size_t offset = 0;
 
     if (custom_path) {
-        getDerivedHDAddressByPath(master_key, custom_path, address_p2pkh, false);
+        getDerivedHDAddressByPath(master_key, custom_path, address_p2pkh);
     } else {
         for (uint32_t i = 0; i < num_addresses; i++)
         {

--- a/src/optee/ta/libdogecoin_ta.c
+++ b/src/optee/ta/libdogecoin_ta.c
@@ -666,7 +666,7 @@ static TEE_Result generate_address(uint32_t param_types, TEE_Param params[4]) {
     char master_key[HDKEYLEN];
     getHDRootKeyFromSeed(seed, sizeof(seed), false, master_key);
 
-    getDerivedHDAddressByPath(master_key, key_path, address, false);
+    getDerivedHDAddressByPath(master_key, key_path, address);
 
 
     dogecoin_ecc_stop();


### PR DESCRIPTION
Align `getDerivedHDAddressByPath` with actual behavior by dropping `outprivkey`, returning P2PKH (not extended key), and updating `libdogecoin.h`, doc and example.