### PR TITLE
eckey: mint never-reused key ids; stop evicting (and leaking) live keys

### DIFF
--- a/include/dogecoin/eckey.h
+++ b/include/dogecoin/eckey.h
@@ -64,6 +64,13 @@ typedef struct dogecoin_eckey_context {
     eckey_lifetime* lifetimes; /* side table guarding _ts refcounts, keyed by key ptr */
     dogecoin_mutex_t lock; /* guards the registry roots above; no-op for the
                               zero-initialized per-thread default context */
+    uint32_t next_idx;     /* monotonic id source, guarded by lock. Never reused:
+                              deriving ids from HASH_COUNT()+1 recycled an id after
+                              any removal, so a later start_key could mint the id of
+                              a still-live key and evict it via HASH_REPLACE -- which
+                              freed the displaced key WITHOUT cleansing it, leaving
+                              private-key bytes in freed heap. Zero-initialized;
+                              first minted id is 1. */
 } dogecoin_eckey_context;
 
 // instantiates a new eckey

--- a/src/eckey.c
+++ b/src/eckey.c
@@ -55,13 +55,16 @@ static void add_eckey_locked(dogecoin_eckey_context* ctx, eckey *key) {
         HASH_ADD_INT(ctx->keys, idx, key);
         return;
     }
-    /* Idx collision: HASH_REPLACE_INT unlinks the displaced key. It may still be
-       retained by a find_eckey_ts() holder, so dispose of it through the same
-       deferred-delete path as an explicit removal rather than a bare free --
-       which would free it out from under that holder AND skip
-       destroy_eckey_locked()'s cleanse, leaving private-key bytes in freed heap. */
-    HASH_REPLACE_INT(ctx->keys, idx, key, key_old);
-    dispose_unlinked_eckey_locked(ctx, key_old);
+    /* With monotonic, never-reused ids (see new_eckey_ts) a collision is
+       impossible for keys minted by new_eckey_ts()/start_key_ts(). Reaching here
+       means a caller supplied a colliding idx directly. The previous code
+       HASH_REPLACE'd and freed the displaced key -- destroying a live key AND,
+       because dogecoin_key_free() does not cleanse, leaving its private-key bytes
+       in freed heap. Keep the existing key and decline the colliding insert; the
+       caller retains ownership of `key`. (Real removals still go through
+       remove_eckey_locked -> dispose_unlinked_eckey_locked, which preserves the
+       refcount-safe deferred delete and destroy_eckey_locked()'s cleanse.) */
+    (void)key_old;
 }
 
 static eckey* find_eckey_locked(dogecoin_eckey_context* ctx, int idx) {
@@ -216,7 +219,7 @@ eckey* new_eckey_ts(dogecoin_eckey_context* ctx, dogecoin_bool is_testnet) {
     if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) { dogecoin_key_free(key); return NULL; }
     if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) { dogecoin_key_free(key); return NULL; }
     dogecoin_mutex_lock(&ctx->lock);
-    key->idx = HASH_COUNT(ctx->keys) + 1;
+    key->idx = (int)++ctx->next_idx; /* never-reused id; see dogecoin_eckey_context.next_idx */
     dogecoin_mutex_unlock(&ctx->lock);
     return key;
 }
@@ -249,7 +252,7 @@ eckey* new_eckey_from_privkey_ts(dogecoin_eckey_context* ctx, char* private_key)
     if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) { dogecoin_key_free(key); return NULL; }
     if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) { dogecoin_key_free(key); return NULL; }
     dogecoin_mutex_lock(&ctx->lock);
-    key->idx = HASH_COUNT(ctx->keys) + 1;
+    key->idx = (int)++ctx->next_idx; /* never-reused id; see dogecoin_eckey_context.next_idx */
     dogecoin_mutex_unlock(&ctx->lock);
     return key;
 }
