### PR TITLE
script: bound OP_PUSHDATA before allocating in copy_without_op_codeseperator

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -88,7 +88,19 @@ dogecoin_bool dogecoin_script_copy_without_op_codeseperator(const cstring* scrip
             continue;
 
         if (data_len > 0) {
-            assert(data_len < 16777215); //limit max push to 0xFFFFFF
+            /* Reject a push that runs past the end of the script before
+               allocating, mirroring dogecoin_script_get_ops(). Previously this
+               relied on assert(data_len < 0xFFFFFF): in a debug build a crafted
+               OP_PUSHDATA4 length aborts the process (a DoS reachable via
+               dogecoin_tx_sighash() on an attacker-influenced fromPubKey), and
+               in an NDEBUG build the assert is compiled out, so a multi-gigabyte
+               data_len reaches dogecoin_calloc() and triggers a huge allocation
+               attempt before deser_bytes() finally fails -- a memory-exhaustion
+               DoS. Checking against the remaining buffer makes both paths fail
+               cleanly. */
+            if (data_len > buf.len) {
+                goto err_out;
+            }
             unsigned char* bufpush = (unsigned char*)dogecoin_calloc(1, data_len);
             if (!deser_bytes(bufpush, &buf, data_len)) {
                 dogecoin_free(bufpush);

--- a/test/tx_tests.c
+++ b/test/tx_tests.c
@@ -1139,6 +1139,24 @@ void test_script_op_codeseperator()
     free(hexbuf);
     cstr_free(new_script, true);
     cstr_free(script, true);
+
+    /* Regression: a script whose OP_PUSHDATA4 declares a length far larger than
+       the remaining bytes must be rejected cleanly. Previously this hit
+       assert(data_len < 0xFFFFFF) -- a process abort in debug builds (a DoS
+       reachable via dogecoin_tx_sighash) and, with NDEBUG, a multi-gigabyte
+       dogecoin_calloc() before deser_bytes failed. The parser now bounds the
+       push against the buffer before allocating, matching
+       dogecoin_script_get_ops. */
+    {
+        /* OP_PUSHDATA4 (0x4e) + length 0xFFFFFFFE + two payload bytes */
+        uint8_t bad[] = { 0x4e, 0xfe, 0xff, 0xff, 0xff, 0xaa, 0xbb };
+        cstring* bad_in = cstr_new_buf(bad, sizeof(bad));
+        cstring* bad_out = cstr_new_sz(16);
+        dogecoin_bool r = dogecoin_script_copy_without_op_codeseperator(bad_in, bad_out);
+        u_assert_int_eq(r, false);
+        cstr_free(bad_out, true);
+        cstr_free(bad_in, true);
+    }
 }
 
 void test_invalid_tx_deser()


### PR DESCRIPTION
# script: bound OP_PUSHDATA before allocating in copy_without_op_codeseperator

## What

`dogecoin_script_copy_without_op_codeseperator()` handled a push payload like this:

```c
assert(data_len < 16777215); // limit max push to 0xFFFFFF
unsigned char* bufpush = dogecoin_calloc(1, data_len);
if (!deser_bytes(bufpush, &buf, data_len)) { ... }
```

`data_len` comes straight off the wire — up to `0xFFFFFFFF` for `OP_PUSHDATA4` — and nothing checks it against the bytes actually remaining in the script before the allocation.

## Why it matters

Two problems follow from a crafted script, both reachable on attacker-influenced input:

- **Debug builds:** the `assert` aborts the whole process. `dogecoin_tx_sighash()` runs the `fromPubKey` through this function, so any sighash computed over a malicious script crashes the caller.
- **NDEBUG builds:** the `assert` is compiled out, so a multi-gigabyte `data_len` reaches `dogecoin_calloc()` and triggers a huge allocation attempt before `deser_bytes()` finally rejects it — a memory-exhaustion DoS.

## The fix

`dogecoin_script_get_ops()` already does the right thing: it checks `data_len > buf.len` and bails before allocating. This applies the same guard here, replacing the `assert` with a clean `goto err_out`, so an over-long push is rejected (`return false`) instead of aborting or over-allocating. `deser_bytes()` itself is bounds-safe, so the only behavioral change is failing *before* the allocation rather than after.

## Tests

Deterministic repro: a 7-byte script `{ 0x4e, 0xfe,0xff,0xff,0xff, 0xaa,0xbb }` (`OP_PUSHDATA4` declaring `0xFFFFFFFE` bytes) aborts pre-fix and returns false post-fix. Added as a regression case in `test_script_op_codeseperator`. Found while fuzzing `dogecoin_tx_sighash` under ASan+UBSan. Full suite passes under ASan+UBSan and the plain build.

## Notes for reviewers

This is independent of the thread-safety / id-reuse work — it touches only `script.c` and `tx_tests.c` and applies cleanly on `0.1.5-dev` as a standalone PR.
