### PR TITLE
seal: use constant-time comparison for password verification hashes

### DIFF
--- a/include/dogecoin/mem.h
+++ b/include/dogecoin/mem.h
@@ -60,6 +60,7 @@ LIBDOGECOIN_API void dogecoin_free(void* ptr);
 LIBDOGECOIN_API errno_t memset_safe(volatile void *v, rsize_t smax, int c, rsize_t n);
 LIBDOGECOIN_API void* memcpy_safe(void* destination, const void* source, size_t count);
 LIBDOGECOIN_API volatile void* dogecoin_mem_zero(volatile void* dst, size_t len);
+LIBDOGECOIN_API int dogecoin_mem_cmp_ct(const void* a, const void* b, size_t len);
 
 LIBDOGECOIN_API uint8_t* dogecoin_uint8_vla(size_t size);
 LIBDOGECOIN_API uint32_t* dogecoin_uint32_vla(size_t size);

--- a/src/mem.c
+++ b/src/mem.c
@@ -246,6 +246,33 @@ volatile void* dogecoin_mem_zero(volatile void* dst, size_t len)
     return 0;
 }
 
+/**
+ * @brief Constant-time memory comparison.
+ *
+ * Compares len bytes of a and b without short-circuiting on the first
+ * differing byte, so the running time depends only on len and not on the
+ * contents or on the position of the first difference. Use this in place of
+ * memcmp() whenever either operand is secret or secret-derived (key material,
+ * MACs, password-derived verification hashes), where a data-dependent
+ * comparison time can leak information.
+ *
+ * @param a First buffer.
+ * @param b Second buffer.
+ * @param len Number of bytes to compare.
+ * @return 0 if the buffers are equal, non-zero otherwise.
+ */
+int dogecoin_mem_cmp_ct(const void* a, const void* b, size_t len)
+{
+    const volatile uint8_t* pa = (const volatile uint8_t*)a;
+    const volatile uint8_t* pb = (const volatile uint8_t*)b;
+    volatile uint8_t diff = 0;
+    size_t i;
+    for (i = 0; i < len; i++) {
+        diff |= (uint8_t)(pa[i] ^ pb[i]);
+    }
+    return diff;
+}
+
 uint8_t* dogecoin_uint8_vla(size_t size)
 {
     uint8_t* outarray;

--- a/src/seal.c
+++ b/src/seal.c
@@ -1540,7 +1540,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_seed_with_sw(SEED seed, const int
     sha512_raw(derived_verification_key, AES_KEY_SIZE, derived_verification_key_hash);
 
     // Compare the derived verification key hash with the stored one
-    if (memcmp(stored_verification_key_hash, derived_verification_key_hash, SHA512_DIGEST_LENGTH) != 0)
+    if (dogecoin_mem_cmp_ct(stored_verification_key_hash, derived_verification_key_hash, SHA512_DIGEST_LENGTH) != 0)
     {
         fprintf(stderr, "ERROR: Incorrect password.\n");
         fclose(fp);
@@ -2388,7 +2388,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_hdnode_with_sw(dogecoin_hdnode* o
     sha512_raw(derived_verification_key, AES_KEY_SIZE, derived_verification_key_hash);
 
     // Compare the derived verification key hash with the stored one
-    if (memcmp(stored_verification_key_hash, derived_verification_key_hash, SHA512_DIGEST_LENGTH) != 0)
+    if (dogecoin_mem_cmp_ct(stored_verification_key_hash, derived_verification_key_hash, SHA512_DIGEST_LENGTH) != 0)
     {
         fprintf(stderr, "ERROR: Incorrect password.\n");
         fclose(fp);
@@ -3240,7 +3240,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_mnemonic_with_sw(MNEMONIC mnemoni
     sha512_raw(derived_verification_key, AES_KEY_SIZE, derived_verification_key_hash);
 
     // Compare the derived verification key hash with the stored one
-    if (memcmp(stored_verification_key_hash, derived_verification_key_hash, SHA512_DIGEST_LENGTH) != 0)
+    if (dogecoin_mem_cmp_ct(stored_verification_key_hash, derived_verification_key_hash, SHA512_DIGEST_LENGTH) != 0)
     {
         fprintf(stderr, "ERROR: Incorrect password.\n");
         fclose(fp);


### PR DESCRIPTION
# seal: use constant-time comparison for password verification hashes

## What

The three software decrypt paths (seed, hdnode, mnemonic) verify the entered
password by comparing a PBKDF2 + SHA-512 derived verification hash against the
stored one with plain `memcmp`:

```c
if (memcmp(stored_verification_key_hash,
           derived_verification_key_hash, SHA512_DIGEST_LENGTH) != 0)
```

`memcmp` short-circuits on the first differing byte, so its running time depends
on the length of the matching prefix — a classic data-dependent comparison over
secret-derived material.

## Measurement

A dudect-style timing measurement confirms the leak is real at the
microarchitectural level: comparison time increases monotonically with the
position of the first mismatch (~0.8 cycle spread across a 64-byte buffer;
Welch |t| in the hundreds over 2M samples). A branchless compare is flat across
mismatch positions (spread within noise, and non-monotonic — consistent with no
signal), and the fix's compiled `-O2` form was confirmed position-independent.

## Severity (stated honestly)

Practical exploitability here is **low**. The compared values are SHA-512 hashes
of a PBKDF2-stretched key, so an attacker cannot steer a password guess to
incrementally match more bytes of the stored hash — that would require a
preimage, and each guess produces an essentially random 64-byte hash. The
byte-at-a-time timing attack that motivates constant-time MAC comparison does
not transfer to this construction.

This change is therefore **hardening**, not a fix for a directly exploitable
oracle. It is included because constant-time comparison of secret-derived
material is cheap, unambiguously correct, and removes a footgun if this code is
later refactored so the compared values become attacker-influenceable.

## The change

Add `dogecoin_mem_cmp_ct()` alongside the existing secure-memory helpers in
`mem.c` — a branchless OR-accumulate of byte XORs through `volatile` pointers,
matching `memcmp`'s zero / non-zero contract (which is all these call sites
test) — and use it at the three verification sites.

Verified: equal / unequal / zero-length behaviour matches `memcmp`; the
compiled `-O2` function is position-independent; the encrypt→decrypt round trips
still pass.

## Notes for reviewers

Standalone, applies cleanly on `0.1.5-dev`. The new helper is general-purpose and
available for any future secret-comparison site.
