### PR TITLE
seal: remove redundant free in software seed decryption

### DIFF
--- a/src/seal.c
+++ b/src/seal.c
@@ -1592,7 +1592,6 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_seed_with_sw(SEED seed, const int
     if (decrypted_actual_size == 0)
     {
         fprintf(stderr, "ERROR: AES decryption failed.\n");
-        dogecoin_free(encrypted_seed);
         return false;
     }
 


### PR DESCRIPTION
# seal: remove redundant free in software seed decryption

## What

`dogecoin_decrypt_seed_with_sw()` frees `encrypted_seed` unconditionally after `aes256_cbc_decrypt()` returns, then frees it a second time inside the following error branch:

```c
dogecoin_free(encrypted_seed);
if (decrypted_actual_size == 0) {
    fprintf(stderr, "ERROR: AES decryption failed.\n");
    dogecoin_free(encrypted_seed);   /* double free */
    return false;
}
```

The pointer is not reassigned between the two calls, so taking that branch is a double free.

The two sibling functions — `dogecoin_decrypt_hdnode_with_sw()` and `dogecoin_decrypt_mnemonic_with_sw()` — free their buffer exactly once and do not repeat it in the error branch. This looks like a copy/paste slip in the seed path; the fix brings it in line with the other two.

## Reachability

This is a **latent** defect, not a currently reachable one, and the commit message says so plainly.

The seed decrypt passes a fixed 64-byte input (`ENCRYPTED_SEED_SIZE`, a multiple of `AES_BLOCK_SIZE`) with padding disabled. `aes256_cbc_decrypt()` only returns `0` on a NULL/zero argument, on a size that is not a multiple of the block size, or on bad padding — none of which can happen here. So the `decrypted_actual_size == 0` branch cannot execute as the code stands.

It becomes a live double free the moment the input size is made variable, padding is enabled, or the decrypt contract changes. Removing the stray free closes that hazard at no cost.

## Testing

The encrypt → decrypt round trip in `test_tpm` still passes, and a direct in-memory encrypt/decrypt round trip confirms the seed path is unaffected. The change is a single-line deletion with no behavioural change on any reachable path.

## Notes for reviewers

Standalone, applies cleanly on `0.1.5-dev`. No dependency on other in-flight branches, no new build flags.
