### PR TITLE
fuzz: PSBT (BIP174) deserializer harness + regression corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1286,7 +1286,7 @@ jobs:
           # getheaders locator vector) from aborting CI as raw OOM.
           RUNS=20000
           COMMON="-runs=$RUNS -max_len=8192 -rss_limit_mb=2048 -malloc_limit_mb=1024"
-          for t in fuzz_tx fuzz_block fuzz_wtx fuzz_logdb fuzz_protocol; do
+          for t in fuzz_tx fuzz_block fuzz_wtx fuzz_logdb fuzz_psbt fuzz_protocol; do
             if [ -x "fuzz/$t" ]; then
               echo "::group::$t"
               ./fuzz/$t $COMMON
@@ -1301,4 +1301,25 @@ jobs:
           mkdir -p corpus_logdb
           ./fuzz/seed_logdb_corpus corpus_logdb
           ./fuzz/fuzz_logdb corpus_logdb -runs=20000 -max_len=8192 -rss_limit_mb=2048
+        shell: bash
+
+      - name: replay checked-in regression corpus
+        run: |
+          # Deterministic regression gate. Replays every committed seed under
+          # test/fuzz_corpus/<target>/ exactly once (-runs=0, no mutation) so a
+          # change that reintroduces a fixed bug fails here on the exact input
+          # that originally reproduced it. New seeds are added by committing the
+          # crashing/OOM input the fuzzer wrote during triage.
+          status=0
+          for dir in test/fuzz_corpus/*/; do
+            t="fuzz_$(basename "$dir")"
+            if [ -x "fuzz/$t" ] && [ -n "$(ls -A "$dir" 2>/dev/null)" ]; then
+              echo "::group::replay $t ($(ls -1 "$dir" | wc -l) seeds)"
+              # -runs=0 executes each corpus file once and exits; any crash,
+              # leak, or OOM on a committed seed fails the job.
+              ./fuzz/$t "$dir" -runs=0 -rss_limit_mb=2048 -malloc_limit_mb=1024 || status=1
+              echo "::endgroup::"
+            fi
+          done
+          exit $status
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1248,3 +1248,57 @@ jobs:
           files: |
             gitian/builds/${{ github.ref_name }}/**/*
           fail_on_unmatched_files: true
+
+  fuzz:
+    name: fuzz-libfuzzer
+    runs-on: ubuntu-22.04
+    steps:
+      - name: install packages
+        run: |
+          sudo apt-get update
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
+            autoconf automake libtool-bin build-essential curl python3 \
+            clang llvm libevent-dev
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: configure libdogecoin (clang + libFuzzer)
+        run: |
+          ./autogen.sh
+          ./configure CC=clang \
+            CFLAGS="-fsanitize=fuzzer-no-link -g -O1" \
+            --enable-fuzz
+        shell: bash
+
+      - name: build fuzz harnesses
+        run: |
+          # The vendored secp256k1 convenience library must be built before
+          # the harnesses link against libdogecoin.la.
+          make -C src/secp256k1
+          make fuzz fuzz/seed_logdb_corpus
+        shell: bash
+
+      - name: smoke-run harnesses
+        run: |
+          # Short bounded runs: surface crashes/leaks without long fuzzing.
+          # rss/malloc limits keep known unbounded-allocation paths (e.g. the
+          # getheaders locator vector) from aborting CI as raw OOM.
+          RUNS=20000
+          COMMON="-runs=$RUNS -max_len=8192 -rss_limit_mb=2048 -malloc_limit_mb=1024"
+          for t in fuzz_tx fuzz_block fuzz_wtx fuzz_logdb fuzz_protocol; do
+            if [ -x "fuzz/$t" ]; then
+              echo "::group::$t"
+              ./fuzz/$t $COMMON
+              echo "::endgroup::"
+            fi
+          done
+
+      - name: seed corpus + replay (logdb)
+        run: |
+          # Generate checksum-valid seeds and re-run logdb from them so the
+          # fuzzer exercises the post-checksum record-accepted path.
+          mkdir -p corpus_logdb
+          ./fuzz/seed_logdb_corpus corpus_logdb
+          ./fuzz/fuzz_logdb corpus_logdb -runs=20000 -max_len=8192 -rss_limit_mb=2048
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ package-lock.json
 # fuzzing
 fuzz/fuzz_tx
 fuzz/fuzz_block
