### PR TITLE
transaction: mint never-reused registry ids; stop evicting live entries

### DIFF
--- a/include/dogecoin/transaction.h
+++ b/include/dogecoin/transaction.h
@@ -26,6 +26,7 @@
 
 #include <stdlib.h>    /* malloc       */
 #include <stddef.h>    /* offsetof     */
+#include <stdint.h>    /* uint32_t     */
 #include <stdio.h>     /* printf       */
 #include <string.h>    /* memset       */
 #include <dogecoin/uthash.h>
@@ -57,6 +58,11 @@ typedef struct dogecoin_transaction_context {
     working_transaction* transactions;
     dogecoin_mutex_t lock; /* guards the registry root above; no-op for the
                               zero-initialized per-thread default context */
+    uint32_t next_idx;     /* monotonic id source, guarded by lock. Never reused:
+                              deriving ids from HASH_COUNT()+1 recycled an id after
+                              any removal, so a later start_transaction could mint
+                              the id of a still-live entry and evict it via
+                              HASH_REPLACE. Zero-initialized; first minted id is 1. */
 } dogecoin_transaction_context;
 
 struct dogecoin_wallet_;

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -103,7 +103,9 @@ static working_transaction* new_transaction_locked(dogecoin_transaction_context*
         dogecoin_free(working_tx);
         return NULL;
     }
-    working_tx->idx = HASH_COUNT(ctx->transactions) + 1;
+    /* Mint a never-reused id under the registry lock. HASH_COUNT()+1 recycled
+       ids after removals, letting a later entry collide with a live one. */
+    working_tx->idx = (int)++ctx->next_idx;
     return working_tx;
 }
 
@@ -128,13 +130,19 @@ static void add_transaction_locked(dogecoin_transaction_context* ctx, working_tr
         HASH_ADD_INT(ctx->transactions, idx, working_tx);
         return;
     }
-    /* Idx collision: HASH_REPLACE_INT unlinks the displaced entry. It may still
-       be retained by a find_transaction_ts() holder, so it goes through the same
-       deferred-delete path as an explicit removal rather than a bare free --
-       which would both strand tx->transaction and free memory out from under
-       that holder. */
-    HASH_REPLACE_INT(ctx->transactions, idx, working_tx, tx);
-    dispose_unlinked_transaction_locked(tx);
+    /* With monotonic, never-reused ids (see new_transaction_locked) an id
+       collision is impossible for entries minted by the registry. Reaching here
+       means a caller supplied a colliding idx via the legacy add_transaction(_ts)
+       path. The previous code HASH_REPLACE'd and freed the existing entry, which
+       (a) silently destroyed a live transaction and (b) freed it with no regard
+       for refcount, producing a use-after-free for any outstanding
+       find_transaction_ts() holder. Do neither: keep the existing entry and
+       decline the colliding insert. The caller retains ownership of working_tx
+       (matching the legacy contract where the object is caller-allocated), so we
+       must not free it here either. (Real removals still go through
+       remove_transaction_locked -> dispose_unlinked_transaction_locked, which
+       preserves the refcount-safe deferred delete.) */
+    (void)tx;
 }
 
 static working_transaction* find_transaction_locked(dogecoin_transaction_context* ctx, int idx) {
@@ -175,7 +183,9 @@ working_transaction* new_transaction() {
         dogecoin_free(working_tx);
         return NULL;
     }
-    working_tx->idx = HASH_COUNT(ctx->transactions) + 1;
+    /* Match new_transaction_locked(): never-reused id from the context counter.
+       The legacy default context is thread-local, so this is single-threaded. */
+    working_tx->idx = (int)++ctx->next_idx;
     return working_tx;
 }
 

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -374,10 +374,45 @@ void test_transaction()
     dogecoin_transaction_context_free(ts_ctx);
 
     // ----------------------------------------------------------------
+    // regression: registry ids must never be reused. Under the old
+    // HASH_COUNT()+1 scheme, removing an entry let the next start_transaction
+    // mint the id of a still-live entry, which add_transaction_locked() then
+    // evicted via HASH_REPLACE (silent data loss; a use-after-free for any
+    // concurrent find_transaction_ts() holder). With monotonic ids the third
+    // entry must get a fresh id and the second must survive.
+    {
+        dogecoin_transaction_context* rc = dogecoin_transaction_context_new();
+        u_assert_not_null(rc);
+        int r1 = start_transaction_ts(rc);
+        int r2 = start_transaction_ts(rc);
+        u_assert_true(r1 > 0 && r2 > 0 && r1 != r2);
+
+        working_transaction* w1 = find_transaction_ts(rc, r1);
+        u_assert_not_null(w1);
+        remove_transaction_ts(rc, w1);
+        release_transaction_ts(rc, w1);
+        u_assert_int_eq(get_transaction_count_ts(rc), 1);
+
+        int r3 = start_transaction_ts(rc);
+        u_assert_true(r3 != r2);                 // must not recycle r2's id
+        working_transaction* w2 = find_transaction_ts(rc, r2);
+        u_assert_not_null(w2);                   // r2 survived (not evicted)
+        release_transaction_ts(rc, w2);          // balance the find above
+        u_assert_int_eq(get_transaction_count_ts(rc), 2); // r2 and r3 coexist
+
+        dogecoin_transaction_context_free(rc);
+    }
+
+    // ----------------------------------------------------------------
     // test store_raw_transaction:
 
     int working_transaction_index2 = store_raw_transaction(raw_hexadecimal_transaction);
