### PR TITLE
test: free the height-100 wtx in reorg utxo update test

### DIFF
--- a/test/wallet_tests.c
+++ b/test/wallet_tests.c
@@ -317,6 +317,7 @@ void test_wallet_reorg_utxo_update() {
 
     dogecoin_wallet_flush(wallet);
     dogecoin_wallet_wtx_free(wtx_new);
+    dogecoin_wallet_wtx_free(wtx);
     dogecoin_wallet_free(wallet);
     dogecoin_hdnode_free(node);
     remove_all_utxos();


### PR DESCRIPTION
test_wallet_reorg_utxo_update allocates two wtx objects via dogecoin_wallet_wtx_new: `wtx` (height 100) and `wtx_new` (height 105). dogecoin_wallet_scrape_utxos borrows the wtx to populate the global utxo set but does not take ownership of it, which is why `wtx_new` is freed explicitly after its scrape. `wtx` was never given the same treatment and leaked — valgrind reported 88 direct + 296 indirect bytes definitely lost (the wtx struct plus its tx, vout vector, output, and script).

free `wtx` alongside `wtx_new`. dogecoin_wallet_wtx_free recursively frees wtx->tx, reclaiming the output and script added to it, so there is no double free.

verified with valgrind --leak-check=full --show-leak-kinds=all on the isolated test: 0 bytes in use at exit, 0 errors.

unrelated to the PSBT work; surfaced while running the suite under valgrind for PR #317.