+fuzz/fuzz_protocol
 fuzz/fuzz_psbt
 fuzz/*.bin
 crash-*

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,11 @@ package-lock.json
 
 # Generated ZK carrier circuit/proving artifacts
 /contrib/zk_carrier/circuits/build/
+
+# fuzzing
+fuzz/fuzz_tx
+fuzz/fuzz_psbt
+fuzz/*.bin
+crash-*
+oom-*
+timeout-*

--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ package-lock.json
 
 # fuzzing
 fuzz/fuzz_tx
+fuzz/fuzz_block
 fuzz/fuzz_psbt
 fuzz/*.bin
 crash-*

--- a/Makefile.am
+++ b/Makefile.am
@@ -527,6 +527,13 @@ fuzz_fuzz_logdb_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_logdb_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_logdb_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
+noinst_PROGRAMS += fuzz/fuzz_psbt
+fuzz_fuzz_psbt_SOURCES = fuzz/fuzz_psbt.c
+fuzz_fuzz_psbt_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
+fuzz_fuzz_psbt_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_psbt_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_psbt_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
 # Corpus seed generator for fuzz_logdb. NOT a libFuzzer target: it links
 # the plain (uninstrumented) library and emits checksum-valid single
 # records so the fuzzer can mutate past the per-record SHA256 gate.
@@ -542,7 +549,7 @@ fuzz-corpus: fuzz/seed_logdb_corpus
 	./fuzz/seed_logdb_corpus $(CORPUS)
 
 
-FUZZ_TARGETS = fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_wtx fuzz/fuzz_logdb
+FUZZ_TARGETS = fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_wtx fuzz/fuzz_logdb fuzz/fuzz_psbt
 if WITH_NET
 FUZZ_TARGETS += fuzz/fuzz_protocol
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -506,5 +506,19 @@ fuzz_fuzz_protocol_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_protocol_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_protocol_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
-fuzz: fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_protocol
+noinst_PROGRAMS += fuzz/fuzz_wtx
+fuzz_fuzz_wtx_SOURCES = fuzz/fuzz_wtx.c
+fuzz_fuzz_wtx_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
+fuzz_fuzz_wtx_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_wtx_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_wtx_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
+noinst_PROGRAMS += fuzz/fuzz_logdb
+fuzz_fuzz_logdb_SOURCES = fuzz/fuzz_logdb.c
+fuzz_fuzz_logdb_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/src/logdb/include
+fuzz_fuzz_logdb_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_logdb_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_logdb_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
+fuzz: fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_protocol fuzz/fuzz_wtx fuzz/fuzz_logdb
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -527,6 +527,21 @@ fuzz_fuzz_logdb_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_logdb_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_logdb_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
+# Corpus seed generator for fuzz_logdb. NOT a libFuzzer target: it links
+# the plain (uninstrumented) library and emits checksum-valid single
+# records so the fuzzer can mutate past the per-record SHA256 gate.
+noinst_PROGRAMS += fuzz/seed_logdb_corpus
+fuzz_seed_logdb_corpus_SOURCES = fuzz/seed_logdb_corpus.c
+fuzz_seed_logdb_corpus_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/src/logdb/include
+fuzz_seed_logdb_corpus_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+
+# Generate a starter corpus: make fuzz-corpus CORPUS=path (default ./corpus_logdb)
+CORPUS ?= corpus_logdb
+fuzz-corpus: fuzz/seed_logdb_corpus
+	$(MKDIR_P) $(CORPUS)
+	./fuzz/seed_logdb_corpus $(CORPUS)
+
+
 FUZZ_TARGETS = fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_wtx fuzz/fuzz_logdb
 if WITH_NET
 FUZZ_TARGETS += fuzz/fuzz_protocol

--- a/Makefile.am
+++ b/Makefile.am
@@ -493,5 +493,12 @@ fuzz_fuzz_tx_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_tx_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_tx_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
-fuzz: fuzz/fuzz_tx
+noinst_PROGRAMS += fuzz/fuzz_block
+fuzz_fuzz_block_SOURCES = fuzz/fuzz_block.c
+fuzz_fuzz_block_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
+fuzz_fuzz_block_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_block_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_block_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
+fuzz: fuzz/fuzz_tx fuzz/fuzz_block
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -499,12 +499,19 @@ fuzz_fuzz_block_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
 fuzz_fuzz_block_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_block_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_block_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
+# fuzz_protocol drives p2p message deserializers from protocol.c, which is
+# only compiled into the library under WITH_NET (and pulls in libevent).
+# Gate the harness on the same condition so `make fuzz` still builds the
+# net-independent targets when networking is disabled.
+if WITH_NET
 noinst_PROGRAMS += fuzz/fuzz_protocol
 fuzz_fuzz_protocol_SOURCES = fuzz/fuzz_protocol.c
 fuzz_fuzz_protocol_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
 fuzz_fuzz_protocol_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_protocol_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_protocol_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+endif
 
 noinst_PROGRAMS += fuzz/fuzz_wtx
 fuzz_fuzz_wtx_SOURCES = fuzz/fuzz_wtx.c
@@ -520,5 +527,10 @@ fuzz_fuzz_logdb_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_logdb_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_logdb_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
-fuzz: fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_protocol fuzz/fuzz_wtx fuzz/fuzz_logdb
+FUZZ_TARGETS = fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_wtx fuzz/fuzz_logdb
+if WITH_NET
+FUZZ_TARGETS += fuzz/fuzz_protocol
+endif
+
+fuzz: $(FUZZ_TARGETS)
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I build-aux/m4
 AUTOMAKE_OPTIONS = serial-tests
-.PHONY: gen
+.PHONY: gen fuzz
 .INTERMEDIATE: $(GENBIN)
 
 DIST_SUBDIRS = src/secp256k1
@@ -484,3 +484,14 @@ endif
 endif
 
 libdogecoin_la_LDFLAGS = -no-undefined -version-info $(LIB_VERSION_CURRENT):$(LIB_VERSION_REVISION):$(LIB_VERSION_AGE)
+
+if USE_FUZZ
+noinst_PROGRAMS += fuzz/fuzz_tx
+fuzz_fuzz_tx_SOURCES = fuzz/fuzz_tx.c
+fuzz_fuzz_tx_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
+fuzz_fuzz_tx_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_tx_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_tx_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
+fuzz: fuzz/fuzz_tx
+endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -499,6 +499,12 @@ fuzz_fuzz_block_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
 fuzz_fuzz_block_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_block_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_block_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+noinst_PROGRAMS += fuzz/fuzz_protocol
+fuzz_fuzz_protocol_SOURCES = fuzz/fuzz_protocol.c
+fuzz_fuzz_protocol_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
+fuzz_fuzz_protocol_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_protocol_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_protocol_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
-fuzz: fuzz/fuzz_tx fuzz/fuzz_block
+fuzz: fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_protocol
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -233,6 +233,11 @@ AC_ARG_ENABLE(tests,
   [use_tests=$enableval],
   [use_tests=yes])
 
+AC_ARG_ENABLE(fuzz,
+  AS_HELP_STRING([--enable-fuzz],[build libFuzzer harnesses, requires clang (default is no)]),
+  [use_fuzz=$enableval],
+  [use_fuzz=no])
+
 AC_MSG_CHECKING([for __builtin_expect])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[void myfunc() {__builtin_expect(0,0);}]])],
   [ AC_MSG_RESULT([yes]);AC_DEFINE(HAVE_BUILTIN_EXPECT,1,[Define this symbol if __builtin_expect is available]) ],
@@ -497,6 +502,7 @@ if test x$use_intel_avx2 = xyes || test x$use_intel_sse = xyes; then
 fi
 AC_SUBST([NASM])
 AM_CONDITIONAL([USE_TESTS], [test x"$use_tests" != x"no"])
+AM_CONDITIONAL([USE_FUZZ], [test x"$use_fuzz" = x"yes"])
 AM_CONDITIONAL([WITH_BENCH], [test "x$with_bench" = "xyes"])
 AM_CONDITIONAL([WITH_TOOLS], [test "x$with_tools" = "xyes"])
 AM_CONDITIONAL([WITH_NET], [test "x$with_net" = "xyes"])

--- a/fuzz/fuzz_block.c
+++ b/fuzz/fuzz_block.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * libFuzzer harness for dogecoin_block_header_deserialize.
  */
 #include <stdint.h>

