### PR TITLE
tx: fix getAddrFromPubkeyHash to accept a pubkey hash, not a scriptPubKey

### DIFF
--- a/src/tx.c
+++ b/src/tx.c
@@ -1349,5 +1349,14 @@ enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, cons
  * @return 1 if the address was added successfully, 0 otherwise.
  */
 int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN], const dogecoin_bool is_testnet, char p2pkh_address[P2PKHLEN]) {
-    return dogecoin_pubkey_hash_to_p2pkh_address((char *)utils_hex_to_uint8(pubkey_hash), SCRIPT_PUBKEY_LENGTH, p2pkh_address, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main);
+    /* pubkey_hash is a bare 20-byte hash160 (hex). Convert it directly to a
+       p2pkh address. Previously this routed through
+       dogecoin_pubkey_hash_to_p2pkh_address(), which expects a full 25-byte
+       scriptPubKey (it strips OP_DUP/OP_HASH160/.../OP_CHECKSIG and reads the
+       hash from offset 3) and was passed SCRIPT_PUBKEY_LENGTH as the length of
+       a 20-byte hash -- so feeding it the documented hash160 input produced a
+       wrong address and broke the address<->pubkey-hash round trip. */
+    uint8_t* hash160 = utils_hex_to_uint8(pubkey_hash);
+    if (!hash160) return false;
+    return dogecoin_p2pkh_addr_from_hash160(hash160, is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main, p2pkh_address, P2PKHLEN);
 }


### PR DESCRIPTION
# tx: fix getAddrFromPubkeyHash to accept a pubkey hash, not a scriptPubKey

**File:** `src/tx.c` (`getAddrFromPubkeyHash`)
**Type:** Correctness bug — function does not perform its documented conversion

## Summary

`getAddrFromPubkeyHash` is declared to take a pubkey hash:

```c
int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN],
                          const dogecoin_bool is_testnet,
                          char p2pkh_address[P2PKHLEN]);
```

but its implementation delegates to `dogecoin_pubkey_hash_to_p2pkh_address`,
which expects a full **scriptPubKey**, not a bare hash:

```c
return dogecoin_pubkey_hash_to_p2pkh_address(
    (char *)utils_hex_to_uint8(pubkey_hash),
    SCRIPT_PUBKEY_LENGTH,                       // 25 — wrong for a 20-byte hash
    p2pkh_address, ...);
```

`dogecoin_pubkey_hash_to_p2pkh_address` strips P2PKH script opcodes
(`OP_DUP OP_HASH160 … OP_EQUALVERIFY OP_CHECKSIG`) and reads the hash from
offset 3 of its input. Given a bare 20-byte hash160 (the documented input),
there are no opcodes to strip and offset 3 is the wrong starting byte, so the
resulting address is wrong. The `SCRIPT_PUBKEY_LENGTH` (25) length argument is
also wrong for a 20-byte hash.

## Impact

The function does not convert a pubkey hash to an address. The natural round
trip is broken:

```
address
  -> dogecoin_address_to_pubkey_hash   (returns bare 20-byte hash160)
  -> getAddrFromPubkeyHash             (returns WRONG address)
```

It only returns the correct address if fed a full scriptPubKey hex
(e.g. the 25-byte output of `dogecoin_private_key_wif_to_pubkey_hash`), which
contradicts both its name and its `pubkey_hash[PUBKEYHASHLEN]` parameter.

## Reproduction (via the Python binding, 0.1.5rc1)

```python
import libdogecoin as l
l.w_context_start()
priv, addr = l.w_generate_priv_pub_key_pair(0, False)
hash_form   = l.w_dogecoin_address_to_pubkey_hash(addr)          # 20-byte hash160
script_form = l.w_dogecoin_private_key_wif_to_pubkey_hash(priv)  # 25-byte scriptPubKey
l.w_get_addr_from_pubkey_hash(hash_form, False)    # WRONG address
l.w_get_addr_from_pubkey_hash(script_form, False)  # correct (but wrong input type)
l.w_context_stop()
```

## Fix

Convert the hash directly with `dogecoin_p2pkh_addr_from_hash160`
(the hash160 → address helper), skipping the scriptPubKey-stripping path:

```c
int getAddrFromPubkeyHash(const char pubkey_hash[PUBKEYHASHLEN],
                          const dogecoin_bool is_testnet,
                          char p2pkh_address[P2PKHLEN]) {
    uint8_t* hash160 = utils_hex_to_uint8(pubkey_hash);
    if (!hash160) return false;
    return dogecoin_p2pkh_addr_from_hash160(
        hash160,
        is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main,
        p2pkh_address, P2PKHLEN);
}
```

After the fix, `address -> dogecoin_address_to_pubkey_hash ->
getAddrFromPubkeyHash` round-trips to the original address.

## How it was found

End-to-end testing of the 0.1.5rc1 Python binding (built from the v0.1.5-pre
tag): an `address <-> pubkey-hash` round-trip failed, traced to this function.

## Related note (separate issue)

The three `*_to_pubkey_hash` wrappers return inconsistent formats for the same
key — `dogecoin_address_to_pubkey_hash` returns a 20-byte hash160, while
`dogecoin_private_key_wif_to_pubkey_hash` returns a 25-byte scriptPubKey.
Worth aligning the naming/contract, but tracked separately from this fix.
