### PR TITLE
update: apply upstream ctaes uint16_t cast hardening

### DIFF
--- a/src/ctaes.c
+++ b/src/ctaes.c
@@ -26,7 +26,7 @@ static void LoadByte(AES_state* s, unsigned char byte, int r, int c)
 {
     int i;
     for (i = 0; i < 8; i++) {
-        s->slice[i] |= (byte & 1) << (r * 4 + c);
+        s->slice[i] |= (uint16_t)(byte & 1) << (r * 4 + c);
         byte >>= 1;
     }
 }
@@ -259,7 +259,7 @@ static void SubBytes(AES_state* s, int inv)
     }
 }
 
-#define BIT_RANGE(from, to) (((1 << ((to) - (from))) - 1) << (from))
+#define BIT_RANGE(from, to) ((uint16_t)((1 << ((to) - (from))) - 1) << (from))
 
 #define BIT_RANGE_LEFT(x, from, to, shift) (((x)&BIT_RANGE((from), (to))) << (shift))
 #define BIT_RANGE_RIGHT(x, from, to, shift) (((x)&BIT_RANGE((from), (to))) >> (shift))


### PR DESCRIPTION
Backport the two integer-cast fixes from current bitcoin-core/ctaes to the vendored src/ctaes.c, without pulling in upstream's bundled CBC layer (libdogecoin provides CBC separately in src/aes.c).

- LoadByte: cast (byte & 1) to uint16_t before the left shift
- BIT_RANGE macro: cast the mask to uint16_t before the shift

Both shifts previously operated on int-promoted operands whose result is stored in a uint16_t slice; the casts make the width explicit and match upstream. Behavior-preserving: AES NIST KAT (test_aes) passes and a direct FIPS-197 C.3 AES-256 known-answer check is unchanged.