--- a/fuzz/fuzz_block.c
+++ b/fuzz/fuzz_block.c
@@ -1,0 +1,21 @@
+/*
+ * libFuzzer harness for dogecoin_block_header_deserialize.
+ */
+#include <stdint.h>
+#include <stddef.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/block.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/buffer.h>
+#include <dogecoin/arith_uint256.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+    dogecoin_block_header *header = dogecoin_block_header_new();
+    struct const_buffer buf = { data, size };
+    arith_uint256 chainwork = {0};
+    dogecoin_block_header_deserialize(header, &buf, &dogecoin_chainparams_main, &chainwork);
+    dogecoin_block_header_free(header);
+    return 0;
+}

--- a/fuzz/fuzz_logdb.c
+++ b/fuzz/fuzz_logdb.c
@@ -1,0 +1,49 @@
+/*
+ * libFuzzer harness for logdb_record_deser_from_file.
+ *
+ * logdb is the append-only record store backing the wallet/headers DBs.
+ * The per-record deserializer reads attacker-controlled varint key/value
+ * lengths and fread()s that many bytes, making it the natural target for
+ * the stack-overflow + unbounded-allocation hardening in PR #345.
+ *
+ * The real function reads from a FILE* (db->file). We wrap the fuzz input
+ * in an in-memory stream via fmemopen so no disk I/O is required.
+ *
+ * Build:  ./configure CC=clang CFLAGS="-fsanitize=fuzzer-no-link" --enable-fuzz && make fuzz
+ * Run:    ./fuzz/fuzz_logdb CORPUS_DIR -max_len=100000
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include <dogecoin/dogecoin.h>
+#include <logdb/logdb_core.h>
+#include <logdb/logdb_rec.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+
+    /* fmemopen requires a non-NULL, non-empty buffer. */
+    FILE *f = fmemopen((void *)data, size, "rb");
+    if (!f) return 0;
+
+    logdb_log_db *db = logdb_new();
+    if (!db) { fclose(f); return 0; }
+    db->file = f;
+
+    logdb_record *rec = logdb_record_new();
+    enum logdb_error error = LOGDB_SUCCESS;
+
+    /* Single record parse: exercises magic/hash/mode reads, both
+     * varint-length fields, and the cstr_resize + fread loops. */
+    logdb_record_deser_from_file(rec, db, &error);
+
+    logdb_record_free(rec);
+
+    /* Detach the stream before logdb_free so it doesn't fclose a
+     * second time (we own f here). */
+    db->file = NULL;
+    logdb_free(db);
+    fclose(f);
+    return 0;
+}

