### PR TITLE
transaction: fail cleanly on malformed WIF in sign_raw_transaction

### DIFF
--- a/src/transaction.c
+++ b/src/transaction.c
@@ -560,15 +560,12 @@ int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, i
     if (dogecoin_privkey_decode_wif(privkey, chain, &key)) {
         sign = true;
     } else {
-        if (privkey) {
-            if (strlen(privkey) > 50) {
-                dogecoin_tx_free(txtmp);
-                cstr_free(script, true);
-                return false;
-            }
-        } else {
-            return false;
-        }
+        // WIF decode failed: the key is unusable. Previously this leaked txtmp
+        // and script and fell through to `return true` (claiming success on a
+        // bad key) whenever strlen(privkey) <= 50. Always clean up and fail.
+        dogecoin_tx_free(txtmp);
+        cstr_free(script, true);
+        return false;
     }
     if (sign) {
         uint8_t sigcompact[64] = {0};

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -491,7 +491,7 @@ void clear_transaction(int txindex) {
  * @return 1 if the raw transaction was signed successfully, 0 otherwise.
  */
 int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, int sighashtype, char* privkey) {
-    if(!incomingrawtx || !scripthex) return false;
+    if(!incomingrawtx || !scripthex || !privkey) return false;
 
     size_t tx_hex_len = strspn(incomingrawtx, VALID_HEX_CHARS);
     if (tx_hex_len == 0 || (tx_hex_len % 2) != 0 || incomingrawtx[tx_hex_len] != '\0' || tx_hex_len > TXHEXMAXLEN) {
@@ -574,7 +574,10 @@ int sign_raw_transaction(int inputindex, char* incomingrawtx, char* scripthex, i
         enum dogecoin_tx_sign_result res = dogecoin_tx_sign_input(txtmp, script, &key, inputindex, sighashtype, sigcompact, sigder_plus_hashtype, &sigderlen);
         cstr_free(script, true);
 
-        if (res != DOGECOIN_SIGN_OK) return false;
+        if (res != DOGECOIN_SIGN_OK) {
+            dogecoin_tx_free(txtmp);
+            return false;
+        }
 
         char sigcompacthex[64*2+1] = {0};
         utils_bin_to_hex((unsigned char *)sigcompact, 64, sigcompacthex);

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -408,6 +408,20 @@ void test_transaction()
     }
 
     // ----------------------------------------------------------------
+    // regression: a malformed WIF must fail cleanly. Previously the decode
+    // failure path only freed txtmp/script and returned false when
+    // strlen(privkey) > 50; a short invalid WIF leaked both allocations and
+    // fell through to `return true`, reporting success on an unusable key.
+    {
+        char badbuf[2048];
+        strcpy(badbuf, unsigned_hexadecimal_transaction);
+        // short (<= 50 char) invalid WIF -- exercises the previously-leaking path
+        u_assert_int_eq(sign_raw_transaction(0, badbuf, utxo_scriptpubkey, 1, "notavalidwifkey"), 0);
+        // buffer must be left untouched on failure
+        u_assert_str_eq(badbuf, unsigned_hexadecimal_transaction);
+    }
+
+    // ----------------------------------------------------------------
     // test building transaction and signing with sign_transaction_w_privkey:
 
     // instantiate a new working_transaction object by calling start_transaction()


### PR DESCRIPTION
Malformed WIF previously leaked txtmp/script and returned true for keys <=50 chars. Always free and return false on decode failure. Includes a regression test.