### PR TITLE
protocol: bound getheaders locator count before allocating

### DIFF
--- a/src/protocol.c
+++ b/src/protocol.c
@@ -381,6 +381,15 @@ dogecoin_bool dogecoin_p2p_deser_msg_getheaders(vector_t* blocklocators, uint256
         return false;
     if (!deser_varlen(&vsize, buf))
         return false;
+    /* vsize is an attacker-controlled count read straight off the wire (up to
+       0xFFFFFFFF). Each locator that follows is a 32-byte hash, so a message can
+       legitimately declare at most buf->len / 32 of them. Without this check
+       vector_resize() below reallocates blocklocators to vsize * sizeof(void*)
+       (up to ~32 GB for vsize 0xFFFFFFFF) and NULL-fills it before a single hash
+       is read -- a memory-exhaustion DoS triggerable by a ~9-byte getheaders
+       message. Reject counts that cannot fit the remaining buffer. */
+    if (vsize > buf->len / DOGECOIN_HASH_LENGTH)
+        return false;
     vector_resize(blocklocators, vsize);
     for (unsigned int i = 0; i < vsize; i++) {
         uint256_t *hash = dogecoin_malloc(DOGECOIN_HASH_LENGTH);

--- a/test/protocol_tests.c
+++ b/test/protocol_tests.c
@@ -128,4 +128,21 @@ void test_protocol()
     vector_free(blocklocators, true);
     vector_free(blocklocators_check, true);
     cstr_free(p2p_msg, true);
+
+    /* Regression: a getheaders message whose locator count is larger than the
+       remaining buffer could possibly hold must be rejected before allocating.
+       Previously the unvalidated count was passed straight to vector_resize(),
+       so a ~9-byte message declaring 0xFFFFFFFF locators triggered a multi-
+       gigabyte allocation (memory-exhaustion DoS) before any hash was read. */
+    {
+        /* int32 version=1, then varint 0xFFFFFFFF, then nothing */
+        uint8_t bad[] = { 0x01,0x00,0x00,0x00, 0xfe, 0xff,0xff,0xff,0xff };
+        struct const_buffer bad_buf = { bad, sizeof(bad) };
+        vector_t *bad_locs = vector_new(1, free);
+        uint256_t bad_stop;
+        dogecoin_bool r = dogecoin_p2p_deser_msg_getheaders(bad_locs, bad_stop, &bad_buf);
+        u_assert_int_eq(r, false);
+        u_assert_uint32_eq((uint32_t)bad_locs->len, 0);
+        vector_free(bad_locs, true);
+    }
 }


### PR DESCRIPTION
# protocol: bound getheaders locator count before allocating

## What

`dogecoin_p2p_deser_msg_getheaders()` read the block-locator count straight off the wire and passed it directly to `vector_resize()`:

```c
if (!deser_varlen(&vsize, buf)) return false;
vector_resize(blocklocators, vsize);
```

`vsize` is fully attacker-controlled (up to `0xFFFFFFFF`). `vector_resize()` grows the vector to `vsize * sizeof(void*)` and NULL-fills every slot *before* the loop reads a single locator hash.

## Why it matters

A crafted ~9-byte getheaders message (int32 version + varint `0xFFFFFFFF`) drives a multi-gigabyte allocation — a memory-exhaustion DoS. On a peer-facing node this is **remotely triggerable** by anyone who can send a message, with no valid handshake state required beyond reaching the message handler.

## The fix

Each locator that follows the count is a 32-byte hash, so a well-formed message can declare at most `buf->len / DOGECOIN_HASH_LENGTH` of them. Reject any count larger than the remaining buffer can hold, before `vector_resize()`:

```c
if (vsize > buf->len / DOGECOIN_HASH_LENGTH)
    return false;
```

This is a tighter bound than a fixed cap and needs no magic constant; it mirrors the bound-before-allocate pattern used in the script and tx parsers.

## Tests

Deterministic repro: `{ 0x01,0,0,0, 0xfe,0xff,0xff,0xff,0xff }` drives a ~32 GB realloc pre-fix and returns false post-fix. Added as a regression case in `test_protocol`. Found while fuzzing the p2p deserializers under ASan+UBSan; the version / inv / addr deserializers were clean (their lengths are fixed or already bounded — the version user-agent is capped at 1024). Requires a `WITH_NET` build.

## Notes for reviewers

Independent of the other in-flight fixes — touches only `protocol.c` and `protocol_tests.c`, applies cleanly on `0.1.5-dev` as a standalone PR.