--- a/fuzz/fuzz_logdb.c
+++ b/fuzz/fuzz_logdb.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * libFuzzer harness for logdb_record_deser_from_file.
  *
  * logdb is the append-only record store backing the wallet/headers DBs.

--- a/fuzz/fuzz_protocol.c
+++ b/fuzz/fuzz_protocol.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * libFuzzer harness for p2p message deserializers in protocol.c.
  *
  * Primary target: dogecoin_p2p_deser_msg_getheaders, which parses an

--- a/fuzz/fuzz_protocol.c
+++ b/fuzz/fuzz_protocol.c
@@ -1,0 +1,51 @@
+/*
+ * libFuzzer harness for p2p message deserializers in protocol.c.
+ *
+ * Primary target: dogecoin_p2p_deser_msg_getheaders, which parses an
+ * untrusted, unauthenticated getheaders message (a block-locator vector
+ * plus a hashstop). Also exercises the version-message deserializer.
+ *
+ * The first input byte selects which parser to drive, so one corpus can
+ * cover multiple message types.
+ *
+ * Build:  ./configure CC=clang CFLAGS="-fsanitize=fuzzer-no-link" --enable-fuzz && make fuzz
+ * Run:    ./fuzz/fuzz_protocol CORPUS_DIR -max_len=100000
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/protocol.h>
+#include <dogecoin/buffer.h>
+#include <dogecoin/vector.h>
+#include <dogecoin/cstr.h>
+
+static void free_locator(void *p) { dogecoin_free(p); }
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 1) return 0;
+
+    uint8_t selector = data[0];
+    struct const_buffer buf = { data + 1, size - 1 };
+
+    switch (selector & 0x01) {
+    case 0: {
+        /* getheaders: block-locator vector + hashstop */
+        vector_t *locators = vector_new(8, free_locator);
+        uint256_t hashstop;
+        memset(hashstop, 0, sizeof(hashstop));
+        dogecoin_p2p_deser_msg_getheaders(locators, hashstop, &buf);
+        vector_free(locators, true);
+        break;
+    }
+    case 1: {
+        /* version message */
+        dogecoin_p2p_version_msg msg;
+        memset(&msg, 0, sizeof(msg));
+        dogecoin_p2p_msg_version_deser(&msg, &buf);
+        break;
+    }
+    }
+    return 0;
+}

