### PR TITLE
arith_uint256/jpeg: fix signed-overflow UB in bit assembly

### DIFF
--- a/src/arith_uint256.c
+++ b/src/arith_uint256.c
@@ -125,7 +125,7 @@ arith_uint256* div_arith_uint256(arith_uint256* a, arith_uint256* b) {
         // Set the least significant bit of remainder to bit i of a
         int word_idx = i / 32;
         int bit_idx = i % 32;
-        if ((a->pn[word_idx] & (1 << bit_idx)) != 0) {
+        if ((a->pn[word_idx] & (1u << bit_idx)) != 0) {
             remainder->pn[0] |= 1;
         }
 

--- a/src/jpeg.c
+++ b/src/jpeg.c
@@ -207,8 +207,8 @@ static void jpec_huff_encode_block_impl(jpec_block_t* block, jpec_huff_state_t* 
  */
 static void jpec_huff_write_bits(jpec_huff_state_t* s, unsigned int bits, int n) {
 	assert(s && n > 0 && n <= 16);
-	int32_t mask = (((int32_t)1) << n) - 1;
-	int32_t buffer = (int32_t)bits;
+	uint32_t mask = (((uint32_t)1) << n) - 1;
+	uint32_t buffer = bits;
 	int nbits = s->nbits + n;
 	buffer &= mask;
 	buffer <<= 24 - nbits;


### PR DESCRIPTION
Surfaced running the test suite under -fsanitize=undefined.

div_arith_uint256 tested bits via (a->pn[word_idx] & (1 << bit_idx)); bit_idx ranges 0..31, so 1 << 31 overflows INT_MAX -> UB. jpec's huff bit writer accumulated into an int32_t and did buffer <<= 8 / buffer <<= 24 - nbits, overflowing once the high bits were set.

Shift in unsigned: 1u << bit_idx, and a uint32_t huff accumulator. Benign on two's-complement targets (values wrap as intended) but undefined per standard. No behavior change: pn[] is uint32_t, the huff buffer round-trips the same bit pattern; test_arith_uint256 and test_qr pass.

Unrelated to the PSBT work; found during a full ASAN+UBSAN make check.