### PR TITLE
wallet: bound transaction record length when loading from disk

### DIFF
--- a/src/wallet.c
+++ b/src/wallet.c
@@ -45,6 +45,7 @@
 #endif
 
 #include <dogecoin/wallet.h>
+#include <dogecoin/protocol.h>
 #include <dogecoin/seal.h>
 
 #define COINBASE_MATURITY 100
@@ -913,11 +914,19 @@ dogecoin_bool dogecoin_wallet_load_address(dogecoin_wallet* wallet) {
 
 dogecoin_bool dogecoin_wallet_load_transaction(dogecoin_wallet* wallet, uint32_t reclen) {
     if (!wallet) return false;
+    /* reclen is read straight from the wallet file. A serialized wtx record
+       (u32 height + u256 hash + a transaction) cannot legitimately exceed the
+       maximum block/message payload, so reject anything larger before
+       allocating -- otherwise a corrupt or hostile file declaring e.g.
+       reclen=0xFFFFFFFF drives a ~4 GB allocation (memory-exhaustion DoS) and,
+       if the allocation fails, a NULL dereference in the fread below. */
+    if (reclen == 0 || reclen > DOGECOIN_MAX_P2P_MSG_SIZE) return false;
     unsigned char* buf = dogecoin_uchar_vla(reclen);
+    if (!buf) return false;
     struct const_buffer cbuf = {buf, reclen};
-    if (fread(buf, reclen, 1, wallet->dbfile) != 1) return false;
+    if (fread(buf, reclen, 1, wallet->dbfile) != 1) { dogecoin_free(buf); return false; }
     dogecoin_wtx *wtx = dogecoin_wallet_wtx_new();
-    if (!dogecoin_wallet_wtx_deserialize(wtx, &cbuf)) return false;
+    if (!dogecoin_wallet_wtx_deserialize(wtx, &cbuf)) { dogecoin_free(buf); dogecoin_wallet_wtx_free(wtx); return false; }
     dogecoin_free(buf);
     dogecoin_wallet_scrape_utxos(wallet, wtx);
     dogecoin_wallet_add_wtx_intern_move(wallet, wtx); // hands memory management over to the binary tree
@@ -1799,9 +1808,14 @@ int dogecoin_unregister_watch_address_with_node(char* address) {
                     }
                     free(buf);
                 } else if (rectype == WALLET_DB_REC_TYPE_TX) {
+                    /* Bound the record length from the file before allocating;
+                       see dogecoin_wallet_load_transaction() for rationale. */
+                    if (reclen == 0 || reclen > DOGECOIN_MAX_P2P_MSG_SIZE) return false;
                     unsigned char* buf = dogecoin_uchar_vla(reclen);
+                    if (!buf) return false;
                     struct const_buffer cbuf = {buf, reclen};
                     if (fread(buf, reclen, 1, wallet->dbfile) != 1) {
+                        dogecoin_free(buf);
                         return false;
                     }
 

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -116,6 +116,7 @@ extern void test_examples();
 #ifdef WITH_WALLET
 extern void test_wallet_basics();
 extern void test_wallet();
+extern void test_wallet_malformed_reclen();
 extern void test_wallet_reorg_utxo_update();
 extern void test_wallet_balance_accounts_for_spends();
 #endif
@@ -228,6 +229,7 @@ int main()
 #ifdef WITH_WALLET
     u_run_test(test_wallet_basics);
     u_run_test(test_wallet);
+    u_run_test(test_wallet_malformed_reclen);
     u_run_test(test_wallet_reorg_utxo_update);
     u_run_test(test_wallet_balance_accounts_for_spends);
 #endif

--- a/test/wallet_tests.c
+++ b/test/wallet_tests.c
@@ -222,7 +222,8 @@ void test_wallet_malformed_reclen()
     fclose(f);
 
     dogecoin_wallet* w = dogecoin_wallet_new(&dogecoin_chainparams_main);
-    int error = 0, created = 0;
+    int error = 0;
+    dogecoin_bool created = false;
     /* Must reject the oversized record rather than allocating ~4 GB / crashing. */
     u_assert_int_eq(dogecoin_wallet_load(w, path, &error, &created, false), false);
     dogecoin_wallet_free(w);

--- a/test/wallet_tests.c
+++ b/test/wallet_tests.c
@@ -196,6 +196,39 @@ void test_wallet()
     dogecoin_wallet_free(wallet);
 }
 
+/* Regression: a wallet file whose transaction record declares an enormous
+   length must be rejected at load, not turned into a multi-gigabyte allocation
+   (and a NULL-deref when that allocation fails). Craft a minimal file with a
+   valid header and a single TX record claiming reclen = 0xFFFFFFFF, then load
+   it and assert the loader returns false instead of crashing. */
+void test_wallet_malformed_reclen()
+{
+    static const unsigned char hdr_magic[4] = {0xA8, 0xF0, 0x11, 0xC5};
+    static const unsigned char rec_magic[4] = {0xC8, 0xF2, 0x69, 0x1E};
+    const char* path = "malformed_reclen_tests.wallet";
+    unlink(path);
+
+    FILE* f = fopen(path, "wb");
+    u_assert_int_eq(f != NULL, 1);
+    /* header: magic(4) + version(4, LE = 1) + genesis hash(32) */
+    fwrite(hdr_magic, 4, 1, f);
+    uint32_t ver = 1; fwrite(&ver, 4, 1, f);
+    fwrite(dogecoin_chainparams_main.genesisblockhash, 32, 1, f);
+    /* one TX record: rec_magic(4) + reclen varint (0xFE + 0xFFFFFFFF) + rectype(1 = TX = 2) */
+    fwrite(rec_magic, 4, 1, f);
+    unsigned char vlen[5] = {0xFE, 0xFF, 0xFF, 0xFF, 0xFF};
+    fwrite(vlen, 5, 1, f);
+    uint8_t rectype = 2; fwrite(&rectype, 1, 1, f);
+    fclose(f);
+
+    dogecoin_wallet* w = dogecoin_wallet_new(&dogecoin_chainparams_main);
+    int error = 0, created = 0;
+    /* Must reject the oversized record rather than allocating ~4 GB / crashing. */
+    u_assert_int_eq(dogecoin_wallet_load(w, path, &error, &created, false), false);
+    dogecoin_wallet_free(w);
+    unlink(path);
+}
+
 void test_wallet_basics()
 {
     unlink(wallettmpfile);


### PR DESCRIPTION
# wallet: bound transaction record length when loading from disk

## What

When loading a wallet from disk, two TX-record paths read a record length straight from the file and hand it to `dogecoin_uchar_vla()` (a `malloc` wrapper) with no upper bound and no NULL check, then `fread` into the result:

```c
unsigned char* buf = dogecoin_uchar_vla(reclen);   /* malloc(reclen) */
struct const_buffer cbuf = {buf, reclen};
if (fread(buf, reclen, 1, wallet->dbfile) != 1) return false;
```

`reclen` is a varint read directly from the wallet file (`deser_varlen_from_file`), so a corrupt or hostile file declaring `reclen = 0xFFFFFFFF` drives a ~4 GB allocation — a memory-exhaustion DoS. When that allocation fails, `malloc` returns NULL and the following `fread()` dereferences it, crashing the loader.

The same unbounded pattern appears at both TX-record sites: `dogecoin_wallet_load_transaction()` and the second record loop later in the load path.

## Reproduction

A 45-byte file is enough: a valid header (magic + version + genesis hash) followed by one TX record whose varint length is `0xFFFFFFFF`. Loading it under ASan aborts with an out-of-memory error before any payload is read:

```
==ERROR: AddressSanitizer: out of memory: allocator is trying to allocate 0xffffffff bytes
SUMMARY: AddressSanitizer: out-of-memory in malloc
```

## The fix

A serialized wtx record (a `uint32` height + a `uint256` hash + a transaction) cannot legitimately exceed the maximum block/message payload, since a transaction must fit in a block. So before allocating, reject `reclen == 0` or `reclen > DOGECOIN_MAX_P2P_MSG_SIZE`, and NULL-check the allocation:

```c
if (reclen == 0 || reclen > DOGECOIN_MAX_P2P_MSG_SIZE) return false;
unsigned char* buf = dogecoin_uchar_vla(reclen);
if (!buf) return false;
```

The same bound is applied at both TX-record sites. `4 * 1000 * 1000` (the existing `DOGECOIN_MAX_P2P_MSG_SIZE`) is far above any real wtx record but rejects the attack outright.

While here, this also frees `buf` on the `fread`-failure and `wtx_deserialize`-failure paths, which previously leaked it — and in `load_transaction` the `wtx_deserialize`-failure path leaked the `wtx` as well.

## Tests

Adds `test_wallet_malformed_reclen`, which crafts the oversized-record file in-process and asserts `dogecoin_wallet_load()` returns `false` instead of crashing. Verified the test triggers the OOM/crash without the fix and passes with it. All existing wallet tests (`test_wallet`, `test_wallet_basics`, reorg, UTXO, thread-safety, balance) continue to pass, so legitimate load/save round-trips are unaffected.

## Notes for reviewers

Standalone change — applies cleanly on `0.1.5-dev` with no dependency on other in-flight branches. Requires no special build flags. Adds an `#include <dogecoin/protocol.h>` to `wallet.c` for the size constant.