--- a/fuzz/fuzz_protocol.c
+++ b/fuzz/fuzz_protocol.c
@@ -20,6 +20,7 @@
 #include <dogecoin/buffer.h>
 #include <dogecoin/vector.h>
 #include <dogecoin/cstr.h>
+#include <dogecoin/mem.h>
 
 static void free_locator(void *p) { dogecoin_free(p); }
 

--- a/fuzz/fuzz_psbt.c
+++ b/fuzz/fuzz_psbt.c
@@ -1,0 +1,72 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
+ * libFuzzer harness for dogecoin_psbt_deserialize + serialize round-trip.
+ *
+ * Drives the BIP174 PSBT parser (src/psbt.c) on untrusted bytes. The parser
+ * walks attacker-controlled key/value maps with varint-prefixed lengths and
+ * fixed-size pubkey copies, so it is a natural target for memory-safety and
+ * unbounded-allocation defects. This harness exercises:
+ *   - deser_psbt_kv: the klen/vlen varint allocation path (PR #352, kv-OOM)
+ *   - the BIP32 derivation handlers: the klen==34 pubkey-copy guard
+ *     in both the input and output maps (PR #353, heap overflow)
+ *   - the global/input/output map state machine and free() paths
+ *
+ * On a successful parse it re-serializes the PSBT to also exercise the
+ * serializer and surface deser/ser asymmetry. dogecoin_psbt_deserialize
+ * owns the *out allocation: on success the caller frees it; on failure it
+ * sets *out = NULL and frees internally, so the harness only frees on
+ * success.
+ *
+ * The checked-in regression corpus at test/fuzz_corpus/psbt/ (including the
+ * crash-eea3d... input that reproduced the #353 overflow pre-fix) should be
+ * passed as a seed/replay directory so the harness proves those fixes hold.
+ */
+#include <stdint.h>
+#include <stddef.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/psbt.h>
+#include <dogecoin/cstr.h>
+#include <dogecoin/mem.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+
+    dogecoin_psbt *psbt = NULL;
+    if (dogecoin_psbt_deserialize(data, size, &psbt) && psbt) {
+        /* Round-trip: re-serialize the parsed PSBT. Exercises the
+         * serialization path and surfaces deser/ser asymmetry. */
+        cstring *out = dogecoin_psbt_serialize(psbt);
+        if (out) cstr_free(out, 1);
+        dogecoin_psbt_free(psbt);
+    }
+    /* On failure dogecoin_psbt_deserialize sets *out = NULL and frees its
+     * own internal allocation, so there is nothing to free here. */
+    return 0;
+}

--- a/fuzz/fuzz_tx.c
+++ b/fuzz/fuzz_tx.c
@@ -1,0 +1,22 @@
+/*
+ * libFuzzer harness for dogecoin_tx_deserialize.
+ *
+ * Build:  ./configure CC=clang CFLAGS="-fsanitize=fuzzer-no-link" --enable-fuzz && make fuzz
+ * Run:    ./fuzz/fuzz_tx CORPUS_DIR -max_len=100000
+ */
+#include <stdint.h>
+#include <stddef.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/tx.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+
+    dogecoin_tx *tx = dogecoin_tx_new();
+    size_t consumed = 0;
+    dogecoin_tx_deserialize((const unsigned char *)data, size, tx, &consumed);
+    dogecoin_tx_free(tx);
+
+    return 0;
+}

--- a/fuzz/fuzz_tx.c
+++ b/fuzz/fuzz_tx.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * libFuzzer harness for dogecoin_tx_deserialize + serialize round-trip.
  */
 #include <stdint.h>

--- a/fuzz/fuzz_tx.c
+++ b/fuzz/fuzz_tx.c
@@ -1,22 +1,25 @@
 /*
- * libFuzzer harness for dogecoin_tx_deserialize.
- *
- * Build:  ./configure CC=clang CFLAGS="-fsanitize=fuzzer-no-link" --enable-fuzz && make fuzz
- * Run:    ./fuzz/fuzz_tx CORPUS_DIR -max_len=100000
+ * libFuzzer harness for dogecoin_tx_deserialize + serialize round-trip.
  */
 #include <stdint.h>
 #include <stddef.h>
 
 #include <dogecoin/dogecoin.h>
 #include <dogecoin/tx.h>
+#include <dogecoin/cstr.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (size == 0) return 0;
 
     dogecoin_tx *tx = dogecoin_tx_new();
     size_t consumed = 0;
-    dogecoin_tx_deserialize((const unsigned char *)data, size, tx, &consumed);
+    if (dogecoin_tx_deserialize((const unsigned char *)data, size, tx, &consumed)) {
+        /* Round-trip: re-serialize the parsed tx. Exercises the
+         * serialization path and surfaces deser/ser asymmetry. */
+        cstring *out = cstr_new_sz(1024);
+        dogecoin_tx_serialize(out, tx);
+        cstr_free(out, 1);
+    }
     dogecoin_tx_free(tx);
-
     return 0;
 }

