### PR TITLE
transaction: fix heap overflow in sign_raw_transaction in-place write

### DIFF
--- a/src/transaction.c
+++ b/src/transaction.c
@@ -602,8 +602,16 @@ int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, i
             free(signed_tx_hex);
             return false;
         }
-        strncpy(incomingrawtx, signed_tx_hex, TO_UINT8_HEX_BUF_LEN - 1);
-        incomingrawtx[TO_UINT8_HEX_BUF_LEN - 1] = '\0';
+        // Overwrite the caller's buffer in place. Copy only the actual signed
+        // length (+ NUL), never a fixed TO_UINT8_HEX_BUF_LEN: strncpy with a
+        // fixed count NUL-fills the destination out to that count, writing
+        // 200001 bytes into a buffer the caller sized to the input tx. That
+        // overflows any binding/caller buffer not pre-sized to TXHEXMAXLEN
+        // (heap corruption -> SIGABRT). The in-place contract requires the
+        // caller's buffer to be at least signed_len + 1; the signed tx is only
+        // marginally larger than the unsigned input it replaces.
+        memcpy(incomingrawtx, signed_tx_hex, signed_len);
+        incomingrawtx[signed_len] = '\0';
         debug_print("signed TX: %s\n", incomingrawtx);
         cstr_free(signed_tx, true);
         dogecoin_tx_free(txtmp);

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -384,6 +384,28 @@ void test_transaction()
     // transaction with both inputs signed:
     u_assert_str_eq(raw_hexadecimal_transaction, expected_signed_raw_hexadecimal_transaction);
 
+    // ----------------------------------------------------------------
+    // regression: sign_raw_transaction must not write past the caller's buffer.
+    // Previously it strncpy'd a fixed TO_UINT8_HEX_BUF_LEN-1 (200000) bytes into
+    // incomingrawtx, overflowing any buffer sized to the input tx rather than to
+    // TXHEXMAXLEN. Callers (e.g. language bindings) that pass a tightly-sized
+    // buffer got heap corruption -> SIGABRT. Here we sign in place using a heap
+    // buffer sized to the unsigned input plus modest headroom; under ASan this
+    // call traps the regression, and the trailing canary guards a plain build.
+    {
+        size_t in_len   = strlen(unsigned_hexadecimal_transaction);
+        size_t scratch  = in_len + 256;          // ample for signature growth
+        char*  small    = dogecoin_malloc(scratch + 1);
+        u_assert_not_null(small);
+        memcpy(small, unsigned_hexadecimal_transaction, in_len + 1);
+        small[scratch] = (char)0xAB;             // canary just past usable region
+
+        u_assert_int_eq(sign_raw_transaction(0, small, utxo_scriptpubkey, 1, private_key_wif), 1);
+
+        u_assert_str_eq(small, expected_single_input_signed_transaction);
+        u_assert_true((unsigned char)small[scratch] == 0xAB); // canary intact
+        dogecoin_free(small);
+    }
 
     // ----------------------------------------------------------------
     // test building transaction and signing with sign_transaction_w_privkey:


### PR DESCRIPTION
See commit message. ASan-confirmed heap overflow in the in-place write; copies signed_len instead of a fixed TO_UINT8_HEX_BUF_LEN. Includes a small-buffer regression test.