### PR TITLE
sha2: avoid unaligned word loads in sha256_transform

### DIFF
--- a/src/sha2.c
+++ b/src/sha2.c
@@ -907,6 +907,16 @@ static void sha256_transform(sha256_context* context, const sha2_word32* data)
     sha2_word32 T1, *W256;
     int j;
 
+    /* Callers may pass a byte buffer that is not 4-byte aligned;
+     * dereferencing it as sha2_word32 is UB and faults on strict-
+     * alignment targets. Copy into an aligned buffer only when needed,
+     * so the common (already-aligned) path stays zero-cost. */
+    sha2_word32 aligned_block[16];
+    if (((uintptr_t)data & (sizeof(sha2_word32) - 1)) != 0) {
+        memcpy(aligned_block, data, SHA256_BLOCK_LENGTH);
+        data = aligned_block;
+    }
+
     W256 = (sha2_word32*)context->buffer;
 
     /* Initialize registers with the prev. intermediate value */
@@ -974,6 +984,16 @@ static void sha256_transform(sha256_context* context, const sha2_word32* data)
     sha2_word32 a, b, c, d, e, f, g, h, s0, s1;
     sha2_word32 T1, T2, *W256;
     int j;
+
+    /* Callers may pass a byte buffer that is not 4-byte aligned;
+     * dereferencing it as sha2_word32 is UB and faults on strict-
+     * alignment targets. Copy into an aligned buffer only when needed,
+     * so the common (already-aligned) path stays zero-cost. */
+    sha2_word32 aligned_block[16];
+    if (((uintptr_t)data & (sizeof(sha2_word32) - 1)) != 0) {
+        memcpy(aligned_block, data, SHA256_BLOCK_LENGTH);
+        data = aligned_block;
+    }
 
     W256 = (sha2_word32*)context->buffer;
 


### PR DESCRIPTION
Surfaced running the test suite under -fsanitize=alignment.

sha256_transform takes const sha2_word32* and reads it via *data++, but callers pass byte buffers (e.g. hashing an unaligned input string) cast to sha2_word32*. Dereferencing a misaligned pointer as a 4-byte word is UB and faults on strict-alignment targets (some ARM, MIPS, SPARC); benign on x86_64/aarch64.

Copy the block into an aligned local only when the pointer is misaligned, so the common already-aligned path (sha256_write / finalize, and therefore all of scrypt/PoW) stays zero-cost.

No output change: SHA-256 KATs pass on deliberately misaligned input in both transform variants (SHA2_UNROLL_TRANSFORM on and off), and the full make check is clean under ASAN+UBSAN.

Stacks on #324 (same file, different function: hmac_sha256_prepare). Unrelated to the PSBT work.