--- a/fuzz/fuzz_wtx.c
+++ b/fuzz/fuzz_wtx.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * libFuzzer harness for dogecoin_wallet_wtx_deserialize.
  *
  * Parses an untrusted on-disk wallet transaction record:

--- a/fuzz/fuzz_wtx.c
+++ b/fuzz/fuzz_wtx.c
@@ -1,0 +1,35 @@
+/*
+ * libFuzzer harness for dogecoin_wallet_wtx_deserialize.
+ *
+ * Parses an untrusted on-disk wallet transaction record:
+ *   uint32 height | uint256 tx_hash_cache | serialized dogecoin_tx
+ *
+ * This is the read path exercised when loading a wallet file, so the
+ * input is fully attacker-controlled if a wallet .dat is tampered with.
+ * Directly targets the record-length / truncation handling hardened in
+ * PR #342 (wtx reclen DoS) and the alloc/free balance touched by #318.
+ *
+ * Build:  ./configure CC=clang CFLAGS="-fsanitize=fuzzer-no-link" --enable-fuzz && make fuzz
+ * Run:    ./fuzz/fuzz_wtx CORPUS_DIR -max_len=100000
+ */
+#include <stdint.h>
+#include <stddef.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/wallet.h>
+#include <dogecoin/buffer.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+
+    dogecoin_wtx *wtx = dogecoin_wallet_wtx_new();
+    struct const_buffer buf = { data, size };
+
+    /* Return value intentionally ignored: we care about memory-safety of
+     * the parse on both the success and failure paths, including
+     * truncated headers (height/hash) and embedded-tx truncation. */
+    dogecoin_wallet_wtx_deserialize(wtx, &buf);
+
+    dogecoin_wallet_wtx_free(wtx);
+    return 0;
+}

--- a/fuzz/seed_logdb_corpus.c
+++ b/fuzz/seed_logdb_corpus.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * Corpus seed generator for fuzz_logdb.
  *
  * fuzz_logdb drives logdb_record_deser_from_file() against a fresh

