### PR TITLE
fix: widen base58_decode_check buffer hint to accept valid short payl…

### DIFF
--- a/src/base58.c
+++ b/src/base58.c
@@ -228,11 +228,27 @@ size_t dogecoin_base58_decode_check(const char* str, uint8_t* data, size_t datal
     if (strl > 128 || datalen < strl) {
         return 0;
     }
-    size_t binsize = strl;
+    /* dogecoin_base58_decode uses its size argument both to size its working
+       word array and to derive a high-word zeromask that rejects any value
+       not fitting in exactly that many bytes. Passing the raw string length
+       (strl) as that size makes it reject otherwise-valid inputs: strl is not
+       the decoded width, and strl % sizeof(word) can yield a mask that drops a
+       legitimately full top word (failures observed at payload lengths 1, 2,
+       5, ... depending on leading-digit magnitude, e.g. raw payload
+       0488ade400). Empirically the decoder needs the hint to exceed strl by a
+       whole word for the mask to clear. A base58 string always decodes to
+       fewer bytes than its length, so strl + sizeof(word) is a safe upper
+       bound on the field width; the decoder returns the true (leading-zero
+       stripped) length in binsize and the value is left-aligned below. */
+    size_t binhint = strl + sizeof(uint32_t);
+    if (binhint > datalen) {
+        binhint = datalen;
+    }
+    size_t binsize = binhint;
     if (!dogecoin_base58_decode(data, &binsize, str, strl)) {
         return 0;
     }
-    memmove(data, data + strl - binsize, binsize);
+    memmove(data, data + binhint - binsize, binsize);
     dogecoin_mem_zero(data + binsize, datalen - binsize);
     if (dogecoin_b58check(data, binsize, str) < 0) {
         ret = 0;

--- a/test/base58_tests.c
+++ b/test/base58_tests.c
@@ -166,4 +166,36 @@ void test_base58()
         i_raw += 2;
         i_cmd += 2;
     }
+
+    /* Regression: short payloads must round-trip through encode_check ->
+       decode_check. The previous code passed the encoded string length to the
+       decoder as an exact output-width hint; for several short payloads that
+       made the decoder's high-word zeromask reject an otherwise-valid value,
+       so decode_check returned 0. These specific raw payloads all failed under
+       the old hint and must now decode back to their exact bytes. */
+    static const char* short_payload_vectors[] = {
+        "0488ade400",  /* the payload cited in the fix; 5 bytes */
+        "ff",          /* single byte, high value */
+        "ffff",        /* two bytes, full */
+        "01",          /* single byte, small value */
+        "abcdef",      /* three bytes */
+        "123456789a",  /* five bytes */
+        0,
+    };
+    for (const char** v = short_payload_vectors; *v; v++) {
+        size_t len = strlen(*v) / 2;
+        uint8_t raw[64];
+        memcpy_safe(raw, utils_hex_to_uint8(*v), len);
+
+        char enc[128];
+        size_t enc_len = dogecoin_base58_encode_check(raw, len, enc, sizeof(enc));
+        assert(enc_len == strlen(enc) + 1);
+
+        uint8_t dec[64];
+        size_t dec_len = dogecoin_base58_decode_check(enc, dec, sizeof(dec));
+        /* decode_check returns payload + 4 checksum bytes; the leading dec_len-4
+           bytes must equal the original payload. */
+        assert(dec_len == len + 4);
+        assert(memcmp(dec, raw, len) == 0);
+    }
 }


### PR DESCRIPTION
…oads

dogecoin_base58_decode_check passed binsize = strl (the encoded string length) as the buffer-size hint to dogecoin_base58_decode. That inner decoder treats its size argument as the exact output field width and derives a high-word zeromask from it; because strl is not the decoded width and strl % sizeof(word) varies with the leading-digit magnitude, the mask can reject otherwise-valid inputs. As a result some base58check strings produced by dogecoin_base58_encode_check itself failed to decode (observed at payload lengths 1, 2, 5 and others; e.g. raw payload 0488ade400).

Size the hint as strl + sizeof(uint32_t) instead. A base58 string always decodes to fewer bytes than its length, so this is a safe upper bound on the field width; it gives the decoder a whole extra word of slack so the zeromask clears, and the result is left-aligned using the same hint. Payload lengths 1..89 now round-trip; the > 128 length cap is unchanged; undersized buffers are still rejected.

Verified:
- All 58 in-tree tests pass; the change is valgrind-clean.
- All callers of dogecoin_base58_decode_check were audited (address.c, wallet.c, tx.c x3, key.c, bip32.c, plus tests). Every call passes datalen >= strl, which the function's existing guard already requires. Confirmed end-to-end with 50 keypair -> WIF-decode -> address round trips and direct decode tests at datalen == strl (e.g. 25-byte address data from a 34-char string, 38-byte WIF data from a 52-char string).
- The encode_check call sites were also audited (cli/tool.c x2, key.c x2, bip32.c x2, eckey.c x2). The smallest payload the library encodes is 21 bytes (a 20-byte hash160 plus version byte; WIF is 34, extended keys 78), which encodes to a >= 28-char string, so nothing the library produces can round-trip into the edge below.

Bound on the clamp: when datalen is in [strl, strl+3] the hint clamps to datalen. Sweeping all string lengths with worst-case (0xFF) payloads, the minimum hint at which dogecoin_base58_decode succeeds exceeds strl only at strl == 7 -- i.e. a 1-byte payload decoded into a 7- or 8-byte buffer. Every base58check format in this library carries a >= 21-byte payload (addresses, WIF, extended keys; strings >= 34 chars), so the clamp is structurally unreachable by any in-tree caller. A deeper alternative would be to correct the zeromask derivation inside dogecoin_base58_decode directly; that is a larger change to the core decoder and is not required here.