### PR TITLE
fix: const-correct utils_bin_to_hex decl in umbrella header

### DIFF
--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -330,7 +330,7 @@ dogecoin_bool deriveBIP44ExtendedPublicKey(
 uint8_t* utils_hex_to_uint8(const char* str);
 char* utils_uint8_to_hex(const uint8_t* bin, size_t l);
 void utils_hex_to_bin(const char* str, unsigned char* out, size_t inLen, size_t* outLen);
-void utils_bin_to_hex(unsigned char* bin_in, size_t inlen, char* hex_out);
+void utils_bin_to_hex(const unsigned char* bin_in, size_t inlen, char* hex_out);
 char* getpass(const char *prompt);
 
 /* Advanced API functions for mnemonic seedphrase generation


### PR DESCRIPTION
The aggregate header include/dogecoin/libdogecoin.h inlines a copy of utils_bin_to_hex that drifted from the canonical declaration in include/dogecoin/utils.h: the umbrella copy took a non-const unsigned char* while utils.h takes const unsigned char*.

A translation unit that pulls in both headers (possible transitively) fails to compile with "conflicting types for 'utils_bin_to_hex'". Sync the umbrella declaration to the const-correct signature.

No functional change; declaration only.