### PR TITLE
bip32/bip37: fix signed-overflow UB in big-endian word assembly

### DIFF
--- a/src/bip32.c
+++ b/src/bip32.c
@@ -185,7 +185,7 @@ dogecoin_bool dogecoin_hdnode_public_ckd(dogecoin_hdnode* inout, uint32_t i)
 
     sha256_raw(inout->public_key, DOGECOIN_ECKEY_COMPRESSED_LENGTH, fingerprint);
     rmd160(fingerprint, 32, fingerprint);
-    inout->fingerprint = (fingerprint[0] << 24) + (fingerprint[1] << 16) + (fingerprint[2] << 8) + fingerprint[3];
+    inout->fingerprint = ((uint32_t)fingerprint[0] << 24) | ((uint32_t)fingerprint[1] << 16) | ((uint32_t)fingerprint[2] << 8) | (uint32_t)fingerprint[3];
 
     dogecoin_mem_zero(inout->private_key, 32);
 
@@ -237,8 +237,8 @@ dogecoin_bool dogecoin_hdnode_private_ckd(dogecoin_hdnode* inout, uint32_t i)
 
     sha256_raw(inout->public_key, DOGECOIN_ECKEY_COMPRESSED_LENGTH, fingerprint);
     rmd160(fingerprint, 32, fingerprint);
-    inout->fingerprint = (fingerprint[0] << 24) + (fingerprint[1] << 16) +
-                         (fingerprint[2] << 8) + fingerprint[3];
+    inout->fingerprint = ((uint32_t)fingerprint[0] << 24) | ((uint32_t)fingerprint[1] << 16) |
+                         ((uint32_t)fingerprint[2] << 8) | (uint32_t)fingerprint[3];
 
     dogecoin_mem_zero(fingerprint, sizeof(fingerprint));
     memcpy_safe(p, inout->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);

--- a/src/bip37.c
+++ b/src/bip37.c
@@ -40,7 +40,7 @@ static uint32_t bip37_murmur3(const uint8_t* key, size_t len, uint32_t seed)
     uint32_t h = seed;
     size_t i = 0;
     for (; i + 4 <= len; i += 4) {
-        uint32_t k = key[i] | (key[i + 1] << 8) | (key[i + 2] << 16) | (key[i + 3] << 24);
+        uint32_t k = (uint32_t)key[i] | ((uint32_t)key[i + 1] << 8) | ((uint32_t)key[i + 2] << 16) | ((uint32_t)key[i + 3] << 24);
         k *= 0xcc9e2d51u;
         k = (k << 15) | (k >> 17);
         k *= 0x1b873593u;


### PR DESCRIPTION
Building a uint32 from bytes via (b[0] << 24) promotes the byte to signed int; when b[0] >= 0x80 the shift overflows INT_MAX -> UB, flagged by UBSAN in dogecoin_hdnode_private_ckd. Benign on two's- complement targets (wraps to the intended value) but undefined.

Cast operands to uint32_t before shifting. Output unchanged: verified value-identical across all 256 top-byte values, UBSAN clean.