### PR TITLE
protocol: bound getheaders locator count before allocation

### DIFF
--- a/src/protocol.c
+++ b/src/protocol.c
@@ -381,6 +381,12 @@ dogecoin_bool dogecoin_p2p_deser_msg_getheaders(vector_t* blocklocators, uint256
         return false;
     if (!deser_varlen(&vsize, buf))
         return false;
+    /* Each locator is a 32-byte hash that must be present in the buffer;
+     * a larger count is malformed and would force an oversized allocation
+     * in vector_resize (remote DoS via an unauthenticated getheaders). */
+    if (vsize > buf->len / sizeof(uint256_t)) {
+        return false;
+    }
     vector_resize(blocklocators, vsize);
     for (unsigned int i = 0; i < vsize; i++) {
         uint256_t *hash = dogecoin_malloc(DOGECOIN_HASH_LENGTH);


### PR DESCRIPTION
# protocol: bound getheaders locator count before allocation

**File:** `src/protocol.c` (`dogecoin_p2p_deser_msg_getheaders`)
**Severity:** Remote unauthenticated denial of service (memory exhaustion)

## Summary

`dogecoin_p2p_deser_msg_getheaders` reads a block-locator count (`vsize`)
from an untrusted `getheaders` p2p message and passes it directly to
`vector_resize()` with no bound:

```c
if (!deser_varlen(&vsize, buf))
    return false;
vector_resize(blocklocators, vsize);   // vsize fully attacker-controlled
```

`vector_resize` -> `vector_grow` eagerly allocates capacity for `vsize`
pointers, and `vector_resize` then NULL-initializes every slot:

```c
if (!vector_grow(vec, newsz)) return false;
for (i = vec->len; i < newsz; i++)
    vec->data[i] = NULL;               // touches every slot -> commits memory
```

A peer sending a `getheaders` message that declares `vsize = 0xFFFFFFFF`
forces an allocation of `0xFFFFFFFF * sizeof(void*)` (~34 GB on 64-bit) and
a loop that writes to every slot, committing the pages. The triggering
message is only a few bytes.

## Impact

Remote, unauthenticated denial of service. `getheaders` is processed from
any connected peer with no authentication. A single small message can
exhaust memory and crash or OOM-kill the node.

## Root cause

The locator count is used to size an allocation before being validated
against the data actually available. A block locator is a sequence of
32-byte hashes; the message cannot legitimately contain more hashes than
the buffer holds.

## Fix

Bound `vsize` against the remaining buffer before resizing:

```c
if (!deser_varlen(&vsize, buf))
    return false;
if (vsize > buf->len / sizeof(uint256_t)) {
    return false;
}
vector_resize(blocklocators, vsize);
```

This mirrors Bitcoin Core's `MAX_LOCATOR_SZ` guard on the same message,
generalized to the buffer length. (An explicit `MAX_LOCATOR_SZ`-style cap,
e.g. `vsize > 101`, could be added as a tighter semantic bound; the
buffer-length check alone removes the DoS.)

## How it was found

Source audit for the pattern "a `deser_varlen` count feeding an allocation
without a buffer bound" — the same class as the PSBT `deser_psbt_kv` fix
and the auxpow merkle-count fixes. A `fuzz/fuzz_protocol.c` harness over
the p2p message deserializers exercises this path; the fix must be applied
before fuzzing, since the unfixed path OOMs on the first large-`vsize`
input.
