### PR TITLE
cstr: fix integer overflow in cstr_alloc_min_sz buffer sizing

### DIFF
--- a/src/cstr.c
+++ b/src/cstr.c
@@ -22,18 +22,35 @@
 static int cstr_alloc_min_sz(cstring* s, size_t sz)
 {
     unsigned int shift;
-    unsigned int al_sz;
+    size_t al_sz;
     char* new_s;
 
+    /* Reject a size that would overflow when the NUL-overhead byte is added.
+       Without this, sz++ wraps to 0 and the rounding loop below would pick an
+       allocation far smaller than the caller asked for. */
+    if (sz == (size_t)-1) {
+        return 0;
+    }
     sz++; /* NULL overhead */
 
     if (s->alloc && (s->alloc >= sz)) {
         return 1;
     }
 
+    /* Round up to the next power of two. al_sz and the shift are computed in
+       size_t: the previous code used a 32-bit unsigned int and shifted a
+       signed int literal (1 << shift), which is undefined once shift reaches
+       31 and, for sizes above 2^31, either looped without terminating or
+       produced an allocation smaller than sz -- a heap overflow when the
+       caller (e.g. logdb record deserialization) then wrote sz bytes into it. */
     shift = 3;
-    while ((al_sz = (1 << shift)) < sz) {
+    while (shift < sizeof(size_t) * 8 && ((al_sz = ((size_t)1 << shift)) < sz)) {
         shift++;
+    }
+    /* If sz exceeds the largest representable power of two, fail rather than
+       wrap. */
+    if (shift >= sizeof(size_t) * 8) {
+        return 0;
     }
 
     new_s = dogecoin_realloc(s->str, al_sz);


### PR DESCRIPTION
# cstr: fix integer overflow in cstr_alloc_min_sz buffer sizing

## What

`cstr_alloc_min_sz()` rounds the requested size up to the next power of two:

```c
unsigned int shift, al_sz;
while ((al_sz = (1 << shift)) < sz) shift++;
```

For a large `sz` (it is a `size_t`) this is wrong in two ways:

- `1 << shift` shifts a signed `int` literal. At `shift == 31` this is undefined behaviour (left shift into the sign bit), and at `shift >= 32` it is fully undefined.
- `al_sz` is a 32-bit `unsigned int`, so it cannot represent the rounded size once `sz` exceeds 2^31, and the comparison against the `size_t sz` truncates.

For a request above 2^31 the loop either spins (the masked shift count cycles `al_sz` through small powers of two that never reach `sz`) or exits with an `al_sz` far smaller than `sz`. In the latter case `realloc()` returns a buffer smaller than requested while the caller goes on to write `sz` bytes into it — a heap buffer overflow.

This is reachable from untrusted input: logdb record deserialization reads a `uint32` length straight from the file and passes it to `cstr_resize()`, which calls this function.

## The fix

Compute the rounded size in `size_t`, shift `(size_t)1`, stop at the `size_t` width, and fail (`return 0`) rather than wrap if the request exceeds the largest representable power of two or if the `+1` NUL overhead would overflow. `realloc` failure is already handled by the existing NULL check, so an over-large request now fails cleanly instead of under-allocating.

## Testing

Power-of-two rounding for all normal sizes is unchanged — verified `100->128`, `1000->1024`, `4096->8192`, `100000->131072`. `test_cstr`, `test_buffer`, and the tx/script suites still pass. A direct test of a `> 2^31` resize previously tripped UBSan (`left shift of 1 by 31 places`); it now rounds correctly and fails the allocation cleanly.

## Notes for reviewers

Standalone, applies cleanly on `0.1.5-dev`. This is the root-cause fix; the companion logdb change adds an explicit length bound at the untrusted entry point as defence in depth.