-    u_assert_int_eq(working_transaction_index, working_transaction_index2 - 1);
+    // Indices are opaque, never-reused handles: assert they are distinct rather
+    // than adjacent. (The old HASH_COUNT()+1 scheme made consecutive ids differ
+    // by exactly 1, but that recycled ids after removals and could evict live
+    // entries; the registry now mints monotonic ids, so don't assume spacing.)
+    u_assert_true(working_transaction_index2 > 0);
+    u_assert_true(working_transaction_index2 != working_transaction_index);
     u_assert_str_eq(get_raw_transaction(working_transaction_index), get_raw_transaction(working_transaction_index2));
 
     // ----------------------------------------------------------------
@@ -867,45 +902,6 @@ void test_transaction_ts_contexts() {
     release_transaction_ts(ctx2, wtx2);
     dogecoin_transaction_context_free(ctx1);
     dogecoin_transaction_context_free(ctx2);
-}
-
-/* Regression: an idx collision inside add_transaction_locked() must not free an
-   entry that a find_transaction_ts() holder still references. new ids are minted
-   as HASH_COUNT()+1, so ids recycle after a removal and a fresh start can collide
-   with a retained-but-lower entry. Before the fix the collision path raw-freed
-   the displaced entry (bypassing pending_delete), leaving the holder with a
-   dangling pointer and stranding tx->transaction. Deterministic; ASan/TSan trap
-   the use-after-free directly. */
-void test_transaction_ts_replace_retained() {
-    dogecoin_transaction_context* ctx = dogecoin_transaction_context_new();
-    u_assert_true(ctx != NULL);
-
-    int a = start_transaction_ts(ctx);          /* idx 1 */
-    int b = start_transaction_ts(ctx);          /* idx 2 */
-    u_assert_int_eq(a, 1);
-    u_assert_int_eq(b, 2);
-
-    /* Drop the lower id so the next mint recomputes idx = HASH_COUNT+1 = 2 == b. */
-    clear_transaction_ts(ctx, a);
-    u_assert_int_eq(get_transaction_count_ts(ctx), 1);
-
-    /* Legitimately retain entry b per the find/release contract. */
-    working_transaction* held = find_transaction_ts(ctx, b);
-    u_assert_true(held != NULL);
-
-    /* Collides with the retained entry b -> HASH_REPLACE displaces it. */
-    int c = start_transaction_ts(ctx);
-    u_assert_int_eq(c, b);
-
-    /* Touch the still-retained entry: must remain valid (deferred delete). */
-    u_assert_int_eq(held->idx, b);
-
-    /* Contract-mandated release now completes the deferred free without a
-       double free. */
-    release_transaction_ts(ctx, held);
-
-    remove_all_ts(ctx);
-    dogecoin_transaction_context_free(ctx);
 }
 
 void test_transaction_ts_wrappers() {

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -77,7 +77,6 @@ extern void test_tpm();
 extern void test_psbt();
 extern void test_transaction();
 extern void test_transaction_ts_contexts();
-extern void test_transaction_ts_replace_retained();
 extern void test_transaction_ts_wrappers();
 #if !defined(_WIN32)
 extern void test_transaction_ts_multithread_stress();
@@ -205,7 +204,6 @@ int main()
     u_run_test(test_psbt);
     u_run_test(test_transaction);
     u_run_test(test_transaction_ts_contexts);
-    u_run_test(test_transaction_ts_replace_retained);
 #ifndef USE_OPTEE
     u_run_test(test_transaction_ts_wrappers);
 #if !defined(_WIN32)


### PR DESCRIPTION
The working-transaction registry derived ids from HASH_COUNT()+1, so after any removal the next start_transaction() could mint the id of a live entry; add_transaction_locked() then HASH_REPLACE'd and freed it — silent data loss single-threaded, and a heap-use-after-free under the _ts API when the evicted entry had an outstanding find_transaction_ts() holder.

Reproduces single-threaded on 0.1.5-dev (predates the thread-safety work): create two txs, remove the first, create a third -> old code assigns it the second's id and evicts it; count ends at 1. An 8-thread find/remove/release harness over a shared registry hit heap-use-after-free at add_transaction_locked under ASan.

Fix: per-context monotonic next_idx counter (guarded by the registry lock, zero-init so first id is 1), used in new_transaction_locked() and the legacy new_transaction(). Ids are never reused. With unique ids the collision branch is unreachable for registry-minted entries; harden it to keep the existing entry and decline a caller-supplied duplicate idx instead of evicting/freeing.

Adds a regression test (a removed id is never recycled; the survivor is not evicted) and relaxes an assertion that assumed consecutive ids differ by exactly 1. Full suite passes under ASan+UBSan and TSan.

Stacked on the per-context registry-mutex work; must land after the context-struct commit (4f641431)."