### PR TITLE
net: dispatch only this message's payload to command handlers

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -192,7 +192,13 @@ void read_cb(struct bufferevent* bev, void* ctx)
             break;
         }
         if (buf.len >= hdr.data_len) {
-            struct const_buffer cmd_data_buf = {buf.p, buf.len};
+            /* Hand the command handler exactly this message's payload, not the
+               entire remaining receive buffer. Using buf.len here let a command
+               deserializer read past its own hdr.data_len boundary into the
+               bytes of the next pipelined message -- the per-message length
+               carried in the header was not enforced at dispatch (only the
+               buffer advance below used hdr.data_len). */
+            struct const_buffer cmd_data_buf = {buf.p, hdr.data_len};
             if ((node->state & NODE_CONNECTED) != NODE_CONNECTED) {
                 return;
             }


### PR DESCRIPTION
# net: dispatch only this message's payload to command handlers

## What

`read_cb()` framed each incoming message by its header length (`hdr.data_len`) for the buffer advance, but handed the command handler a `const_buffer` covering the **entire remaining receive buffer**:

```c
struct const_buffer cmd_data_buf = {buf.p, buf.len};
...
dogecoin_node_parse_message(node, &hdr, &cmd_data_buf);
buf.p += hdr.data_len;
buf.len -= hdr.data_len;
```

When multiple messages are pipelined in one read, a command deserializer could read past its own `hdr.data_len` boundary into the bytes of the following message. The per-message length from the header was enforced for advancing the stream but not for the dispatch itself.

## Why it matters

This is a framing / desync correctness issue rather than a memory-safety one: every command deserializer bounds its reads against the buffer length and fails cleanly at the end, so no out-of-bounds access occurs. But a handler — for example the `ping` nonce read, or the `inv` walk in a postcmd callback — could consume bytes belonging to the *next* message, mis-parsing the stream and desyncing the connection.

## The fix

Cap the dispatched buffer to `hdr.data_len` so each handler sees exactly its own payload, matching the length already used to advance the buffer:

```c
struct const_buffer cmd_data_buf = {buf.p, hdr.data_len};
```

## Tests

The existing protocol / net round-trip tests (version, verack, getheaders, inv, reorg) pass unchanged, since well-formed handlers already stop at the message boundary; the fix only constrains the malformed / pipelined case. The bug lives in `read_cb`, which is driven by a live `bufferevent`, so it has no standalone unit seam — the regression protection is the existing round-trip coverage plus the now-correct boundary.

## Notes for reviewers

Independent one-line correctness fix in `net.c`; applies cleanly on `0.1.5-dev`. Requires a `WITH_NET` build to compile.

A related observation for a separate change: the receive path does not verify the 4-byte payload checksum carried in the message header before dispatch. Bitcoin Core validates it; libdogecoin currently ignores it. That is a larger behavioral change (and the mock-message tests would need valid checksums), so it is intentionally **not** bundled here — flagging it for follow-up.