--- a/fuzz/seed_logdb_corpus.c
+++ b/fuzz/seed_logdb_corpus.c
@@ -1,0 +1,149 @@
+/*
+ * Corpus seed generator for fuzz_logdb.
+ *
+ * fuzz_logdb drives logdb_record_deser_from_file() against a fresh
+ * logdb_log_db (logdb_new(): sha256_init'd hashctx, NO file header
+ * absorbed) reading exactly one record from an fmemopen'd buffer.
+ *
+ * A record ends with a SHA256 checksum over (running_ctx || record body),
+ * so random bytes essentially never pass the memcmp() gate and the fuzzer
+ * plateaus before reaching the record-accepted path. This tool emits
+ * valid single-record buffers, computed against the SAME fresh-context
+ * init the harness uses, so libFuzzer mutates outward from inputs that
+ * already clear the checksum.
+ *
+ * It writes records by hand using the library's own ser/hash primitives,
+ * mirroring logdb_write_record() exactly but over a fresh sha256 context
+ * (no header), which is what the harness sees.
+ *
+ * Build (from a configured tree):
+ *   clang -I include -I src/logdb/include seed_logdb_corpus.c \
+ *       .libs/libdogecoin.a src/secp256k1/.libs/libsecp256k1.a -o seed_logdb
+ * Run:
+ *   ./seed_logdb CORPUS_DIR
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/sha2.h>
+#include <dogecoin/cstr.h>
+#include <dogecoin/serialize.h>
+#include <logdb/logdb_core.h>
+#include <logdb/logdb_rec.h>
+
+/* Must match logdb_core.c. record_magic is the per-record start marker;
+ * hashlen is the truncated-SHA length the default db uses. */
+static const uint8_t RECORD_MAGIC[8] =
+    { 0x88, 0x61, 0xAD, 0xFC, 0x5A, 0x11, 0x22, 0xF8 };
+#define HASHLEN 16  /* kLOGDB_DEFAULT_HASH_LEN */
+
+/* Build one valid record buffer for a fresh (header-less) hash context,
+ * exactly as the harness's logdb_new() db would expect to read it.
+ *
+ * On-disk record layout consumed by logdb_record_deser_from_file (note
+ * mode is a STANDALONE byte, and the body-hashcheck appears TWICE, once
+ * before mode and once after the value, with hashlen = 16):
+ *
+ *   magic[8]
+ *   hashcheck[16]               (body-start indicator, arbitrary bytes;
+ *                                deser only feeds it to the SHA context,
+ *                                never validates it against the body)
+ *   mode[1]
+ *   varint(klen) | key
+ *   [ varint(vlen) | value ]    (WRITE only)
+ *   hashcheck[16]               (body-end indicator, same note as above)
+ *   finalcheck[16]              (sha256(running_ctx), first 16 bytes)
+ *
+ * The running ctx absorbs, in order:
+ *   magic, hashcheck, mode, varint(klen), key,
+ *   [varint(vlen), value,] hashcheck
+ * then is finalized; the first hashlen(=16) bytes are finalcheck.
+ *
+ * The two hashcheck blocks are NOT verified against the body by the
+ * reader (it only memcmp()s the final checksum), so we use a fixed
+ * indicator value for them and let the final SHA bind the whole record.
+ */
+static void put_varlen(cstring *s, uint32_t v) {
+    ser_varlen(s, v);  /* CompactSize, same encoder the reader's varint expects */
+}
+
+static cstring *build_record(uint8_t mode, const char *key, size_t klen,
+                             const char *val, size_t vlen) {
+    /* fixed body-start/-end indicator (16 bytes); value is irrelevant to
+     * validation, it only needs to be consistent between the bytes we
+     * emit and the bytes we feed the hash. */
+    uint8_t indicator[HASHLEN];
+    memset(indicator, 0xA5, sizeof(indicator));
+
+    /* encode the body field-by-field in reader order */
+    cstring *kv = cstr_new_sz(64);
+    put_varlen(kv, (uint32_t)klen);
+    if (klen) cstr_append_buf(kv, key, klen);
+    if (mode == RECORD_TYPE_WRITE) {
+        put_varlen(kv, (uint32_t)vlen);
+        if (vlen) cstr_append_buf(kv, val, vlen);
+    }
+
+    /* running context: magic | indicator | mode | kv | indicator */
+    sha256_context ctx;
+    sha256_init(&ctx);
+    sha256_write(&ctx, RECORD_MAGIC, 8);
+    sha256_write(&ctx, indicator, HASHLEN);
+    sha256_write(&ctx, &mode, 1);
+    sha256_write(&ctx, (const uint8_t *)kv->str, kv->len);
+    sha256_write(&ctx, indicator, HASHLEN);
+
+    uint8_t finalhash[SHA256_DIGEST_LENGTH];
+    sha256_context ctx_final = ctx;
+    sha256_finalize(&ctx_final, finalhash);
+
+    /* assemble bytes in reader order */
+    cstring *out = cstr_new_sz(64 + kv->len);
+    cstr_append_buf(out, RECORD_MAGIC, 8);
+    cstr_append_buf(out, indicator, HASHLEN);
+    cstr_append_buf(out, &mode, 1);
+    cstr_append_buf(out, kv->str, kv->len);
+    cstr_append_buf(out, indicator, HASHLEN);
+    cstr_append_buf(out, finalhash, HASHLEN);  /* only first HASHLEN bytes read */
+
+    cstr_free(kv, true);
+    return out;
+}
+
+static void dump(const char *dir, const char *name, cstring *buf) {
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/%s", dir, name);
+    FILE *f = fopen(path, "wb");
+    if (!f) { perror(path); return; }
+    fwrite(buf->str, 1, buf->len, f);
+    fclose(f);
+    printf("wrote %s (%zu bytes)\n", path, buf->len);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s CORPUS_DIR\n", argv[0]);
+        return 1;
+    }
+    const char *dir = argv[1];
+
+    struct { uint8_t mode; const char *k; size_t kl; const char *v; size_t vl; const char *name; } cases[] = {
+        { RECORD_TYPE_WRITE,  "k",    1,   "v",    1,   "seed_write_tiny" },
+        { RECORD_TYPE_WRITE,  "addr", 4,   "value12bytes", 12, "seed_write_small" },
+        { RECORD_TYPE_ERASE,  "k",    1,   "",     0,   "seed_erase" },
+        { RECORD_TYPE_WRITE,  "",     0,   "",     0,   "seed_write_empty" },
+        { RECORD_TYPE_WRITE,  "longkey_padding_0123456789", 26,
+                              "longval_padding_0123456789abcdef", 32, "seed_write_long" },
+    };
+
+    for (size_t i = 0; i < sizeof(cases)/sizeof(cases[0]); i++) {
+        cstring *b = build_record(cases[i].mode, cases[i].k, cases[i].kl,
+                                  cases[i].v, cases[i].vl);
+        dump(dir, cases[i].name, b);
+        cstr_free(b, true);
+    }
+    return 0;
+}

