### PR TITLE
logdb: fix stack overflow and unbounded allocation in record deserialization

### DIFF
--- a/src/logdb/logdb_core.c
+++ b/src/logdb/logdb_core.c
@@ -39,6 +39,12 @@
 
 /* reduce sha256 hash to 8 bytes for checksum */
 #define kLOGDB_DEFAULT_HASH_LEN 16
+
+/* Upper bound on a single record's key or value length read from a logdb file.
+   A logdb record carries serialized wallet/chain data; 64 MiB is far above any
+   legitimate record while rejecting corrupt or hostile lengths (up to the 4 GiB
+   a uint32 varint can encode) before they reach the allocator. */
+#define LOGDB_MAX_RECORD_LEN (64u * 1024u * 1024u)
 #define kLOGDB_DEFAULT_VERSION 1
 
 static const unsigned char file_hdr_magic[4] = {0xF9, 0xAA, 0x03, 0xBA}; /* header magic */
@@ -563,8 +569,13 @@ logdb_bool logdb_record_deser_from_file(logdb_record* rec, logdb_log_db *db, enu
     unsigned char check[SHA256_DIGEST_LENGTH];
 
     /* prepate a buffer for the varint data (max 4 bytes) */
-    size_t buflen = sizeof(uint32_t);
-    uint8_t readbuf[sizeof(uint32_t)];
+    /* deser_varlen_file() writes the length prefix byte followed by up to a
+       uint32 of length data, so the buffer must hold sizeof(uint32_t) + 1
+       bytes. The previous sizeof(uint32_t) buffer was one byte too small and
+       overflowed by one byte on the wire (a stack buffer overflow driven by
+       untrusted record lengths). */
+    size_t buflen = sizeof(uint32_t) + 1;
+    uint8_t readbuf[sizeof(uint32_t) + 1];
 
     *error = LOGDB_SUCCESS;
 
@@ -600,9 +611,18 @@ logdb_bool logdb_record_deser_from_file(logdb_record* rec, logdb_log_db *db, enu
         return false;
     }
 
+    /* len is read straight from the file. Reject absurd lengths before resizing
+       so a corrupt or hostile record cannot drive a multi-gigabyte allocation
+       (memory-exhaustion DoS), and check the resize result rather than writing
+       into a buffer that may not have been grown. */
+    if (len > LOGDB_MAX_RECORD_LEN || !cstr_resize(rec->key, len))
+    {
+        *error = LOGDB_ERROR_DATASTREAM_ERROR;
+        return false;
+    }
+
     sha256_write(&ctx, readbuf, buflen);
 
-    cstr_resize(rec->key, len);
     if (fread(rec->key->str, 1, len, db->file) != len)
     {
         *error = LOGDB_ERROR_DATASTREAM_ERROR;
@@ -614,8 +634,14 @@ logdb_bool logdb_record_deser_from_file(logdb_record* rec, logdb_log_db *db, enu
     if (rec->mode == RECORD_TYPE_WRITE)
     {
         /* read value (not for delete mode) */
-        buflen = sizeof(uint32_t);
+        buflen = sizeof(uint32_t) + 1;
         if (!deser_varlen_file(&len, db->file, readbuf, &buflen))
+        {
+            *error = LOGDB_ERROR_DATASTREAM_ERROR;
+            return false;
+        }
+
+        if (len > LOGDB_MAX_RECORD_LEN || !cstr_resize(rec->value, len))
         {
             *error = LOGDB_ERROR_DATASTREAM_ERROR;
             return false;
@@ -623,7 +649,6 @@ logdb_bool logdb_record_deser_from_file(logdb_record* rec, logdb_log_db *db, enu
 
         sha256_write(&ctx, readbuf, buflen);
 
-        cstr_resize(rec->value, len);
         if (fread(rec->value->str, 1, len, db->file) != len)
         {
             *error = LOGDB_ERROR_DATASTREAM_ERROR;

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -465,8 +465,11 @@ int deser_varlen_file(uint32_t* lo, FILE* file, uint8_t* rawdata, size_t* buflen
     unsigned char c;
     const unsigned char bufp[sizeof(uint64_t)];
 
-    /* check min size of the buffer */
-    if (*buflen_inout < sizeof(len))
+    /* The caller's buffer must hold the 1-byte length prefix plus up to a
+       uint32 of length bytes (the 253/254/255 encodings write rawdata[0] then
+       up to sizeof(len) more bytes). Requiring only sizeof(len) here let a
+       caller pass a buffer one byte too small, overflowing it by one byte. */
+    if (*buflen_inout < sizeof(len) + 1)
         return false;
 
     if (fread(&c, 1, 1, file) != 1)


### PR DESCRIPTION
# logdb: fix stack overflow and unbounded allocation in record deserialization

`logdb_record_deser_from_file()` has two distinct flaws when reading a record from an untrusted logdb file.

## 1. Stack buffer overflow via `deser_varlen_file()`

The caller passes `readbuf[sizeof(uint32_t)]` (4 bytes) with `*buflen_inout` set to `sizeof(uint32_t)`. `deser_varlen_file()` writes the 1-byte length prefix at `rawdata[0]` and then, for the 253/254/255 encodings, copies up to a further `sizeof(uint32_t)` bytes at `rawdata + 1` — i.e. up to **5 bytes into a 4-byte buffer**. Its own capacity guard only checked `*buflen_inout < sizeof(len)`, so the one-byte-too-small buffer passed the check and overflowed by one byte.

ASan reports a stack-buffer-overflow WRITE in `memcpy_safe` (`serialize.c:494`) for any record that reaches the key/value length field, reproducible with a minimal crafted file:

```
WRITE of size 1 ... in memcpy_safe
  #1 deser_varlen_file serialize.c:494
  #2 logdb_record_deser_from_file logdb_core.c
  #3 logdb_load
```

Fixed on both sides: `deser_varlen_file()` now requires `sizeof(len) + 1` bytes, and the logdb caller's buffer is sized `sizeof(uint32_t) + 1`.

## 2. Unbounded allocation / ignored resize result

`len` is a `uint32` varint read straight from the file and was passed directly to `cstr_resize()` with the result ignored. A record declaring `len = 0xFFFFFFFF` drove a ~4 GB allocation (memory-exhaustion DoS), and had the resize failed the code would have written into a buffer that was never grown.

The fix rejects `len > LOGDB_MAX_RECORD_LEN` (64 MiB, far above any real record) and checks the `cstr_resize()` return before reading, for both the key and the value.

## Notes

The per-record sha256 update now happens after these checks, so a rejected record is not folded into the running hash (no effect on valid records). `test_logdb_memdb` and `test_logdb_rbtree`, which round-trip real records, still pass; a crafted file using each of the 253/254/255 length encodings is now rejected cleanly with no overflow or over-large allocation.

Standalone, applies cleanly on `0.1.5-dev`. Complementary to the `cstr_alloc_min_sz` integer-overflow fix (which hardens the allocator itself); this change stops the hostile length at the parser.
