### PR TITLE
net: break event loop on shutdown

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -258,6 +258,7 @@ void node_periodical_timer(int fd, short int event, void* ctx)
     if (node->time_started_con + DOGECOIN_CONNECT_TIMEOUT_S < now && ((node->state & NODE_CONNECTING) == NODE_CONNECTING)) {
         node->state = 0;
         node->time_started_con = 0;
+        node->state |= NODE_ERRORED;
         node->state |= NODE_TIMEOUT;
         dogecoin_node_connection_state_changed(node);
     }
@@ -510,6 +511,11 @@ void dogecoin_node_group_shutdown(dogecoin_node_group *group) {
 
     if (group->http_server) {
         dogecoin_http_server_shutdown(group);
+    }
+
+    /* break the event loop if it's running */
+    if (group->event_base) {
+        event_base_loopbreak(group->event_base);
     }
 }
 

--- a/src/spv.c
+++ b/src/spv.c
@@ -781,13 +781,11 @@ void dogecoin_net_spv_periodic_statecheck(dogecoin_node *node, uint64_t *now)
 
     if ((client->stateflags & SPV_HEADER_SYNC_FLAG) == SPV_HEADER_SYNC_FLAG)
     {
-        client->last_headersrequest_time = 0;
         dogecoin_net_spv_request_headers(client);
     }
 
     if ((client->stateflags & SPV_FULLBLOCK_SYNC_FLAG) == SPV_FULLBLOCK_SYNC_FLAG)
     {
-        node->time_last_request = 0;
         dogecoin_net_spv_request_headers(client);
     }
 


### PR DESCRIPTION
Some events in `tests` can keep the event loop running after shutdown. Break the event loop during node shutdown, matching the existing behavior in `spv.c`.