### PR TITLE
psbt: bound key/value lengths before allocation in deser_psbt_kv

### DIFF
--- a/src/psbt.c
+++ b/src/psbt.c
@@ -167,6 +167,7 @@ static dogecoin_bool deser_psbt_kv(struct const_buffer *buf,
 
     if (!deser_varlen(&klen, buf)) return false;
     if (klen == 0) return true; /* separator */
+    if (klen > buf->len) return false; /* declared key length exceeds remaining input */
 
     *key = dogecoin_malloc(klen);
     if (!deser_bytes(*key, buf, klen)) { dogecoin_free(*key); *key = NULL; return false; }
@@ -174,6 +175,7 @@ static dogecoin_bool deser_psbt_kv(struct const_buffer *buf,
 
     if (!deser_varlen(&vlen, buf)) { dogecoin_free(*key); *key = NULL; return false; }
     if (vlen > 0) {
+        if (vlen > buf->len) { dogecoin_free(*key); *key = NULL; return false; }
         *val = dogecoin_malloc(vlen);
         if (!deser_bytes(*val, buf, vlen)) {
             dogecoin_free(*key); dogecoin_free(*val);


### PR DESCRIPTION
# psbt: bound key/value lengths before allocation in deser_psbt_kv

**Branch:** `psbt-fix-kv-oom`
**Base:** `0.1.5-dev-psbt`
**Severity:** Denial of service (availability)

## Summary

`deser_psbt_kv()` read attacker-controlled key and value lengths from a
PSBT byte stream and passed them directly to `dogecoin_malloc()` **before**
validating them against the bytes actually remaining in the input buffer.
A crafted PSBT can declare a multi-gigabyte key or value length in only a
few bytes, forcing an enormous allocation and an out-of-memory abort.

## Impact

Remote denial of service. Any code path that deserializes an untrusted
PSBT — wallet import, PSBT combiner, RPC — can be crashed with an input on
the order of a dozen bytes. No memory corruption; impact is availability.

## Root cause

The key/value reader allocated `klen` / `vlen` bytes via `dogecoin_malloc`
prior to any bound check. `deser_bytes()` correctly bounds the subsequent
*read*, so the parser never over-read — but the oversized *allocation*
happened first regardless. The defect was purely the premature allocation.

## Fix

Reject any declared length that exceeds the remaining buffer
(`klen > buf->len`, `vlen > buf->len`) before allocating. A key or value
can never legitimately exceed the bytes left in the input, so no
valid-input behaviour changes.

```c
if (!deser_varlen(&klen, buf)) return false;
if (klen == 0) return true; /* separator */
if (klen > buf->len) return false;            /* added: key bound */
*key = dogecoin_malloc(klen);
...
if (vlen > 0) {
    if (vlen > buf->len) {                     /* added: value bound */
        dogecoin_free(*key); *key = NULL; return false;
    }
    *val = dogecoin_malloc(vlen);
    ...
}
```

## How it was found / reproduction

Found by libFuzzer against the PSBT deserializer:

```
==ERROR: libFuzzer: out-of-memory (malloc(2854581247))
  #10 deser_psbt_kv            src/psbt.c
  #11 dogecoin_psbt_deserialize src/psbt.c
```

With the fix, 200,000 fuzz iterations run clean — no OOM, bounded RSS.

## Related

Same class as the already-accepted unbounded-allocation fixes
(`fix-logdb-reclen`, `fix-map-idx-collision`, `fix-cstr-alloc-overflow`):
a length field read from untrusted input drives an allocation without a
bound check against available data.
