### PR TITLE
cmake: build and run the Raccoon-G test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,25 @@ TARGET_SOURCES(tests ${visibility}
         test/zk_carrier_tests.c
 )
 ENDIF()
+IF(USE_RACCOON_G)
+TARGET_SOURCES(tests ${visibility}
+        test/raccoong_polyr_tests.c
+        test/raccoong_ntt_tests.c
+        test/raccoong_shake_tests.c
+        test/raccoong_xof_sample_q_tests.c
+        test/raccoong_matvec_tests.c
+        test/raccoong_keygen_t_tests.c
+        test/raccoong_keypair_tests.c
+        test/raccoong_gaussian_tests.c
+        test/raccoong_hd_derive_tests.c
+        test/raccoong_signature_serialize_tests.c
+        test/raccoong_buff_mu_tests.c
+        test/raccoong_chal_poly_tests.c
+        test/raccoong_hash_vec_tests.c
+        test/raccoong_sign_tests.c
+)
+TARGET_INCLUDE_DIRECTORIES(tests ${visibility} ${CMAKE_SOURCE_DIR})
+ENDIF()
 IF (USE_YUBIKEY)
     SET(LIBS ${LIBDOGECOIN_NAME} ${LIBYKPIV})
 ELSE()
@@ -587,6 +606,9 @@ ELSEIF (USE_TSS2)
     TARGET_LINK_LIBRARIES(tests ${LIBS} ${LIBTSS2})
 ELSE()
     TARGET_LINK_LIBRARIES(tests ${LIBS})
+ENDIF()
+IF(USE_RACCOON_G)
+    TARGET_LINK_LIBRARIES(tests m ${LIBMPFR} ${LIBGMP})
 ENDIF()
     ADD_TEST(NAME ${LIBDOGECOIN_NAME}_tests COMMAND tests)
     # move test/wordlist to build


### PR DESCRIPTION
# cmake: build and run the Raccoon-G test suite

## What

The autotools build (`Makefile.am`) compiles the Raccoon-G unit tests under `if USE_RACCOON_G / if USE_TESTS`. The CMake build never added those test sources to the `tests` target, even though `unittester.c` declares and calls them (`test_raccoong_polyr`, `_ntt`, `_gaussian`, `_sign`, …).

As a result a CMake build with `-DUSE_RACCOON_G=ON` either failed to link with undefined references to those test functions, or — where the registrations were not reached — silently skipped the **entire Raccoon-G known-answer suite**. The two build systems disagreed, and the CMake path, which is what most contributors and CI use, exercised none of the lattice correctness vectors.

## The fix

Add the 14 `raccoong_*_tests.c` sources to the `tests` target under `IF(USE_RACCOON_G)`, mirroring the autotools list, plus the two things those tests need that the CMake `tests` target was not providing:

- `TARGET_INCLUDE_DIRECTORIES(tests ... CMAKE_SOURCE_DIR)` so the tests can `#include "src/raccoon_g/*.h"` the way they already do under autotools, and
- the `m` / MPFR / GMP libraries the Gaussian sampler and bignum code require, using the same `${LIBMPFR} ${LIBGMP}` variables the library target links.

## Result

With this change a `-DUSE_RACCOON_G=ON` CMake build runs all 14 component KATs — `polyr`, `ntt`, `shake`, `xof_sample_q`, `matvec`, `keygen_t`, `keypair`, `gaussian`, `hd_derive`, `signature_serialize`, `buff_mu`, `chal_poly`, `hash_vec`, and `sign` — all of which pass against the committed reference vectors in `test/data/`.

As an independent check, every committed `test/data/raccoong_*_vectors.h` was regenerated from the pinned upstream reference (`p-11/lattice-hd-wallets` @ `461a5ed`) via the `contrib/raccoon_g/gen_*` scripts and confirmed byte-identical, so the suite now wired into CMake is exercising vectors that match the reference implementation.

## Notes for reviewers

Build-system change only; no source or vector changes. Standalone, applies cleanly on `0.1.5-dev`. Requires GMP/MPFR (already required by `USE_RACCOON_G`).
