### PR TITLE
ci, build, depends: normalize depends option flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           - x86_64-linux-avx2
           - x86_64-linux-sse
           - x86_64-linux-openenclave
-          - x86_64-linux-raccoon-g
+          - x86_64-linux-pqc-raccoon-g
           - x86_64-linux-zk-carrier
           - x86_64-macos
           - arm64-macos
@@ -68,7 +68,7 @@ jobs:
             run-tests: true
             run-container: true
             packages: g++-aarch64-linux-gnu qemu-user-static qemu-user
-            dep-opts: "CROSS_COMPILE='yes' YUBIKEY=y SPEED=slow V=1"
+            dep-opts: "CROSS_COMPILE='yes' YUBIKEY=1 SPEED=slow V=1"
             config-opts: "LIBS=-levent_pthreads --enable-static --disable-shared --enable-optee CFLAGS=-Wp,-D_FORTIFY_SOURCE=0"
             goal: install
           - name: aarch64-android
@@ -118,7 +118,7 @@ jobs:
             run-tests: true
             run-container: true
             packages: python3-dev python3-dbg
-            dep-opts: "DEBUG=1 YUBIKEY=y SPEED=slow V=1"
+            dep-opts: "DEBUG=1 YUBIKEY=1 SPEED=slow V=1"
             config-opts: "--enable-openenclave CFLAGS=-Wp,-D_FORTIFY_SOURCE=0"
             goal: install
           - name: x86_64-macos
@@ -216,24 +216,21 @@ jobs:
             dep-opts: "SPEED=slow V=1"
             config-opts: "--enable-static --disable-shared"
             goal: install
-          - name: x86_64-linux-raccoon-g
+          - name: x86_64-linux-pqc-raccoon-g
             host: x86_64-pc-linux-gnu
             os: ubuntu-22.04
-            # libgmp-dev / libmpfr-dev are required by the in-tree Raccoon-G-44
-            # gaussian sampler (MPFR @256-bit) and are gated behind
-            # --enable-raccoon-g in configure.ac.
-            packages: libgmp-dev libmpfr-dev
+            packages: python3-dev python3-dbg
             run-tests: true
-            dep-opts: "SPEED=slow V=1"
-            config-opts: "--enable-static --disable-shared --enable-raccoon-g"
+            dep-opts: "SPEED=slow V=1 LIBOQS=1 RACCOON_G=1"
+            config-opts: "--enable-static --disable-shared --enable-liboqs --enable-raccoon-g"
             goal: install
           - name: x86_64-linux-zk-carrier
             host: x86_64-pc-linux-gnu
             os: ubuntu-22.04
             run-tests: true
-            packages: python3-dev python3-dbg libgmp-dev
+            packages: python3-dev python3-dbg
             dep-opts: "DEBUG=1 SPEED=slow V=1 ZK_CARRIER=1"
-            config-opts: "--enable-debug --enable-test-passwd --enable-zk-carrier --with-rapidsnark"
+            config-opts: "--enable-debug --enable-test-passwd --enable-zk-carrier --with-rapidsnark --with-mcl"
             goal: install
 
     runs-on: ${{ matrix.os }}

--- a/configure.ac
+++ b/configure.ac
@@ -371,8 +371,8 @@ if test "x$use_liboqs" = xyes; then
 fi
 
 if test "x$use_raccoon_g" = xyes; then
-  AC_CHECK_HEADER([gmp.h],,[AC_MSG_ERROR([gmp.h missing (required by --enable-raccoon-g; build via depends RACCOON_G=y or install libgmp-dev)])])
-  AC_CHECK_HEADER([mpfr.h],,[AC_MSG_ERROR([mpfr.h missing (required by --enable-raccoon-g; build via depends RACCOON_G=y or install libmpfr-dev)])])
+  AC_CHECK_HEADER([gmp.h],,[AC_MSG_ERROR([gmp.h missing (required by --enable-raccoon-g; build via depends RACCOON_G=1 or install libgmp-dev)])])
+  AC_CHECK_HEADER([mpfr.h],,[AC_MSG_ERROR([mpfr.h missing (required by --enable-raccoon-g; build via depends RACCOON_G=1 or install libmpfr-dev)])])
   AC_CHECK_LIB([gmp],[__gmpz_init],[LIBGMP=-lgmp],AC_MSG_ERROR(libgmp missing))
   AC_CHECK_LIB([mpfr],[mpfr_init],[LIBMPFR=-lmpfr],AC_MSG_ERROR(libmpfr missing),[$LIBGMP])
   AC_CHECK_LIB([m],[sqrt],[LIBM=-lm],AC_MSG_ERROR(libm missing))

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -6,8 +6,7 @@ SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
 NO_WALLET ?=
 NO_UPNP ?=
-NO_LIBOQS ?=
-LIBOQS_RACCOON ?=
+LIBOQS ?=
 RACCOON_G ?=
 ZK_CARRIER ?=
 YUBIKEY ?=
@@ -120,12 +119,12 @@ qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch
 wallet_packages_$(NO_WALLET) = $(wallet_packages)
 upnp_packages_$(NO_UPNP) = $(upnp_packages)
 yubikey_packages_$(YUBIKEY) = $(yubikey_packages)
-liboqs_packages_$(NO_LIBOQS) = $(liboqs_packages)
-# raccoon_g_packages (gmp, mpfr) are only built when RACCOON_G=y is passed.
+liboqs_packages_$(LIBOQS) = $(liboqs_packages)
+# raccoon_g_packages (gmp, mpfr) are only built when RACCOON_G=1 is passed.
 # They provide the mpmath-equivalent arbitrary-precision FP arithmetic that the
 # in-tree Raccoon-G Gaussian sampler needs to be byte-exact against the upstream
 # Python reference. They are independent of liboqs.
