### PR TITLE
map: mint never-reused hash/map ids; stop evicting live entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,7 @@ IF(USE_TESTS)
         test/hash_tests.c
         test/key_tests.c
         test/koinu_tests.c
+        test/map_tests.c
         test/mem_tests.c
         test/moon_tests.c
         test/opreturn_tests.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -278,6 +278,7 @@ tests_SOURCES = \
     test/hash_tests.c \
     test/key_tests.c \
     test/koinu_tests.c \
+    test/map_tests.c \
     test/mem_tests.c \
     test/moon_tests.c \
     test/opreturn_tests.c \

--- a/include/dogecoin/map.h
+++ b/include/dogecoin/map.h
@@ -76,6 +76,11 @@ typedef struct hash {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 static DOGECOIN_THREAD_LOCAL hash *hashes = NULL;
+/* Monotonic id source for the hashes table above. Never reused: HASH_COUNT()+1
+   recycled an id after any removal, so a later start_hash() could mint the id of
+   a still-live hash and evict it via HASH_REPLACE. Zero-initialized; first
+   minted id is 1. */
+static DOGECOIN_THREAD_LOCAL uint32_t hash_next_idx = 0;
 #pragma GCC diagnostic pop
 
 // instantiates a new hash
@@ -100,6 +105,10 @@ typedef struct map {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 static DOGECOIN_THREAD_LOCAL map *maps = NULL;
+/* Monotonic id source for the maps table above; see hash_next_idx. Never reused
+   so a removal can't free an id that a later start_map() re-mints onto a live
+   map (which add_map() would then evict via HASH_REPLACE). First minted id 1. */
+static DOGECOIN_THREAD_LOCAL uint32_t map_next_idx = 0;
 #pragma GCC diagnostic pop
 
 // instantiates a new map

--- a/src/map.c
+++ b/src/map.c
@@ -40,7 +40,9 @@ hash* new_hash() {
     hash* h = (struct hash*)dogecoin_calloc(1, sizeof *h);
     int i = 0;
     for (; i < 8; i++) h->data.u32[i] = 0;
-    h->index = HASH_COUNT(hashes) + 1;
+    /* Mint a never-reused id. HASH_COUNT(hashes)+1 recycled ids after removals,
+       letting a later hash collide with a live one and evict it. */
+    h->index = (int)++hash_next_idx;
     return h;
 }
 
@@ -57,10 +59,14 @@ void add_hash(hash *x) {
     HASH_FIND_INT(hashes, &x->index, hash_local);
     if (hash_local == NULL) {
         HASH_ADD_INT(hashes, index, x);
-    } else {
-        HASH_REPLACE_INT(hashes, index, x, hash_local);
+        return;
     }
-    dogecoin_free(hash_local);
+    /* With monotonic, never-reused ids a collision is impossible for hashes
+       minted by new_hash(). Reaching here means a caller supplied a colliding
+       index directly. The previous code HASH_REPLACE'd and dogecoin_free()'d the
+       existing entry, silently destroying a live hash. Keep the existing entry
+       and decline the colliding insert; the caller retains ownership of x. */
+    (void)hash_local;
 }
 
 /**
@@ -167,7 +173,8 @@ map* new_map() {
     m->count = 1;
     if (HASH_COUNT(hashes) < 1) start_hash();
     m->hashes = hashes;
-    m->index = HASH_COUNT(maps) + 1;
+    /* Mint a never-reused id; see new_hash() / map_next_idx. */
+    m->index = (int)++map_next_idx;
     return m;
 }
 
@@ -197,10 +204,14 @@ void add_map(map* map_external) {
     HASH_FIND_INT(maps, &map_external->index, map_local);
     if (map_local == NULL) {
         HASH_ADD_INT(maps, index, map_external);
-    } else {
-        HASH_REPLACE_INT(maps, index, map_external, map_local);
+        return;
     }
-    dogecoin_free(map_local);
+    /* With monotonic, never-reused ids a collision is impossible for maps minted
+       by new_map(). Reaching here means a caller supplied a colliding index
+       directly. The previous code HASH_REPLACE'd and dogecoin_free()'d the
+       existing entry, silently destroying a live map. Keep the existing entry
+       and decline the colliding insert; the caller retains ownership. */
+    (void)map_local;
 }
 
 /**

--- a/test/map_tests.c
+++ b/test/map_tests.c
@@ -1,0 +1,59 @@
+/**********************************************************************
+ * Copyright (c) 2024 The Dogecoin Foundation                         *
+ * Distributed under the MIT software license, see the accompanying   *
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ **********************************************************************/
+
+#include <test/utest.h>
+
+#include <dogecoin/map.h>
+
+/* Regression for the id-reuse / HASH_REPLACE-eviction defect in the map.c
+   stores. Both new_hash() and new_map() derived ids from HASH_COUNT()+1, so
+   removing an entry let the next start_hash()/start_map() mint the id of a
+   still-live entry, which add_hash()/add_map() then evicted via HASH_REPLACE
+   (silently destroying and freeing a live entry). With a monotonic id source
+   the third entry gets a fresh id and the second survives. */
+void test_map_idx_not_reused()
+{
+    /* ---- hashes store ---- */
+    remove_all_hashes();
+    {
+        int a = start_hash();
+        int b = start_hash();
+        u_assert_true(a > 0 && b > 0 && a != b);
+
+        hash* ha = find_hash(a);
+        u_assert_true(ha != NULL);
+        remove_hash(ha);
+
+        int c = start_hash();
+        u_assert_true(c != b);                  /* must not recycle b's id */
+        u_assert_true(find_hash(b) != NULL);    /* b survived (not evicted) */
+        u_assert_true(find_hash(c) != NULL);
+
+        int present = 0;
+        for (int i = 1; i <= 16; i++) if (find_hash(i)) present++;
+        u_assert_int_eq(present, 2);            /* exactly b and c remain */
+    }
+    remove_all_hashes();
+
+    /* ---- maps store ---- */
+    remove_all_maps();
+    {
+        int a = start_map();
+        int b = start_map();
+        u_assert_true(a > 0 && b > 0 && a != b);
+
+        map* ma = find_map(a);
+        u_assert_true(ma != NULL);
+        remove_map(ma);
+
+        int c = start_map();
+        u_assert_true(c != b);
+        u_assert_true(find_map(b) != NULL);
+        u_assert_true(find_map(c) != NULL);
+    }
+    remove_all_maps();
+    remove_all_hashes();
+}

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -55,6 +55,7 @@ extern void test_key();
 extern void test_context_keypair_ex();
 extern void test_context_ts_refcount();
 extern void test_koinu();
+extern void test_map_idx_not_reused();
 extern void test_memory();
 extern void test_moon();
 extern void test_op_return();
@@ -181,6 +182,7 @@ int main()
     u_run_test(test_context_keypair_ex);
     u_run_test(test_context_ts_refcount);
     u_run_test(test_koinu);
+    u_run_test(test_map_idx_not_reused);
     u_run_test(test_memory);
     u_run_test(test_moon);
     u_run_test(test_op_return);


### PR DESCRIPTION
# map: mint never-reused hash/map ids; stop evicting live entries

## What

Both stores in `map.c` derived ids from `HASH_COUNT()+1`: `new_hash()` used `HASH_COUNT(hashes)+1` and `new_map()` used `HASH_COUNT(maps)+1`. After any removal the count drops, so the next `start_hash()` / `start_map()` mints an id that already belongs to a live entry. `add_hash()` / `add_map()` then took their `HASH_REPLACE_INT` branch and `dogecoin_free()`'d the displaced entry — silently destroying a live hash/map with no error returned.

## Why it matters

This is the same id-reuse / `HASH_REPLACE`-eviction defect already fixed in the working-transaction registry, the wallet utxo store, and the eckey registry — here in the generic `map.c` structures, which the auxpow block deserializer and other paths rely on. Reproduces deterministically: create two entries, remove the first, create a third → it collides with the second's id and evicts it.

## The fix

Add thread-local monotonic `hash_next_idx` / `map_next_idx` counters (zero-initialized, first id 1) and mint ids from them in `new_hash()` / `new_map()` instead of `HASH_COUNT()+1`. Ids are now never reused, so collisions cannot occur for store-minted entries.

The remaining `HASH_COUNT()` uses are unaffected: `count_hashes()` is a debug print, and the `HASH_COUNT(hashes) < 1` guard in `new_map()` is an "is the table empty" check — neither assigns ids.

With unique ids the collision branch in `add_hash()` / `add_map()` is unreachable for normal use; harden both so they never evict or free an existing entry. A caller that hand-sets a duplicate index keeps its own object and the insert is declined, instead of `HASH_REPLACE` + free.

## Tests

Adds `test/map_tests.c` with `test_map_idx_not_reused`, covering both stores: a removed id is never recycled and the surviving entry is not evicted. Verified to fail against the old code and pass with the fix. Full suite passes under ASan+UBSan; plain build is warning-free.

## Notes for reviewers

This is the last of a set of fixes for the same `HASH_COUNT()+1` / `HASH_REPLACE` id-reuse pattern. The working-transaction registry, the wallet utxo store, and the eckey registry are fixed in their own PRs; this covers the two generic `map.c` stores.
