### PR TITLE
wallet: mint never-reused utxo ids; stop evicting live utxos

### DIFF
--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -68,6 +68,12 @@ typedef struct dogecoin_utxo_ {
 DISABLE_WARNING_PUSH
 DISABLE_WARNING(-Wunused-variable)
 static DOGECOIN_THREAD_LOCAL dogecoin_utxo* utxos = NULL;
+/* Monotonic id source for the utxos hash above. Never reused: deriving ids from
+   HASH_COUNT(utxos)+1 recycled an id after any removal, so a later
+   start_dogecoin_utxo() could mint the id of a still-live utxo and evict it via
+   HASH_REPLACE (silently dropping a spendable output). Zero-initialized; first
+   minted id is 1. */
+static DOGECOIN_THREAD_LOCAL uint32_t utxo_next_idx = 0;
 DISABLE_WARNING_POP
 
 /** wallet init options */

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -252,7 +252,9 @@ dogecoin_utxo* dogecoin_wallet_utxo_new() {
 
 dogecoin_utxo* new_dogecoin_utxo() {
     dogecoin_utxo* utxo = dogecoin_wallet_utxo_new();
-    utxo->index = HASH_COUNT(utxos) + 1;
+    /* Mint a never-reused id. HASH_COUNT(utxos)+1 recycled ids after removals,
+       letting a later utxo collide with a live one and evict it. */
+    utxo->index = (int)++utxo_next_idx;
     return utxo;
 }
 
@@ -269,10 +271,15 @@ void add_dogecoin_utxo(dogecoin_utxo* utxo_external) {
     HASH_FIND_INT(utxos, &utxo_external->index, utxo_internal);
     if (utxo_internal == NULL) {
         HASH_ADD_INT(utxos, index, utxo_external);
-    } else {
-        HASH_REPLACE_INT(utxos, index, utxo_external, utxo_internal);
+        return;
     }
-    dogecoin_free(utxo_internal);
+    /* With monotonic, never-reused ids a collision is impossible for utxos minted
+       by new_dogecoin_utxo(). Reaching here means a caller supplied a colliding
+       index directly. The previous code HASH_REPLACE'd and dogecoin_free()'d the
+       existing utxo, silently destroying a tracked, possibly-spendable output.
+       Keep the existing entry and decline the colliding insert; the caller
+       retains ownership of utxo_external. */
+    (void)utxo_internal;
 }
 
 dogecoin_utxo* find_dogecoin_utxo(int index) {

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -129,6 +129,7 @@ extern void test_examples();
 extern void test_wallet_basics();
 extern void test_wallet();
 extern void test_wallet_reorg_utxo_update();
+extern void test_wallet_utxo_idx_not_reused();
 extern void test_wallet_ts_wrappers();
 #if !defined(_WIN32)
 extern void test_wallet_ts_multithread_stress();
@@ -259,6 +260,7 @@ int main()
     u_run_test(test_wallet_basics);
     u_run_test(test_wallet);
     u_run_test(test_wallet_reorg_utxo_update);
+    u_run_test(test_wallet_utxo_idx_not_reused);
 #ifndef USE_OPTEE
     u_run_test(test_wallet_ts_wrappers);
 #if !defined(_WIN32)

--- a/test/wallet_tests.c
+++ b/test/wallet_tests.c
@@ -328,6 +328,35 @@ void test_wallet_reorg_utxo_update() {
     remove_all_utxos();
 }
 
+/* Regression: utxo ids must never be reused. Under the old HASH_COUNT(utxos)+1
+   scheme, removing a utxo let the next start_dogecoin_utxo() mint the id of a
+   still-live utxo, which add_dogecoin_utxo() then evicted via HASH_REPLACE --
+   silently dropping a tracked, spendable output (and freeing it). With a
+   monotonic id source the third utxo gets a fresh id and the second survives. */
+void test_wallet_utxo_idx_not_reused() {
+    remove_all_utxos();
+
+    int a = start_dogecoin_utxo();
+    int b = start_dogecoin_utxo();
+    u_assert_true(a > 0 && b > 0 && a != b);
+
+    dogecoin_utxo* ua = find_dogecoin_utxo(a);
+    u_assert_not_null(ua);
+    remove_dogecoin_utxo(ua);
+
+    int c = start_dogecoin_utxo();
+    u_assert_true(c != b);                       /* must not recycle b's id */
+    u_assert_not_null(find_dogecoin_utxo(b));    /* b survived (not evicted) */
+    u_assert_not_null(find_dogecoin_utxo(c));
+
+    /* exactly b and c remain */
+    int present = 0;
+    for (int i = 1; i <= 16; i++) if (find_dogecoin_utxo(i)) present++;
+    u_assert_int_eq(present, 2);
+
+    remove_all_utxos();
+}
+
 void test_wallet_ts_wrappers()
 {
     unlink(wallettmpfile);


### PR DESCRIPTION
# wallet: mint never-reused utxo ids; stop evicting live utxos

## What

The wallet utxo store derived new ids from `HASH_COUNT(utxos) + 1`. After any removal the count drops, so the next `start_dogecoin_utxo()` mints an id that already belongs to a live utxo. `add_dogecoin_utxo()` then took its `HASH_REPLACE_INT` branch and `dogecoin_free()`'d the displaced utxo — silently dropping a tracked, possibly-spendable output from the wallet with no error returned.

## Why it matters

This is the same defect class as the working-transaction registry (`HASH_COUNT()+1` id reuse plus `HASH_REPLACE` eviction), here in the utxo hash. It is arguably worse, because utxos represent funds: losing one means the wallet stops tracking spendable money. The bug predates current work — it reproduces on `0.1.5-dev`.

Deterministic repro (no threads needed): create two utxos, remove the first, create a third → the old code assigns it the second's id and evicts the second; only one utxo remains where two should.

## The fix

Add a thread-local monotonic `utxo_next_idx` counter (zero-initialized, first id 1) and mint ids from it in `new_dogecoin_utxo()` instead of `HASH_COUNT()+1`. Ids are now never reused, so collisions cannot occur for store-minted utxos.

With unique ids the collision branch in `add_dogecoin_utxo()` is unreachable for normal use; harden it so it never evicts or frees an existing entry. A caller that hand-sets a duplicate index keeps its own object and the insert is declined, instead of `HASH_REPLACE` + free.

Both in-tree callers (`start_dogecoin_utxo()` and the wallet-scan path) obtain their index from `new_dogecoin_utxo()`, so they always carry a fresh id and never hit the decline branch.

## Tests

Adds `test_wallet_utxo_idx_not_reused`, asserting that a removed id is never recycled and the surviving utxo is not evicted. Verified to fail against the old code and pass with the fix. Full suite passes under ASan; plain build is warning-free.

## Notes for reviewers

The same `HASH_COUNT()+1` / `HASH_REPLACE` pattern exists in several other stores in the codebase (the working-transaction registry, the eckey registry, and the generic map). This PR fixes the utxo store; the others are tracked separately.