-ifeq ($(RACCOON_G),y)
+ifeq ($(RACCOON_G),1)
 raccoon_g_packages_ = $(raccoon_g_packages)
 endif
 
@@ -133,7 +132,7 @@ ifeq ($(ZK_CARRIER),1)
 packages += $(zk_carrier_packages)
 endif
 
-packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_) $(yubikey_packages_y) $(liboqs_packages_) $(raccoon_g_packages_) $(qrencode_packages_)
+packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_) $(yubikey_packages_1) $(liboqs_packages_1) $(raccoon_g_packages_) $(qrencode_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
 
 ifneq ($(qt_packages_),)

--- a/depends/README.md
+++ b/depends/README.md
@@ -41,19 +41,19 @@ The following can be set when running make: make FOO=bar
     ANDROID_TOOLCHAIN_BIN: Path to Android toolchain if installed via Android SDK Manager
     ANDROID_API_LEVEL: API level corresponding to the Android version targeted
     FALLBACK_DOWNLOAD_PATH: If a source file can't be fetched, try here before giving up
-    NO_LIBOQS: set to skip building liboqs (PQC library). Leave empty to include it (e.g. NO_LIBOQS=)
-    RACCOON_G: set to 'y' to build GMP and MPFR for the in-tree Raccoon-G
+    LIBOQS: set to '1' to build liboqs (PQC library)
+    RACCOON_G: set to '1' to build GMP and MPFR for the in-tree Raccoon-G
                implementation (--enable-raccoon-g). MPFR is the C analogue of
                Python's mpmath and is required to make the Raccoon-G Gaussian
                sampler byte-exact against the upstream Python reference.
     ZK_CARRIER: set to '1' to vendor herumi/mcl for native Groth16
                 verification in the ZK carrier module.  When unset,
                 Groth16 verification is delegated to off-box snarkjs.
+    YUBIKEY: set to '1' to include yubikey packages for the enclave hosts
+    NASM: set to '1' to build native_nasm (for --enable-intel-avx2/--enable-intel-sse or -DUSE_AVX2=ON/-DUSE_SSE=ON).
     DEBUG: disable some optimizations and enable more runtime checking
     HOST_ID_SALT: Optional salt to use when generating host package ids
     BUILD_ID_SALT: Optional salt to use when generating build package ids
-    YUBIKEY: set to 'y' to include yubikey packages for the enclave hosts
-    NASM: set to 1 to build native_nasm (for --enable-intel-avx2/--enable-intel-sse or -DUSE_AVX2=ON/-DUSE_SSE=ON). Default: off.
 
 If some packages are not built, the appropriate
 options will be passed to libdogecoin's configure. In this case, `--disable-net`.

--- a/depends/packages/liboqs.mk
+++ b/depends/packages/liboqs.mk
@@ -2,7 +2,7 @@ package=liboqs
 
 # Upstream liboqs (open-quantum-safe) — Falcon-512 and Dilithium2 only.
 # Raccoon-G-44 is provided by the in-tree port under src/raccoon_g (enabled via
-# RACCOON_G=y / --enable-raccoon-g) and does not require liboqs at all.
+# RACCOON_G=1 / --enable-raccoon-g) and does not require liboqs at all.
 $(package)_version=0.15.0
 $(package)_download_path=https://github.com/open-quantum-safe/liboqs/archive/refs/tags
 $(package)_file_name=$($(package)_version).tar.gz

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -2,7 +2,7 @@ packages:=libevent
 native_packages := native_ccache
 
 # NASM=1 builds native_nasm for Intel AVX2/SSE assembly (src/intel).
-ifneq ($(NASM),)
+ifeq ($(NASM),1)
 native_packages += native_nasm
 endif
 
@@ -15,7 +15,7 @@ darwin_native_packages =
 yubikey_packages = libyubikey libusb ykpers
 liboqs_packages = liboqs
 raccoon_g_packages = gmp mpfr
-zk_carrier_packages = mcl rapidsnark
+zk_carrier_packages = gmp mcl rapidsnark
 
 ifneq ($(build_os),darwin)
 darwin_native_packages += native_cctools native_libtapi

--- a/src/raccoon_g/README.md
+++ b/src/raccoon_g/README.md
@@ -94,7 +94,7 @@ The reference uses `mpmath` (Python) for the rounded Gaussian sampler. MPFR is
 the C analogue: arbitrary-precision floating-point with IEEE-754 correct
 rounding at user-controlled precision. GMP is its transitive dependency. They
 are vendored via `depends/packages/gmp.mk` and `depends/packages/mpfr.mk`
-behind `RACCOON_G=y` so that this build path is reproducible and pinned to
+behind `RACCOON_G=1` so that this build path is reproducible and pinned to
 the same numerics as the reference.
 
 ## File layout
@@ -159,7 +159,7 @@ re-validation.
 
 ## CI
 
-`.github/workflows/ci.yml` includes an `x86_64-linux-raccoon-g` matrix
+`.github/workflows/ci.yml` includes an `x86_64-linux-pqc-raccoon-g` matrix
 entry which builds with `--enable-static --disable-shared
 --enable-raccoon-g` (installing `libgmp-dev` / `libmpfr-dev` for the
 in-tree Gaussian sampler) and runs the full unit test suite, including


### PR DESCRIPTION
Normalize depends option flags to use `1`.