### PR TITLE
block: fix error-path leak in dogecoin_block_header_deserialize

### DIFF
--- a/src/block.c
+++ b/src/block.c
@@ -322,28 +322,31 @@ void print_block(dogecoin_auxpow_block* block) {
  */
 int dogecoin_block_header_deserialize(dogecoin_block_header* header, struct const_buffer* buf, const dogecoin_chainparams *params, arith_uint256* chainwork) {
     dogecoin_auxpow_block* block = dogecoin_auxpow_block_new();
+    int ret = false;
     if (!deser_s32(&block->header->version, buf))
-        return false;
+        goto cleanup;
     if (!deser_u256(block->header->prev_block, buf))
-        return false;
+        goto cleanup;
     if (!deser_u256(block->header->merkle_root, buf))
-        return false;
+        goto cleanup;
     if (!deser_u32(&block->header->timestamp, buf))
-        return false;
+        goto cleanup;
     if (!deser_u32(&block->header->bits, buf))
-        return false;
+        goto cleanup;
     if (!deser_u32(&block->header->nonce, buf))
-        return false;
+        goto cleanup;
     dogecoin_block_header_copy(header, block->header);
     if ((block->header->version & 0x100) != 0 && buf->len) {
         if (!deserialize_dogecoin_auxpow_block(block, buf, params, chainwork)) {
             printf("%s:%d:%s:%s\n", __FILE__, __LINE__, __func__, strerror(errno));
-            return false;
+            goto cleanup;
         }
         dogecoin_block_header_copy(header, block->header);
     }
+    ret = true;
+cleanup:
     dogecoin_auxpow_block_free(block);
-    return true;
+    return ret;
     }
 
 int deserialize_dogecoin_auxpow_block(dogecoin_auxpow_block* block, struct const_buffer* buffer, const dogecoin_chainparams *params, arith_uint256* chainwork) {


### PR DESCRIPTION
## What

`dogecoin_block_header_deserialize` allocates an auxpow block up front via
`dogecoin_auxpow_block_new()` (header, parent coinbase tx, parent header),
but every early `return false` — the six header-field parse failures and
the auxpow-parse failure — returned without freeing it. Only the success
path reached `dogecoin_auxpow_block_free`.

## Why it matters

Any malformed block header leaks the entire allocation. This is reachable
from untrusted p2p block data, so a peer sending malformed headers leaks
memory on every one. Found by fuzzing: LeakSanitizer fires on the first
malformed input.

## The fix

A single `goto cleanup` exit so all paths free the allocation:

```c
dogecoin_auxpow_block* block = dogecoin_auxpow_block_new();
int ret = false;
if (!deser_s32(&block->header->version, buf))
    goto cleanup;
/* ... each early failure goes to cleanup ... */
ret = true;
cleanup:
    dogecoin_auxpow_block_free(block);
    return ret;
```

`deserialize_dogecoin_auxpow_block` does not free `block` on its own error
paths, so the single outer free is not a double free.

## Scope note

This PR originally also included auxpow merkle-count hardening (the
`(uint32_t*)&uint8_t` type-pun and bounds). That work duplicates #334 and
has been dropped here — the merkle fix belongs to #334, which this PR does
not touch. This PR is now narrowly the error-path allocation leak in
`dogecoin_block_header_deserialize`, which #334 does not address.

## How it was found

`fuzz/fuzz_block.c` (added in #351) over `dogecoin_block_header_deserialize`:
LeakSanitizer aborts on the first malformed input pre-fix, and the harness
runs cleanly post-fix.
