### PR TITLE
net: verify message payload checksum before dispatch

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -202,6 +202,18 @@ void read_cb(struct bufferevent* bev, void* ctx)
             if ((node->state & NODE_CONNECTED) != NODE_CONNECTED) {
                 return;
             }
+            /* Verify the payload checksum carried in the header (first 4 bytes of
+               the double-SHA256 of the payload) before handing the message to a
+               command handler. The receive path previously parsed hdr.hash but
+               never checked it, so a corrupted or forged payload would be parsed
+               as if intact. This mirrors the checksum dogecoin_p2p_message_new()
+               writes when sending. */
+            uint256_t msghash;
+            dogecoin_hash((const uint8_t*)cmd_data_buf.p, hdr.data_len, msghash);
+            if (memcmp(msghash, hdr.hash, 4) != 0) {
+                dogecoin_node_misbehave(node);
+                return;
+            }
             dogecoin_node_parse_message(node, &hdr, &cmd_data_buf);
 
             buf.p = (const unsigned char*)buf.p + hdr.data_len;

--- a/test/protocol_tests.c
+++ b/test/protocol_tests.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 
 #include <dogecoin/chainparams.h>
+#include <dogecoin/hash.h>
 #include <dogecoin/utils.h>
 #include <dogecoin/protocol.h>
 #include <test/utest.h>
@@ -144,5 +145,36 @@ void test_protocol()
         u_assert_int_eq(r, false);
         u_assert_uint32_eq((uint32_t)bad_locs->len, 0);
         vector_free(bad_locs, true);
+    }
+
+    /* Regression: the receive path must verify the payload checksum carried in
+       the message header. dogecoin_p2p_message_new() writes the first 4 bytes of
+       the double-SHA256 of the payload; read_cb() now recomputes and compares it
+       before dispatch. Exercise that exact check here: a well-formed message
+       must validate, and any payload change must invalidate it. */
+    {
+        const char* payload = "checksum regression payload";
+        uint32_t plen = (uint32_t)strlen(payload);
+        cstring* m = dogecoin_p2p_message_new(dogecoin_chainparams_main.netmagic, DOGECOIN_MSG_VERSION, payload, plen);
+
+        struct const_buffer cbuf = { m->str, m->len };
+        dogecoin_p2p_msg_hdr chk_hdr;
+        dogecoin_p2p_deser_msghdr(&chk_hdr, &cbuf);
+        u_assert_uint32_eq(chk_hdr.data_len, plen);
+
+        /* cbuf now points at the payload; recompute and compare as read_cb does */
+        uint256_t good;
+        dogecoin_hash((const uint8_t*)cbuf.p, chk_hdr.data_len, good);
+        u_assert_int_eq(memcmp(good, chk_hdr.hash, 4), 0);   /* valid: matches */
+
+        /* corrupt one payload byte: the checksum must no longer match */
+        uint256_t bad;
+        uint8_t tampered[64];
+        memcpy(tampered, cbuf.p, chk_hdr.data_len);
+        tampered[0] ^= 0xff;
+        dogecoin_hash(tampered, chk_hdr.data_len, bad);
+        u_assert_true(memcmp(bad, chk_hdr.hash, 4) != 0);    /* tampered: rejected */
+
+        cstr_free(m, true);
     }
 }


### PR DESCRIPTION
# net: verify message payload checksum before dispatch

## What

The P2P message header carries a 4-byte checksum — the first 4 bytes of the double-SHA256 of the payload — and `dogecoin_p2p_deser_msghdr()` reads it into `hdr.hash`. But `read_cb()` never checked it. A payload corrupted in transit, or one forged by a peer so it doesn't match its advertised checksum, was parsed and dispatched to the command handlers as if intact. The integrity field the protocol provides was ignored entirely.

Bitcoin Core validates this checksum on receipt; libdogecoin did not.

## The fix

Recompute the double-SHA256 over the framed payload (now correctly bounded to `hdr.data_len` by the companion boundary fix) and compare its first 4 bytes against `hdr.hash` before calling `dogecoin_node_parse_message()`:

```c
uint256_t msghash;
dogecoin_hash((const uint8_t*)cmd_data_buf.p, hdr.data_len, msghash);
if (memcmp(msghash, hdr.hash, 4) != 0) {
    dogecoin_node_misbehave(node);
    return;
}
```

On mismatch the peer is treated as misbehaving and buffer processing stops, exactly as the existing oversize-message guard does. This mirrors the checksum that `dogecoin_p2p_message_new()` writes when sending, so well-formed traffic is unaffected.

## Tests

Every message built by `dogecoin_p2p_message_new()` already carries a valid checksum, so the existing protocol / net round-trip tests (version, verack, getheaders, inv, block download) pass unchanged. `test_reorg` drives the SPV header path directly and never enters `read_cb`, so it is unaffected.

Adds a regression case to `test_protocol`: it builds a message, confirms its checksum validates using the same `dogecoin_hash` + 4-byte compare `read_cb` uses, then flips a payload byte and asserts the checksum no longer matches. (Verified the assertion executes by temporarily corrupting the computation — it fails as expected.)

## Notes for reviewers

This is the companion to the message-boundary fix and builds on it (the checksum must be computed over exactly `hdr.data_len` bytes, which that fix establishes). It should land after, or together with, `net: dispatch only this message's payload to command handlers`. Requires a `WITH_NET` build.
