### PR TITLE
serialize: prevent length truncation in ser_str / ser_varstr

### DIFF
--- a/src/serialize.c
+++ b/src/serialize.c
@@ -175,7 +175,21 @@ void ser_str(cstring* s, const char* s_in, size_t maxlen)
 {
     size_t slen = strnlen(s_in, maxlen);
 
-    ser_varlen(s, slen);
+    /* ser_varlen() takes a uint32_t length, and the varint format used here is
+       uint32-bounded on both the write and read sides. Passing a size_t length
+       above UINT32_MAX would silently truncate the length prefix while
+       ser_bytes() still wrote the full slen bytes, producing a prefix/data
+       mismatch (a corrupt, non-round-trippable serialization). No current
+       caller reaches this (maxlen is always small), but guard it so the output
+       can never be corrupt: a length we cannot represent is serialized as an
+       empty string. Use a runtime check rather than assert(), which is compiled
+       out in release builds. */
+    if (slen > UINT32_MAX) {
+        ser_varlen(s, 0);
+        return;
+    }
+
+    ser_varlen(s, (uint32_t)slen);
     ser_bytes(s, s_in, slen);
 }
 
@@ -196,7 +210,16 @@ void ser_varstr(cstring* s, cstring* s_in)
         return;
     }
 
-    ser_varlen(s, s_in->len);
+    /* See ser_str(): the varint length is uint32-bounded, so a cstring longer
+       than UINT32_MAX would truncate the length prefix while the full s_in->len
+       bytes are written, corrupting the stream. Guard against it (runtime check,
+       not assert) by emitting an empty string for an unrepresentable length. */
+    if (s_in->len > UINT32_MAX) {
+        ser_varlen(s, 0);
+        return;
+    }
+
+    ser_varlen(s, (uint32_t)s_in->len);
     ser_bytes(s, s_in->str, s_in->len);
 }
 


### PR DESCRIPTION
# serialize: prevent length truncation in ser_str / ser_varstr

## What

`ser_str()` and `ser_varstr()` pass a `size_t` length to `ser_varlen()`, whose
parameter is `uint32_t`, and then write the full length's worth of bytes with
`ser_bytes()`:

```c
void ser_varstr(cstring* s, cstring* s_in) {
    ...
    ser_varlen(s, s_in->len);          /* size_t -> uint32_t (truncates) */
    ser_bytes(s, s_in->str, s_in->len);/* writes full size_t length */
}
```

For a length above `UINT32_MAX` the length prefix silently truncates while the
data does not, so the serialized stream's length prefix disagrees with the bytes
that follow — a corrupt, non-round-trippable serialization. Demonstration: a
`size_t` length of `0x100000005` is written as a prefix of `5` while `ser_bytes`
still appends `0x100000005` bytes.

## Reachability

Latent. `ser_str`'s length is bounded by its `maxlen` argument (always small
in-tree), and the `ser_varstr` call sites serialize transaction scripts that
come from already-bounded deserialization. So this is a correctness defect in
public serialization primitives rather than a presently reachable one — the
write-side mirror of the read-side length-bound issues addressed elsewhere in
this series.

## Fix

Guard both functions: if the length exceeds `UINT32_MAX`, serialize an empty
string (length 0, no data) instead of emitting a prefix that cannot match the
payload. A runtime check is used rather than `assert()`, matching the existing
convention in `tx.c` / `script.c` that attacker-influenceable sizes get a
runtime check (assert is compiled out in release builds). The varint format here
is `uint32`-bounded on both read and write sides, so refusing to emit an
unrepresentable length is the correct closed behaviour.

## Testing

- A normal string still round-trips: `ser_varstr` → `deser_varstr` returns the
  identical bytes.
- The oversize-length path emits a single `0x00` and reads nothing from the data
  pointer (verified with a crafted over-length `cstring`).
- `test_tx_serialization` and `test_scripts` still pass.
- A separate round-trip fuzzer (build tx → serialize → deserialize →
  re-serialize → compare) shows 0 mismatches over 500k iterations for all
  transactions with ≥ 1 input.

## Notes for reviewers

Standalone, applies cleanly on `0.1.5-dev`. The other direct `ser_varlen(x->len)`
sites were reviewed and pass lengths bounded by construction, so they are left
unchanged.