--- a/test/fuzz_corpus/psbt/oom-kvlen-deser_psbt_kv
+++ b/test/fuzz_corpus/psbt/oom-kvlen-deser_psbt_kv
@@ -1,0 +1,1 @@
+psbtÿÿbtÿÿbspsbtp


### PR DESCRIPTION
Adds a libFuzzer harness for the PSBT deserializer plus a regression
corpus that replays the two bugs it originally surfaced. Stacked on #351
(fuzz harness infrastructure).

## Contents
- **fuzz_psbt.c** — drives `dogecoin_psbt_deserialize` on untrusted bytes
  with a re-serialize round-trip on success. Slots into `FUZZ_TARGETS`.
- **Regression corpus** in `test/fuzz_corpus/psbt/`: a kv-OOM reproducer
  plus the bip32 crash seed, for deterministic replay.
- **CI** — the fuzz job replays the checked-in corpus.

## Security fixes — already merged
This harness surfaced two bugs, both now fixed on `0.1.5-dev`:
- **#352 (kv-OOM):** bound `klen`/`vlen` against remaining input before
  allocating in `deser_psbt_kv`. Reproduced the pre-fix
  `malloc(0xffffffff)` OOM in ~256 iterations.
- **#353 (heap overflow):** require `klen == 34` (not `>= 34`) in the
  input/output BIP32 derivation handlers so an oversized pubkey can't
  overflow the 33-byte keypath buffer.

The corpus above guards both against regression.

## Verification
- Pre-fix tree: harness OOMs/overflows within a few thousand iterations.
- Fixed tree: 6.2M iterations clean, cov 380 / ft 1208, flat 626 MB RSS,
  no crash/OOM/leak.

## Dependency note
Rebased onto current `0.1.5-dev`, so the #352/#353 fixes are already
upstream and no longer appear here as duplicate commits. Stacked on #351
— land that first. Harness depends on the merged #317 PSBT implementation.