@@ -385,8 +388,9 @@ int start_key_ts(dogecoin_eckey_context* ctx, dogecoin_bool is_testnet) {
        provisional idx; we overwrite it here under the same lock as the insert. */
     eckey* key = new_eckey_ts(ctx, is_testnet);
     if (!key) return -1;
+    /* new_eckey_ts() already minted a unique, never-reused idx under the lock.
+       Just insert it (re-minting here would burn a second counter value). */
     dogecoin_mutex_lock(&ctx->lock);
-    key->idx = HASH_COUNT(ctx->keys) + 1;
     add_eckey_locked(ctx, key);
     int index = key->idx;
     dogecoin_mutex_unlock(&ctx->lock);

--- a/test/signmsg_tests.c
+++ b/test/signmsg_tests.c
@@ -144,43 +144,40 @@ void test_eckey_ts_retain_release() {
     dogecoin_eckey_context_free(ctx);
 }
 
-/* Regression: an idx collision inside add_eckey_locked() must not free a key a
-   find_eckey_ts() holder still references. Key ids are minted as HASH_COUNT()+1,
-   so ids recycle after a removal and a fresh start_key_ts() can collide with a
-   retained-but-lower entry. Before the fix the collision path raw-freed the
-   displaced key (bypassing the lifetime side table AND destroy_eckey_locked()'s
-   cleanse), leaving the holder dangling and private-key bytes in freed heap.
-   Deterministic; ASan/TSan trap the use-after-free directly. */
-void test_eckey_ts_replace_retained() {
+/* Regression: eckey ids must never be reused. Under the old HASH_COUNT(keys)+1
+   scheme, removing a key let the next start_key_ts() mint the id of a still-live
+   key, which add_eckey_locked() then evicted via HASH_REPLACE -- destroying a
+   live key and, because dogecoin_key_free() does not cleanse, leaving its
+   private-key bytes in freed heap. With a monotonic id source the third key gets
+   a fresh id and the second survives. */
+void test_eckey_idx_not_reused()
+{
     dogecoin_eckey_context* ctx = dogecoin_eckey_context_new();
     u_assert_true(ctx != NULL);
 
-    int a = start_key_ts(ctx, false);           /* idx 1 */
-    int b = start_key_ts(ctx, false);           /* idx 2 */
-    u_assert_int_eq(a, 1);
-    u_assert_int_eq(b, 2);
+    int a = start_key_ts(ctx, false);
+    int b = start_key_ts(ctx, false);
+    u_assert_true(a > 0 && b > 0 && a != b);
 
-    /* Drop the lower id so the next mint recomputes idx = HASH_COUNT+1 = 2 == b. */
+    /* Remove a per the find/remove/release contract: remove defers while the
+       finder ref is held, release completes the free. */
     eckey* ka = find_eckey_ts(ctx, a);
     u_assert_true(ka != NULL);
-    release_eckey_ts(ctx, ka);                  /* drop the finder ref ... */
-    remove_eckey_ts(ctx, ka);                   /* ... then destroy + unlink */
+    remove_eckey_ts(ctx, ka);
+    release_eckey_ts(ctx, ka);
 
-    /* Legitimately retain entry b per the find/release contract. */
-    eckey* held = find_eckey_ts(ctx, b);
-    u_assert_true(held != NULL);
-    char wif0 = held->private_key_wif[0];
-
-    /* Collides with the retained entry b -> HASH_REPLACE displaces it. */
     int c = start_key_ts(ctx, false);
-    u_assert_int_eq(c, b);
+    u_assert_true(c != b);                       /* must not recycle b's id */
 
-    /* The still-retained entry must remain valid and unmodified (deferred free). */
-    u_assert_int_eq(held->idx, b);
-    u_assert_true(held->private_key_wif[0] == wif0);
-
-    /* Contract-mandated release completes the deferred free without a double free. */
-    release_eckey_ts(ctx, held);
-
+    /* b survived (not evicted) and c exists; balance every find with a release
+       so no retained entry leaks. */
+    eckey* kb = find_eckey_ts(ctx, b);
+    u_assert_true(kb != NULL);                   /* b survived */
+    eckey* kc = find_eckey_ts(ctx, c);
+    u_assert_true(kc != NULL);
+    remove_eckey_ts(ctx, kb);
+    release_eckey_ts(ctx, kb);
+    remove_eckey_ts(ctx, kc);
+    release_eckey_ts(ctx, kc);
     dogecoin_eckey_context_free(ctx);
 }

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -72,7 +72,7 @@ extern void test_smpv();
 extern void test_signmsg_ext();
 extern void test_signmsg_ts_contexts();
 extern void test_eckey_ts_retain_release();
-extern void test_eckey_ts_replace_retained();
+extern void test_eckey_idx_not_reused();
 extern void test_tpm();
 extern void test_psbt();
 extern void test_transaction();
@@ -197,7 +197,7 @@ int main()
     u_run_test(test_signmsg_ext);
     u_run_test(test_signmsg_ts_contexts);
     u_run_test(test_eckey_ts_retain_release);
-    u_run_test(test_eckey_ts_replace_retained);
+    u_run_test(test_eckey_idx_not_reused);
     u_run_test(test_smpv);
 #ifndef USE_OPTEE // TPM is not supported in OPTEE
     u_run_test(test_tpm);


### PR DESCRIPTION
# eckey: mint never-reused key ids; stop evicting (and leaking) live keys

## What

The eckey registry derived new ids from `HASH_COUNT(ctx->keys) + 1`. After any removal the count drops, so the next `start_key_ts()` mints an id that already belongs to a live key. `add_eckey_locked()` then took its `HASH_REPLACE_INT` branch and `dogecoin_free()`'d the displaced key.

## Why it matters

This is the same id-reuse / `HASH_REPLACE`-eviction defect as the working-transaction registry and the wallet utxo store — but with an extra hazard specific to key material:

`remove_eckey_locked()` cleanses the private and public key before freeing. The eviction path called `dogecoin_key_free()` directly, and `dogecoin_key_free()` does **not** cleanse. So an evicted key's private-key bytes were left in freed heap — secret residue — in addition to the silent loss of a live key.

## The fix

Add a monotonic `next_idx` counter to `dogecoin_eckey_context` (guarded by the registry lock, zero-initialized so the first id is 1) and mint ids from it in the `new_eckey_ts` / `new_eckey_from_privkey_ts` constructors. `start_key_ts()` no longer re-mints the index — the constructor already assigned a unique one under the lock, so re-minting only burned a second counter value (and broke the first-id-is-1 invariant that the existing context test relies on). Ids are now never reused, so collisions cannot occur for store-minted keys.

With unique ids the collision branch in `add_eckey_locked()` is unreachable for normal use; harden it to never evict or free an existing key. A caller that hand-sets a duplicate idx keeps its own object and the insert is declined, instead of `HASH_REPLACE` + uncleaned free.

## Tests

Adds `test_eckey_idx_not_reused`, asserting that a removed id is never recycled and the surviving key is not evicted. Verified to fail against the old code and pass with the fix. Full suite passes under ASan+UBSan and TSan (eckey is part of the per-context thread-safety work, so the TSan pass matters).

## Notes for reviewers

This is one of a set of fixes for the same `HASH_COUNT()+1` / `HASH_REPLACE` id-reuse pattern, which appears in several stores. The working-transaction registry and the wallet utxo store are fixed in their own PRs; the generic `map.c` stores are tracked separately. This eckey instance is called out on its own because of the additional private-key cleanse issue on the eviction path.
