### PR TITLE
cmake: link liboqs when USE_LIBOQS is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,7 @@ IF(USE_YUBIKEY)
 ENDIF()
 IF(USE_LIBOQS)
     ADD_DEFINITIONS(-DUSE_LIBOQS=1)
+    FIND_LIBRARY(LIBOQS NAMES oqs REQUIRED)
 ENDIF()
 IF(USE_RACCOON_G)
     FIND_LIBRARY(LIBGMP NAMES gmp REQUIRED)
@@ -455,6 +456,14 @@ TARGET_SOURCES(${LIBDOGECOIN_NAME} PUBLIC
 
 IF(WIN32 AND USE_TPM2)
     TARGET_LINK_LIBRARIES(${LIBDOGECOIN_NAME} tbs ncrypt crypt32)
+ENDIF()
+
+# Link liboqs into the core library when enabled. pqc_dilithium.c / pqc_falcon.c
+# call OQS_SIG_* directly, so without this link any executable that pulls in the
+# PQC wrappers (the test runner, such, spvnode) fails to link. The autotools
+# build adds -loqs to LIBS in configure.ac; this mirrors that for CMake.
+IF(USE_LIBOQS)
+    TARGET_LINK_LIBRARIES(${LIBDOGECOIN_NAME} ${LIBOQS})
 ENDIF()
 
 # Link the Linux TPM2 (TSS2) backend into the core library regardless of net,


### PR DESCRIPTION
# cmake: link liboqs when USE_LIBOQS is enabled

## What

The CMake build compiles `src/pqc_dilithium.c` and `src/pqc_falcon.c` under `IF(USE_LIBOQS)` but never links the liboqs library. Those sources call `OQS_SIG_new` / `OQS_SIG_keypair` / `OQS_SIG_sign` / `OQS_SIG_verify` / `OQS_SIG_free` directly, so while the static `libdogecoin` archive builds, any executable that pulls the PQC wrappers in — the test runner, `such`, `spvnode` — fails at link time with undefined references to the `OQS_SIG_*` symbols.

In practice this means `-DUSE_LIBOQS=ON` produces an unusable CMake build: the feature compiles but nothing that uses it can be linked.

## The fix

The autotools build handles this in `configure.ac` (`AC_CHECK_LIB([oqs]...)` appends `-loqs` to `LIBS`). Mirror that for CMake:

```cmake
IF(USE_LIBOQS)
    ADD_DEFINITIONS(-DUSE_LIBOQS=1)
    FIND_LIBRARY(LIBOQS NAMES oqs REQUIRED)
ENDIF()
...
IF(USE_LIBOQS)
    TARGET_LINK_LIBRARIES(${LIBDOGECOIN_NAME} ${LIBOQS})
ENDIF()
```

Linking `${LIBOQS}` into the core library means every dependent target inherits it.

## Verification

With `-DUSE_LIBOQS=ON` the `tests` target now links and runs — previously it failed with undefined references to `OQS_SIG_new` et al. The Dilithium2 and Falcon-512 round-trips in `test_transaction` pass.

## Notes for reviewers

Build-system change only. Standalone, applies cleanly on `0.1.5-dev`. Requires liboqs to be installed (as `USE_LIBOQS` already implies).
