### PR TITLE
test: assert PQC wrapper output lengths and reject tampered inputs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,7 @@ IF(USE_YUBIKEY)
 ENDIF()
 IF(USE_LIBOQS)
     ADD_DEFINITIONS(-DUSE_LIBOQS=1)
+    FIND_LIBRARY(LIBOQS NAMES oqs REQUIRED)
 ENDIF()
 IF(USE_RACCOON_G)
     FIND_LIBRARY(LIBGMP NAMES gmp REQUIRED)
@@ -455,6 +456,14 @@ TARGET_SOURCES(${LIBDOGECOIN_NAME} PUBLIC
 
 IF(WIN32 AND USE_TPM2)
     TARGET_LINK_LIBRARIES(${LIBDOGECOIN_NAME} tbs ncrypt crypt32)
+ENDIF()
+
+# Link liboqs into the core library when enabled. pqc_dilithium.c / pqc_falcon.c
+# call OQS_SIG_* directly, so without this link any executable that pulls in the
+# PQC wrappers (the test runner, such, spvnode) fails to link. The autotools
+# build adds -loqs to LIBS in configure.ac; this mirrors that for CMake.
+IF(USE_LIBOQS)
+    TARGET_LINK_LIBRARIES(${LIBDOGECOIN_NAME} ${LIBOQS})
 ENDIF()
 
 # Link the Linux TPM2 (TSS2) backend into the core library regardless of net,

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -751,6 +751,20 @@ void test_transaction()
     // verify signature
     u_assert_true(dogecoin_falcon512_verify(pk, pk_len, msg, sizeof msg, sig, sig_len));
 
+    // wrapper output lengths must match the algorithm's fixed sizes, and the
+    // verifier must reject a tampered message, a tampered signature, and a
+    // wrong-length public key. These guard against the wrapper silently
+    // mangling lengths or skipping validation.
+    u_assert_true(pk_len == 897 && sig_len > 0 && sig_len <= 752);
+    {
+        uint8_t bad_msg[32]; memcpy(bad_msg, msg, sizeof msg); bad_msg[0] ^= 0xff;
+        u_assert_true(!dogecoin_falcon512_verify(pk, pk_len, bad_msg, sizeof bad_msg, sig, sig_len));
+        uint8_t* bad_sig = malloc(sig_len); memcpy(bad_sig, sig, sig_len); bad_sig[sig_len/2] ^= 0xff;
+        u_assert_true(!dogecoin_falcon512_verify(pk, pk_len, msg, sizeof msg, bad_sig, sig_len));
+        free(bad_sig);
+        u_assert_true(!dogecoin_falcon512_verify(pk, pk_len - 1, msg, sizeof msg, sig, sig_len));
+    }
+
     // compute commit = SHA256(pk||sig)
     uint8_t commit32[32];
     u_assert_true(dogecoin_falcon512_commit_bytes(pk, pk_len, sig, sig_len, commit32));
@@ -776,6 +790,17 @@ void test_transaction()
     u_assert_true(dogecoin_dilithium2_keypair(&dpk, &dpk_len, &dsk, &dsk_len));
     u_assert_true(dogecoin_dilithium2_sign(dsk, dsk_len, msg, sizeof msg, &dsig, &dsig_len));
     u_assert_true(dogecoin_dilithium2_verify(dpk, dpk_len, msg, sizeof msg, dsig, dsig_len));
+
+    // wrapper length/negative checks (see Falcon block above for rationale)
+    u_assert_true(dpk_len == 1312 && dsig_len > 0 && dsig_len <= 2420);
+    {
+        uint8_t bad_msg[32]; memcpy(bad_msg, msg, sizeof msg); bad_msg[0] ^= 0xff;
+        u_assert_true(!dogecoin_dilithium2_verify(dpk, dpk_len, bad_msg, sizeof bad_msg, dsig, dsig_len));
+        uint8_t* bad_sig = malloc(dsig_len); memcpy(bad_sig, dsig, dsig_len); bad_sig[dsig_len/2] ^= 0xff;
+        u_assert_true(!dogecoin_dilithium2_verify(dpk, dpk_len, msg, sizeof msg, bad_sig, dsig_len));
+        free(bad_sig);
+        u_assert_true(!dogecoin_dilithium2_verify(dpk, dpk_len - 1, msg, sizeof msg, dsig, dsig_len));
+    }
 
     uint8_t dcommit32[32];
     u_assert_true(dogecoin_dilithium2_commit_bytes(dpk, dpk_len, dsig, dsig_len, dcommit32));


### PR DESCRIPTION
# test: assert PQC wrapper output lengths and reject tampered inputs

## What

The Dilithium2 / Falcon-512 coverage in `test_transaction` only exercised the happy path — keygen, sign, verify, commit round-trip. It never checked that the wrapper-reported key and signature lengths match the algorithm's fixed sizes, nor that the verifier rejects bad input.

## The change

For both algorithms, add:

- **length assertions** — Falcon `pk == 897`, `sig <= 752`; Dilithium `pk == 1312`, `sig <= 2420` — which catch a wrapper that truncates or mis-sizes its outputs;
- **negative cases** — a tampered message, a tampered signature, and a wrong (nonzero) public-key length must all fail verification.

## Why

These behaviours were cross-checked out of tree against direct liboqs calls: a signature produced by the libdogecoin wrapper verifies under a raw `OQS_SIG_verify` and vice versa, and the wrapper lengths match `alg->length_public_key` / `alg->length_signature` exactly. That confirms the wrappers are faithful pass-throughs; these in-tree additions lock in the length and negative-path behaviour so a future regression in the wrapper layer is caught by the test suite rather than slipping through.

The tamper assertions were confirmed live (not vacuous) by temporarily making verification wrongly accept and observing the test fail.

## Notes for reviewers

Requires a `USE_LIBOQS` build. Depends on the companion change that links liboqs into the CMake build ("cmake: link liboqs when USE_LIBOQS is enabled") — without it the test runner does not link under CMake.
