### PR TITLE
such: fix coin_amount/subtotal buffer type and unterminated copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 # this ci pipeline will build, test and publish (can but currently does not) artifacts for linux, win, macosx
 
+# this ci pipeline will build, test and publish (can but currently does not) artifacts for linux, win, macosx
+
 name: CI
 
 on:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,9 @@ MESSAGE(STATUS "")
 FILE(TOUCH config/libdogecoin-config.h)
 
 ADD_LIBRARY(${LIBDOGECOIN_NAME} ${ASM_SOURCES})
+IF(WIN32 AND NOT BUILD_SHARED_LIBS)
+    TARGET_COMPILE_DEFINITIONS(${LIBDOGECOIN_NAME} PRIVATE UTF8PROC_STATIC)
+ENDIF()
 INSTALL(TARGETS
     ${LIBDOGECOIN_NAME}
     LIBRARY DESTINATION lib
@@ -369,6 +372,7 @@ TARGET_SOURCES(${LIBDOGECOIN_NAME} PRIVATE
     src/auxpow.c
     src/base58.c
     src/bip32.c
+    src/bip38.c
     src/bip39.c
     src/bip44.c
     src/block.c
@@ -397,6 +401,7 @@ TARGET_SOURCES(${LIBDOGECOIN_NAME} PRIVATE
     src/serialize.c
     src/sha2.c
     src/sign.c
+    src/sweep.c
     src/smpv.c
     src/cli/tool.c
     src/transaction.c
@@ -549,6 +554,7 @@ IF(USE_TESTS)
         test/rmd160_tests.c
         test/scrypt_tests.c
         test/serialize_tests.c
+        test/sweep_tests.c
         test/sha1_tests.c
         test/sha2_tests.c
         test/signmsg_tests.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,8 @@ include_HEADERS = \
     include/dogecoin/constants.h \
     include/dogecoin/dogecoin.h \
     include/dogecoin/libdogecoin.h \
+    include/dogecoin/bip38.h \
+    include/dogecoin/sweep.h \
     include/dogecoin/uthash.h \
     config/libdogecoin-config.h
 noinst_HEADERS = \
@@ -34,6 +36,7 @@ noinst_HEADERS = \
     include/dogecoin/auxpow.h \
     include/dogecoin/base58.h \
     include/dogecoin/bip37.h \
+    include/dogecoin/bip38.h \
     include/dogecoin/bip32.h \
     include/dogecoin/bip39.h \
     include/dogecoin/bip44.h \
@@ -67,6 +70,7 @@ noinst_HEADERS = \
     include/dogecoin/rmd160.h \
     include/dogecoin/script.h \
     include/dogecoin/scrypt.h \
+    include/dogecoin/sweep.h \
     include/dogecoin/sign.h \
     include/dogecoin/serialize.h \
     include/dogecoin/seal.h \
@@ -93,6 +97,7 @@ libdogecoin_la_SOURCES = \
     src/arith_uint256.c \
     src/auxpow.c \
     src/base58.c \
+    src/bip38.c \
     src/bip32.c \
     src/bip39.c \
     src/bip44.c \
@@ -121,6 +126,7 @@ libdogecoin_la_SOURCES = \
     src/scrypt.c \
     src/seal.c \
     src/sign.c \
+    src/sweep.c \
     src/serialize.c \
     src/sha2.c \
     src/smpv.c \
@@ -232,7 +238,7 @@ libdogecoin_la_SOURCES += \
     src/scrypt-sse2.c
 endif
 
-libdogecoin_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src/logdb/include -fPIC
+libdogecoin_la_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/src/logdb/include -fPIC -DUTF8PROC_STATIC
 # Linking $(ASM_LIB_FILES) here triggers a libtool "non-portable" warning
 # but is needed so libdogecoin.so ships the asm symbols. Only one of the
 # USE_AVX2 / USE_SSE asm blocks above is active at a time (the SSE block
@@ -283,6 +289,7 @@ tests_SOURCES = \
     test/rmd160_tests.c \
     test/scrypt_tests.c \
     test/serialize_tests.c \
+    test/sweep_tests.c \
     test/sha1_tests.c \
     test/sha2_tests.c \
     test/signmsg_tests.c \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ It is intended that connecting the bits together into an engine be done at the l
 - Generate recoverable signatures (and recover pubkey from signatures)
 - BIP32 hierarchical deterministic key derivation
 - Transaction generation, manipulation, signing and ser-/deserialization including P2PKH, P2SH, multisig
+- BIP38 encrypted private keys and paper-wallet sweep (`doc/sweep.md`)
 - Address generation
 - Base58check encoding
 - Native implementation of SHA256, SHA512, SHA512_HMAC, RIPEMD-160 including NIST testvectors
@@ -109,6 +110,7 @@ The `/doc` folder has many helpful resources regarding setup and usage of Libdog
 - [`project_roadmap.md`](doc/project_roadmap.md) Our plan for the future of Libdogecoin (with pictures!).
 - [`tools.md`](doc/tools.md) Guidance on how to use provided helper scripts and tools like `such` and `sendtx`.
 - [`transaction.md`](doc/transaction.md) Full description of dogecoin transactions and the Libdogecoin Essential Transaction API.
+- [`sweep.md`](doc/sweep.md) BIP38 encryption and paper-wallet sweep API.
 - [`wallet.md`](doc/wallet.md) Wallet query API for address-scoped UTXO and balance access.
 
 ## Quick Start

--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,8 @@ case $host in
     build_windows=yes
     TARGET_OS=windows
     NASMFLAGS="-Werror -fwin64 -Xvc -gcv8 -DWIN_ABI"
+    # utf8proc is vendored into libdogecoin; static MinGW links need no dllimport.
+    CFLAGS="$CFLAGS -DUTF8PROC_STATIC"
     AC_CHECK_LIB([pthread],      [main],, AC_MSG_ERROR(lib missing))
     AC_CHECK_LIB([winpthread],      [main],, AC_MSG_ERROR(lib missing))
     AC_CHECK_LIB([shell32],      [main],, AC_MSG_ERROR(lib missing))

--- a/contrib/examples/example.c
+++ b/contrib/examples/example.c
@@ -936,7 +936,7 @@ int main() {
 	printf("\n\nBEGIN KOINU CONVERSION:\n\n");
 	{
 		char coins_str[32];
-		koinu_to_coins_str(1234567890ULL, coins_str);
+		koinu_to_coins_str(1234567890ULL, coins_str, sizeof(coins_str));
 		printf("1234567890 koinu = %s DOGE\n", coins_str);
 		uint64_t k = coins_to_koinu_str("42.5");
 		printf("42.5 DOGE = %llu koinu\n", (unsigned long long)k);

--- a/contrib/examples/mainnet_sweep_driver.c
+++ b/contrib/examples/mainnet_sweep_driver.c
@@ -1,0 +1,314 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2024 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+ */
+
+/*
+ * Mainnet sweep API driver (libdogecoin).
+ *
+ * Exercises the full public sweep API end-to-end against real mainnet UTXOs:
+ *   - dogecoin_paper_wallet_set_wif / dogecoin_paper_wallet_set_encrypted (BIP38)
+ *   - dogecoin_sweep_options_new / set_destination / set_fee / set_rbf / add_utxo
+ *   - dogecoin_sweep_create_transaction / dogecoin_sweep_sign_transaction
+ *   - dogecoin_sweep_validate_transaction / dogecoin_sweep_get_stats
+ *   - dogecoin_sweep_broadcast_transaction (transmits over the p2p network)
+ *
+ * It is intentionally a thin, scriptable wrapper so the mainnet end-to-end
+ * test (contrib/mainnet_bip38_sweep_test.sh) can transmit a real sweep via
+ * the sweep API and capture evidence in the committed log file.
+ *
+ * Build (from repo root, after ./configure && make):
+ *   gcc contrib/examples/mainnet_sweep_driver.c .libs/libdogecoin.a \
+ *       $(pkg-config --libs libevent) -lpthread -Iinclude -Iinclude/dogecoin \
+ *       -o mainnet_sweep_driver
+ *
+ * Usage:
+ *   mainnet_sweep_driver \
+ *     --wif <WIF> | --bip38 <6P...> --passphrase <pass> \
+ *     --dest <D...> [--fee-per-kb <koinu>] [--min-fee <koinu>] \
+ *     [--max-fee <koinu>] [--rbf] [--no-broadcast] \
+ *     --utxo <txid>:<vout>:<amount_doge> [--utxo ...]
+ */
+
+#include <dogecoin/chainparams.h>
+#include <dogecoin/ecc.h>
+#include <dogecoin/bip38.h>
+#include <dogecoin/sweep.h>
+#include <dogecoin/tx.h>
+#include <dogecoin/cstr.h>
+#include <dogecoin/utils.h>
+#include <dogecoin/mem.h>
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MAX_UTXOS 64
+
+static void usage(const char* prog) {
+    fprintf(stderr,
+        "usage: %s (--wif WIF | --bip38 6P... --passphrase PASS) --dest ADDR\n"
+        "          [--fee-per-kb KOINU] [--min-fee KOINU] [--max-fee KOINU]\n"
+        "          [--rbf] [--no-broadcast] --utxo TXID:VOUT:AMOUNT_DOGE [--utxo ...]\n",
+        prog);
+}
+
+int main(int argc, char** argv) {
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+    const char* wif = NULL;
+    const char* bip38 = NULL;
+    const char* passphrase = NULL;
+    const char* dest = NULL;
+    const char* encrypt_bip38 = NULL; /* passphrase: encrypt the WIF key then reload via BIP38 */
+    uint64_t fee_per_kb = 1000000ULL; /* 0.01 DOGE/kB default for mainnet relay */
+    uint64_t min_fee = 100000ULL;
+    uint64_t max_fee = 100000000ULL;
+    int use_rbf = 0;
+    int do_broadcast = 1;
+    const char* utxo_args[MAX_UTXOS];
+    size_t utxo_count = 0;
+    int rc = 1;
+    int i;
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--wif") == 0 && i + 1 < argc) {
+            wif = argv[++i];
+        } else if (strcmp(argv[i], "--bip38") == 0 && i + 1 < argc) {
+            bip38 = argv[++i];
+        } else if (strcmp(argv[i], "--passphrase") == 0 && i + 1 < argc) {
+            passphrase = argv[++i];
+        } else if (strcmp(argv[i], "--dest") == 0 && i + 1 < argc) {
+            dest = argv[++i];
+        } else if (strcmp(argv[i], "--encrypt-bip38") == 0 && i + 1 < argc) {
+            encrypt_bip38 = argv[++i];
+        } else if (strcmp(argv[i], "--fee-per-kb") == 0 && i + 1 < argc) {
+            fee_per_kb = strtoull(argv[++i], NULL, 10);
+        } else if (strcmp(argv[i], "--min-fee") == 0 && i + 1 < argc) {
+            min_fee = strtoull(argv[++i], NULL, 10);
+        } else if (strcmp(argv[i], "--max-fee") == 0 && i + 1 < argc) {
+            max_fee = strtoull(argv[++i], NULL, 10);
+        } else if (strcmp(argv[i], "--rbf") == 0) {
+            use_rbf = 1;
+        } else if (strcmp(argv[i], "--no-broadcast") == 0) {
+            do_broadcast = 0;
+        } else if (strcmp(argv[i], "--utxo") == 0 && i + 1 < argc) {
+            if (utxo_count >= MAX_UTXOS) {
+                fprintf(stderr, "too many UTXOs (max %d)\n", MAX_UTXOS);
+                return 1;
+            }
+            utxo_args[utxo_count++] = argv[++i];
+        } else {
+            fprintf(stderr, "unknown/incomplete argument: %s\n", argv[i]);
+            usage(argv[0]);
+            return 1;
+        }
+    }
+
+    if (!dest || utxo_count == 0 || (!wif && !(bip38 && passphrase))) {
+        usage(argv[0]);
+        return 1;
+    }
+
+    dogecoin_ecc_start();
+
+    dogecoin_paper_wallet* wallet = dogecoin_paper_wallet_new();
+    dogecoin_sweep_options* opt = NULL;
+    dogecoin_transaction* tx = NULL;
+    if (!wallet) {
+        fprintf(stderr, "failed to allocate paper wallet\n");
+        goto done;
+    }
+
+    if (wif) {
+        printf("[driver] loading paper wallet from WIF\n");
+        if (!dogecoin_paper_wallet_set_wif(wallet, wif, chain)) {
+            fprintf(stderr, "[driver] dogecoin_paper_wallet_set_wif failed\n");
+            goto done;
+        }
+    } else {
+        printf("[driver] loading paper wallet from BIP38 encrypted key\n");
+        if (!dogecoin_paper_wallet_set_encrypted(wallet, bip38, passphrase, chain)) {
+            fprintf(stderr, "[driver] dogecoin_paper_wallet_set_encrypted failed\n");
+            goto done;
+        }
+    }
+
+    if (!dogecoin_paper_wallet_is_valid(wallet)) {
+        fprintf(stderr, "[driver] paper wallet is not valid\n");
+        goto done;
+    }
+
+    /*
+     * Optional BIP38 round trip: encrypt the loaded key (dogecoin_bip38_encrypt),
+     * print the 6P... key, then reload the wallet from it
+     * (dogecoin_paper_wallet_set_encrypted -> BIP38 decrypt) so the sweep that
+     * follows is driven by a key that round-tripped through the full BIP38 API.
+     */
+    if (wif && encrypt_bip38) {
+        uint8_t priv[32];
+        char addr[128];
+        char enckey[128];
+        size_t enclen = sizeof(enckey);
+        memset(priv, 0, sizeof(priv));
+        memset(addr, 0, sizeof(addr));
+        memset(enckey, 0, sizeof(enckey));
+        if (!dogecoin_paper_wallet_get_private_key(wallet, priv) ||
+            !dogecoin_paper_wallet_get_address(wallet, addr, sizeof(addr))) {
+            fprintf(stderr, "[driver] could not extract key/address for BIP38 encrypt\n");
+            goto done;
+        }
+        if (!dogecoin_bip38_encrypt(priv, encrypt_bip38, addr, true, enckey, &enclen)) {
+            dogecoin_mem_zero(priv, sizeof(priv));
+            fprintf(stderr, "[driver] dogecoin_bip38_encrypt failed\n");
+            goto done;
+        }
+        dogecoin_mem_zero(priv, sizeof(priv));
+        printf("[driver] BIP38 encrypted key: %s\n", enckey);
+        printf("[driver] BIP38 passphrase: %s\n", encrypt_bip38);
+        dogecoin_paper_wallet_free(wallet);
+        wallet = dogecoin_paper_wallet_new();
+        if (!wallet) {
+            fprintf(stderr, "[driver] failed to reallocate paper wallet\n");
+            goto done;
+        }
+        printf("[driver] reloading paper wallet from BIP38 encrypted key\n");
+        if (!dogecoin_paper_wallet_set_encrypted(wallet, enckey, encrypt_bip38, chain)) {
+            fprintf(stderr, "[driver] dogecoin_paper_wallet_set_encrypted (round trip) failed\n");
+            goto done;
+        }
+        if (!dogecoin_paper_wallet_is_valid(wallet)) {
+            fprintf(stderr, "[driver] round-tripped paper wallet is not valid\n");
+            goto done;
+        }
+        printf("[driver] BIP38 round trip OK; sweeping with decrypted key\n");
+    }
+
+    {
+        char addr[128];
+        memset(addr, 0, sizeof(addr));
+        if (dogecoin_paper_wallet_get_address(wallet, addr, sizeof(addr))) {
+            printf("[driver] source address: %s\n", addr);
+        }
+    }
+
+    opt = dogecoin_sweep_options_new(chain);
+    if (!opt) {
+        fprintf(stderr, "[driver] dogecoin_sweep_options_new failed\n");
+        goto done;
+    }
+    if (!dogecoin_sweep_options_set_destination(opt, dest)) {
+        fprintf(stderr, "[driver] set_destination failed\n");
+        goto done;
+    }
+    dogecoin_sweep_options_set_fee(
+        opt, dogecoin_sweep_fee_per_kb_to_per_byte(fee_per_kb), min_fee, max_fee);
+    dogecoin_sweep_options_set_rbf(opt, use_rbf ? true : false);
+
+    for (i = 0; (size_t)i < utxo_count; i++) {
+        char buf[256];
+        char* txid;
+        char* vout_s;
+        char* amount;
+        int vout;
+        strncpy(buf, utxo_args[i], sizeof(buf) - 1);
+        buf[sizeof(buf) - 1] = '\0';
+        txid = strtok(buf, ":");
+        vout_s = strtok(NULL, ":");
+        amount = strtok(NULL, ":");
+        if (!txid || !vout_s || !amount) {
+            fprintf(stderr, "[driver] bad --utxo format: %s\n", utxo_args[i]);
+            goto done;
+        }
+        vout = atoi(vout_s);
+        if (!dogecoin_sweep_options_add_utxo(opt, txid, vout, amount)) {
+            fprintf(stderr, "[driver] add_utxo failed for %s\n", utxo_args[i]);
+            goto done;
+        }
+        printf("[driver] added UTXO %s:%d amount=%s DOGE\n", txid, vout, amount);
+    }
+    printf("[driver] configured %zu UTXO(s)\n", dogecoin_sweep_options_utxo_count(opt));
+
+    tx = dogecoin_sweep_create_transaction(wallet, opt);
+    if (!tx) {
+        fprintf(stderr, "[driver] dogecoin_sweep_create_transaction failed\n");
+        goto done;
+    }
+    printf("[driver] unsigned sweep transaction created\n");
+
+    if (!dogecoin_sweep_sign_transaction(tx, wallet)) {
+        fprintf(stderr, "[driver] dogecoin_sweep_sign_transaction failed\n");
+        goto done;
+    }
+    printf("[driver] sweep transaction signed\n");
+
+    if (!dogecoin_sweep_validate_transaction(tx, wallet, opt)) {
+        fprintf(stderr, "[driver] dogecoin_sweep_validate_transaction failed\n");
+        goto done;
+    }
+    printf("[driver] sweep transaction validated\n");
+
+    {
+        uint64_t nin = 0, nout = 0, vin = 0, vout = 0, fee = 0;
+        if (dogecoin_sweep_get_stats(tx, opt, &nin, &nout, &vin, &vout, &fee)) {
+            printf("[driver] stats: inputs=%" PRIu64 " outputs=%" PRIu64
+                   " total_in=%" PRIu64 " koinu total_out=%" PRIu64
+                   " koinu fee=%" PRIu64 " koinu\n",
+                   nin, nout, vin, vout, fee);
+        }
+    }
+
+    {
+        cstring* s = cstr_new_sz(1024);
+        dogecoin_tx_serialize(s, tx);
+        char* hex = dogecoin_char_vla(s->len * 2 + 1);
+        utils_bin_to_hex((unsigned char*)s->str, s->len, hex);
+        printf("[driver] signed sweep tx hex: %s\n", hex);
+        free(hex);
+        cstr_free(s, true);
+    }
+
+    if (do_broadcast) {
+        char txid_out[128];
+        memset(txid_out, 0, sizeof(txid_out));
+        printf("[driver] broadcasting via dogecoin_sweep_broadcast_transaction...\n");
+        if (dogecoin_sweep_broadcast_transaction(tx, chain, txid_out, sizeof(txid_out))) {
+            printf("[driver] BROADCAST OK txid=%s\n", txid_out);
+            rc = 0;
+        } else {
+            fprintf(stderr, "[driver] broadcast failed\n");
+            rc = 2;
+        }
+    } else {
+        printf("[driver] skipping broadcast (--no-broadcast)\n");
+        rc = 0;
+    }
+
+done:
+    if (tx) dogecoin_tx_free(tx);
+    if (opt) dogecoin_sweep_options_free(opt);
+    if (wallet) dogecoin_paper_wallet_free(wallet);
+    dogecoin_ecc_stop();
+    return rc;
+}

--- a/contrib/examples/sweep_example.c
+++ b/contrib/examples/sweep_example.c
@@ -1,0 +1,136 @@
+/*
+ * Paper-wallet sweep example (libdogecoin).
+ *
+ * The app supplies UTXO data from an indexer; libdogecoin builds and signs.
+ *
+ * Build (from repo root, after ./configure && make):
+ *   gcc contrib/examples/sweep_example.c .libs/libdogecoin.a -Iinclude/dogecoin -o sweep_example
+ *
+ * Windows (MSVC, after CMake build):
+ *   cl.exe contrib/examples/sweep_example.c /I"include\dogecoin" /link "build\Debug\dogecoin.lib" ...
+ */
+
+#include <dogecoin/libdogecoin.h>
+#include <dogecoin/bip38.h>
+#include <dogecoin/sweep.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/ecc.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+static void print_sweep_result(const dogecoin_sweep_result* result)
+{
+    if (!result) {
+        printf("  (null result)\n");
+        return;
+    }
+    if (!result->success) {
+        printf("  sweep failed: %s\n",
+               result->error_message ? result->error_message : "unknown");
+        return;
+    }
+    printf("  txid: %s\n", result->transaction_id);
+    printf("  swept: %" PRIu64 " koinu, fee: %" PRIu64 " koinu\n",
+           result->amount_swept, result->fee_paid);
+    printf("  hex (first 80 chars): %.80s...\n", result->transaction_hex);
+}
+
+static dogecoin_bool sweep_wif_example(const dogecoin_chainparams* chain)
+{
+    dogecoin_paper_wallet* wallet;
+    dogecoin_sweep_options* opt;
+    dogecoin_sweep_result* result;
+    dogecoin_bool ok;
+
+    printf("\n--- WIF paper wallet sweep ---\n");
+
+    wallet = dogecoin_paper_wallet_new();
+    if (!wallet) {
+        return false;
+    }
+
+    /* Replace with your paper wallet WIF and real UTXO from your indexer. */
+    ok = dogecoin_paper_wallet_set_wif(wallet, "YOUR_WIF_HERE", chain);
+    if (!ok) {
+        printf("  Set YOUR_WIF_HERE to a valid WIF to run this example.\n");
+        dogecoin_paper_wallet_free(wallet);
+        return true; /* skip demo, not a hard failure */
+    }
+
+    opt = dogecoin_sweep_options_new(chain);
+    dogecoin_sweep_options_set_destination(opt, "D_DESTINATION_ADDRESS");
+    dogecoin_sweep_options_set_fee(
+        opt, dogecoin_sweep_fee_per_kb_to_per_byte(1000000ULL), 1000, 5000000);
+    dogecoin_sweep_options_set_utxo(
+        opt,
+        "b4455e7b7b7acb51fb6feba7a2702c42a5100f61f61abafa31851ed6ae076074",
+        1,
+        "12.0");
+
+    result = dogecoin_sweep_paper_wallet(wallet, opt);
+    print_sweep_result(result);
+    dogecoin_sweep_result_free(result);
+    dogecoin_sweep_options_free(opt);
+    dogecoin_paper_wallet_free(wallet);
+    return true;
+}
+
+static dogecoin_bool sweep_bip38_example(const dogecoin_chainparams* chain)
+{
+    dogecoin_paper_wallet* wallet;
+    dogecoin_sweep_options* opt;
+    dogecoin_sweep_result* result;
+
+    printf("\n--- BIP38 encrypted key sweep ---\n");
+
+    wallet = dogecoin_paper_wallet_new();
+    if (!wallet) {
+        return false;
+    }
+
+    /* Replace with scanned 6P… key, passphrase, and indexer UTXO data. */
+    if (!dogecoin_paper_wallet_set_encrypted(
+            wallet, "6P_YOUR_ENCRYPTED_KEY", "your-passphrase", chain)) {
+        printf("  Set 6P… key and passphrase to run this example.\n");
+        dogecoin_paper_wallet_free(wallet);
+        return true;
+    }
+
+    opt = dogecoin_sweep_options_new(chain);
+    dogecoin_sweep_options_set_destination(opt, "D_DESTINATION_ADDRESS");
+    dogecoin_sweep_options_set_fee(opt, 1000, 1000, 1000000);
+    dogecoin_sweep_options_add_utxo(
+        opt,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        0,
+        "50.0");
+    dogecoin_sweep_options_add_utxo(
+        opt,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        1,
+        "50.0");
+
+    result = dogecoin_sweep_paper_wallet(wallet, opt);
+    print_sweep_result(result);
+    dogecoin_sweep_result_free(result);
+    dogecoin_sweep_options_free(opt);
+    dogecoin_paper_wallet_free(wallet);
+    return true;
+}
+
+int main(void)
+{
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    dogecoin_ecc_start();
+
+    printf("libdogecoin sweep example\n");
+    printf("See doc/sweep.md for integration details.\n");
+
+    sweep_wif_example(chain);
+    sweep_bip38_example(chain);
+
+    dogecoin_ecc_stop();
+    return 0;
+}

--- a/contrib/mainnet_bip38_sweep_test.sh
+++ b/contrib/mainnet_bip38_sweep_test.sh
@@ -1,0 +1,504 @@
+#!/bin/bash
+#
+# BIP38 and Paper Wallet Sweep Mainnet Integration Test Script
+#
+# End-to-end mainnet test for BIP38 encryption/decryption and paper wallet sweep
+# functionality with the libdogecoin CLI tools (such, sendtx, spvnode).
+#
+# This script exercises:
+#   1. Key generation and verification
+#   2. BIP38 encryption (demonstrated through unit tests)
+#   3. Paper wallet sweep transaction building
+#   4. Transaction signing
+#   5. SPV node checkpoint sync and validation
+#   6. Optional transaction broadcast (when UTXOs are available)
+#
+# Prerequisites:
+#   - libdogecoin built with autotools (./configure && make)
+#   - such, sendtx, and spvnode binaries in current directory
+#   - curl, python3 available for UTXO lookups and TX debugging
+#
+# Required environment:
+#   FUNDED_WIF / FUNDED_ADDR        - mainnet privkey/address with UTXOs
+#   FUNDED_UTXO_TXID / VOUT / VALUE - UTXO details for sweep
+#
+# Optional environment:
+#   DESTINATION_ADDR                - where to sweep funds (default: generate new)
+#   BIP38_PASSPHRASE                - passphrase for BIP38 encryption test
+#   SPV_TIMEOUT_SECONDS             - spvnode wait timeout (default 1800)
+#   TX_FEE_KOINU                    - transaction fee (default 2000000)
+#   SKIP_BROADCAST                  - set to 1 to skip actual broadcast
+#
+
+set -e
+umask 077
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ----------------------------- defaults --------------------------------------
+NETWORK_FLAG=""                      # mainnet
+TMPDIR=$(mktemp -d /tmp/bip38_sweep_e2e_XXXXXX)
+chmod 700 "$TMPDIR"
+
+# Funded mainnet wallet credentials (required — no defaults in tree)
+FUNDED_WIF="${FUNDED_WIF:-}"
+FUNDED_ADDR="${FUNDED_ADDR:-}"
+
+# UTXO details - will be looked up if not provided
+FUNDED_UTXO_TXID="${FUNDED_UTXO_TXID:-}"
+FUNDED_UTXO_VOUT="${FUNDED_UTXO_VOUT:-}"
+FUNDED_UTXO_VALUE_KOINU="${FUNDED_UTXO_VALUE_KOINU:-}"
+
+# Destination address (generate new if not provided)
+DESTINATION_ADDR="${DESTINATION_ADDR:-}"
+
+# BIP38 passphrase for encryption test
+# WARNING: test-only default, not secret (see funded-wallet warning above).
+BIP38_PASSPHRASE="${BIP38_PASSPHRASE:-TestDogePassword123}"
+
+# BIP38 passphrase used by the live sweep API round trip (encrypt -> decrypt -> sweep)
+# WARNING: test-only default, not secret (see funded-wallet warning above).
+SWEEP_BIP38_PASSPHRASE="${SWEEP_BIP38_PASSPHRASE:-TestDogeSweep2026!}"
+
+# Sweep API fee parameters (koinu). fee-per-kb maps to libdogecoin fee-per-byte.
+SWEEP_FEE_PER_KB="${SWEEP_FEE_PER_KB:-1000000}"   # 0.01 DOGE/kB (mainnet relay)
+SWEEP_MIN_FEE="${SWEEP_MIN_FEE:-100000}"
+SWEEP_MAX_FEE="${SWEEP_MAX_FEE:-100000000}"
+
+# Sweep API driver (exercises full sweep + BIP38 API and broadcasts the sweep).
+SWEEP_DRIVER="${SWEEP_DRIVER:-./mainnet_sweep_driver}"
+SWEEP_DRIVER_SRC="${SWEEP_DRIVER_SRC:-contrib/examples/mainnet_sweep_driver.c}"
+
+TX_FEE_KOINU="${TX_FEE_KOINU:-2000000}"
+
+SPV_TIMEOUT_SECONDS="${SPV_TIMEOUT_SECONDS:-1800}"
+SPV_NO_BROADCAST_TIMEOUT="${SPV_NO_BROADCAST_TIMEOUT:-30}"
+SENDTX_MAX_RETRIES="${SENDTX_MAX_RETRIES:-3}"
+
+REST_HOST="${REST_HOST:-127.0.0.1}"
+REST_PORT="${REST_PORT:-$((19280 + ($$ % 800)))}"
+REST_SERVER="${REST_SERVER:-${REST_HOST}:${REST_PORT}}"
+
+mkdir -p test-logs
+TS=$(date -u +%Y%m%d_%H%M%S)
+RUN_LOG="${RUN_LOG:-$(pwd)/test-logs/mainnet_bip38_sweep_e2e_${TS}.txt}"
+: > "$RUN_LOG"
+
+SPV_HEADERS_FILE="${SPV_HEADERS_FILE:-$TMPDIR/spv_headers.db}"
+SPV_WALLET_FILE="${SPV_WALLET_FILE:-$TMPDIR/spv_wallet.db}"
+
+# Relay success patterns (same as other test scripts)
+RELAY_SUCCESS_PATTERN='Requested from nodes:[[:space:]]*[1-9]|Seen on other nodes:[[:space:]]*[1-9]|already (broadcasted|known|have transaction)|txn-already-known|txn-already-in-mempool'
+SENDTX_FATAL_PATTERN='Requested from nodes:[[:space:]]*0.*Seen on other nodes:[[:space:]]*0|not relayed back|very likely invalid'
+
+# ----------------------------- logging helpers -------------------------------
+info()    { echo -e "${BLUE}[INFO]${NC} $1"    | tee -a "$RUN_LOG"; }
+success() { echo -e "${GREEN}[SUCCESS]${NC} $1" | tee -a "$RUN_LOG"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $1"   | tee -a "$RUN_LOG"; }
+error()   { echo -e "${RED}[ERROR]${NC} $1"     | tee -a "$RUN_LOG"; exit 1; }
+
+run_and_log() {
+    local label="$1"; shift
+    echo "----- ${label}: $* -----" | tee -a "$RUN_LOG"
+    "$@" 2>&1 | tee -a "$RUN_LOG"
+    local rc=${PIPESTATUS[0]}
+    echo "----- ${label} exit=${rc} -----" | tee -a "$RUN_LOG"
+    return $rc
+}
+
+# ----------------------------- UTXO lookup -----------------------------------
+lookup_utxos() {
+    local addr="$1"
+    info "Looking up UTXOs for $addr..."
+    
+    # Try blockcypher
+    local utxos
+    utxos=$(curl -sf "https://api.blockcypher.com/v1/doge/main/addrs/${addr}?unspentOnly=true&includeScript=true" 2>/dev/null || true)
+    
+    if [ -n "$utxos" ]; then
+        echo "$utxos" | tee -a "$RUN_LOG"
+        local tx_ref
+        tx_ref=$(echo "$utxos" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    if 'txrefs' in d and len(d['txrefs']) > 0:
+        ref = d['txrefs'][0]
+        print(f\"{ref['tx_hash']}:{ref['tx_output_n']}:{ref['value']}\")
+except:
+    pass
+" 2>/dev/null || true)
+        if [ -n "$tx_ref" ]; then
+            FUNDED_UTXO_TXID=$(echo "$tx_ref" | cut -d: -f1)
+            FUNDED_UTXO_VOUT=$(echo "$tx_ref" | cut -d: -f2)
+            FUNDED_UTXO_VALUE_KOINU=$(echo "$tx_ref" | cut -d: -f3)
+            success "Found UTXO: txid=$FUNDED_UTXO_TXID vout=$FUNDED_UTXO_VOUT value=$FUNDED_UTXO_VALUE_KOINU koinu"
+            return 0
+        fi
+    fi
+    
+    warn "Could not find UTXOs via blockcypher API"
+    return 1
+}
+
+# ----------------------- multi-UTXO lookup (sweep API) -----------------------
+# Collects every unspent output for an address into $UTXO_LIST_FILE as
+# "txid:vout:amount_doge" lines and sets SWEEP_TOTAL_KOINU / SWEEP_UTXO_COUNT.
+UTXO_LIST_FILE="$TMPDIR/utxos.txt"
+SWEEP_TOTAL_KOINU=0
+SWEEP_UTXO_COUNT=0
+lookup_all_utxos() {
+    local addr="$1"
+    info "Looking up ALL UTXOs for $addr (multi-UTXO sweep)..."
+    : > "$UTXO_LIST_FILE"
+
+    local utxos
+    utxos=$(curl -sf "https://api.blockcypher.com/v1/doge/main/addrs/${addr}?unspentOnly=true&includeScript=true&limit=2000" 2>/dev/null || true)
+    if [ -z "$utxos" ]; then
+        warn "Could not fetch UTXO set via blockcypher API"
+        return 1
+    fi
+    echo "$utxos" | tee -a "$RUN_LOG" >/dev/null
+
+    echo "$utxos" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+total = 0
+for ref in d.get('txrefs', []):
+    if ref.get('spent'):
+        continue
+    val = int(ref['value'])
+    total += val
+    doge = f'{val/100000000:.8f}'
+    print(f\"{ref['tx_hash']}:{ref['tx_output_n']}:{doge}\")
+sys.stderr.write(str(total))
+" >"$UTXO_LIST_FILE" 2>"$TMPDIR/utxo_total.txt" || true
+
+    SWEEP_TOTAL_KOINU=$(cat "$TMPDIR/utxo_total.txt" 2>/dev/null || echo 0)
+    SWEEP_UTXO_COUNT=$(grep -c ':' "$UTXO_LIST_FILE" 2>/dev/null || echo 0)
+    if [ "$SWEEP_UTXO_COUNT" -gt 0 ]; then
+        success "Found $SWEEP_UTXO_COUNT UTXO(s), total $SWEEP_TOTAL_KOINU koinu"
+        cat "$UTXO_LIST_FILE" | tee -a "$RUN_LOG"
+        return 0
+    fi
+    warn "No spendable UTXOs found for $addr"
+    return 1
+}
+
+# --------------------- build the sweep API driver ----------------------------
+build_sweep_driver() {
+    if [ -x "$SWEEP_DRIVER" ]; then
+        info "Sweep driver already built: $SWEEP_DRIVER"
+        return 0
+    fi
+    if [ ! -f ".libs/libdogecoin.a" ]; then
+        warn "Static library .libs/libdogecoin.a not found; cannot build sweep driver"
+        return 1
+    fi
+    info "Compiling sweep API driver from $SWEEP_DRIVER_SRC..."
+    local evlibs
+    evlibs=$(pkg-config --libs libevent 2>/dev/null || echo "-levent")
+    if gcc "$SWEEP_DRIVER_SRC" .libs/libdogecoin.a $evlibs -lpthread -lm \
+        -Iinclude -o "$SWEEP_DRIVER" 2>&1 | tee -a "$RUN_LOG"; then
+        success "Sweep driver built: $SWEEP_DRIVER"
+        return 0
+    fi
+    warn "Failed to build sweep driver"
+    return 1
+}
+
+# ----------------------------- TX debug --------------------------------------
+debug_tx_hex() {
+    local tx_hex="$1"; local label="${2:-TX}"
+    python3 - "$tx_hex" "$label" <<'PYDEBUG'
+import sys, struct
+tx_hex = sys.argv[1]; label = sys.argv[2]; tx = bytes.fromhex(tx_hex); off = 0
+def ru32(): global off; v=struct.unpack_from('<I',tx,off)[0]; off+=4; return v
+def ru64(): global off; v=struct.unpack_from('<Q',tx,off)[0]; off+=8; return v
+def rvar():
+    global off; b=tx[off]; off+=1
+    if b<0xfd: return b
+    if b==0xfd: v=struct.unpack_from('<H',tx,off)[0]; off+=2; return v
+    if b==0xfe: v=struct.unpack_from('<I',tx,off)[0]; off+=4; return v
+    v=struct.unpack_from('<Q',tx,off)[0]; off+=8; return v
+print(f"=== {label} Debug (size={len(tx)} bytes) ===")
+ver=ru32(); print(f"  version: {ver}"); nin=rvar(); print(f"  inputs: {nin}")
+for i in range(nin):
+    ph=tx[off:off+32][::-1].hex(); off+=32; pi=ru32(); sl=rvar(); off+=sl; sq=ru32()
+    print(f"    in[{i}]: txid={ph} vout={pi} scriptSig_len={sl}")
+nout=rvar(); print(f"  outputs: {nout}")
+for i in range(nout):
+    val=ru64(); sl=rvar(); spk=tx[off:off+sl].hex(); off+=sl; vd=val/1e8
+    kind="P2PKH" if spk.startswith('76a914') else "P2SH" if spk.startswith('a914') else "OP_RETURN" if spk.startswith('6a') else "unknown"
+    dust_ok = "OK" if (val==0 and kind=="OP_RETURN") or val>=100000 else f"DUST(need>=0.001DOGE)"
+    print(f"    out[{i}]: {val} koinu ({vd:.8f} DOGE) type={kind} dust={dust_ok}")
+print(f"=== end {label} ===")
+PYDEBUG
+}
+
+# ----------------------------- broadcast -------------------------------------
+broadcast_with_retry() {
+    local label="$1"; local signed_tx="$2"; local max_retries="${3:-$SENDTX_MAX_RETRIES}"
+    local attempt=0; local sendtx_output="" txid=""
+    while [ "$attempt" -lt "$max_retries" ]; do
+        attempt=$((attempt + 1)); info "Broadcast attempt $attempt/$max_retries for $label..."
+        sendtx_output=$(run_and_log "sendtx $label attempt=$attempt" ./sendtx -d -m 16 -s 30 $NETWORK_FLAG "$signed_tx" || true)
+        echo "$sendtx_output" | sed 's/Error:/sendtx-note:/g' | tee -a "$RUN_LOG"
+        txid=$(echo "$sendtx_output" | sed -n 's/^Start broadcasting transaction:[[:space:]]*\([0-9a-fA-F]\{64\}\).*/\1/p' | head -n1)
+        if echo "$sendtx_output" | grep -Eqi "$RELAY_SUCCESS_PATTERN"; then
+            BROADCAST_RESULT_TXID="$txid"; success "$label broadcast accepted on attempt $attempt: $txid"; return 0
+        fi
+        if echo "$sendtx_output" | grep -Eqi "$SENDTX_FATAL_PATTERN"; then
+            echo -e "${YELLOW}[WARN]${NC} $label relay failed on attempt $attempt. Debugging TX format..."
+            debug_tx_hex "$signed_tx" "$label" 2>&1 | tee -a "$RUN_LOG"
+            [ "$attempt" -lt "$max_retries" ] && sleep 10
+        elif [ -n "$txid" ]; then
+            BROADCAST_RESULT_TXID="$txid"; return 0
+        fi
+    done
+    BROADCAST_RESULT_TXID="$txid"; return 1
+}
+
+# ----------------------------- wait for REST ---------------------------------
+wait_for_rest_tx() {
+    local txid="$1"
+    local timeout="$2"
+    local start_ts now_ts
+    local txid_le
+    local rest_utxos rest_txs
+    start_ts=$(date +%s)
+    txid_le=$(echo "$txid" | sed 's/../& /g' | awk '{for(i=NF;i>=1;i--) printf $i}' | tr -d '\n')
+    while true; do
+        rest_utxos=$(curl -fsS "http://${REST_SERVER}/getUTXOs" 2>/dev/null || true)
+        rest_txs=$(curl -fsS "http://${REST_SERVER}/getTransactions" 2>/dev/null || true)
+        if echo "$rest_utxos$rest_txs" | grep -Eqi "${txid}|${txid_le}"; then
+            date +%s
+            return 0
+        fi
+        now_ts=$(date +%s)
+        if [ $((now_ts - start_ts)) -ge "$timeout" ]; then
+            return 1
+        fi
+        sleep 1
+    done
+}
+
+# ----------------------------- check tools -----------------------------------
+check_tools() {
+    info "Checking required tools..."
+    for tool in such sendtx spvnode; do
+        if [ ! -f "./$tool" ] && ! command -v $tool &> /dev/null; then
+            error "$tool not found. Please build libdogecoin first."
+        fi
+    done
+    if ! command -v curl &> /dev/null; then
+        error "curl not found. Required for UTXO lookups."
+    fi
+    if ! command -v python3 &> /dev/null; then
+        error "python3 not found. Required for TX debugging."
+    fi
+    success "All tools available"
+}
+
+# ----------------------------- main test flow --------------------------------
+main() {
+    info "=========================================="
+    info "BIP38 and Paper Wallet Sweep E2E Test"
+    info "=========================================="
+    info "Log file: $RUN_LOG"
+    info "Temp directory: $TMPDIR"
+    
+    check_tools
+
+    if [ -z "$FUNDED_WIF" ] || [ -z "$FUNDED_ADDR" ]; then
+        error "FUNDED_WIF and FUNDED_ADDR must be set (mainnet wallet with UTXOs). Example: FUNDED_WIF=... FUNDED_ADDR=D... ./contrib/mainnet_bip38_sweep_test.sh"
+    fi
+    
+    # Step 1: Verify funded wallet
+    info "Step 1: Verify funded wallet credentials"
+    run_and_log "such generate_public_key" ./such -c generate_public_key -p "$FUNDED_WIF" $NETWORK_FLAG | tee "$TMPDIR/funded_addr.txt"
+    DERIVED_ADDR=$(grep "p2pkh address:" "$TMPDIR/funded_addr.txt" | cut -d: -f2 | tr -d ' ')
+    if [ "$DERIVED_ADDR" != "$FUNDED_ADDR" ]; then
+        error "WIF does not derive to expected address. Expected: $FUNDED_ADDR, Got: $DERIVED_ADDR"
+    fi
+    success "Funded wallet verified: $FUNDED_ADDR"
+    
+    # Step 2: Generate destination address
+    if [ -z "$DESTINATION_ADDR" ]; then
+        info "Step 2: Generate new destination address"
+        run_and_log "such generate_private_key" ./such -c generate_private_key $NETWORK_FLAG | tee "$TMPDIR/dest_key.txt"
+        DEST_WIF=$(grep "private key wif:" "$TMPDIR/dest_key.txt" | cut -d: -f2 | tr -d ' ')
+        run_and_log "such generate_public_key (dest)" ./such -c generate_public_key -p "$DEST_WIF" $NETWORK_FLAG | tee "$TMPDIR/dest_addr.txt"
+        DESTINATION_ADDR=$(grep "p2pkh address:" "$TMPDIR/dest_addr.txt" | cut -d: -f2 | tr -d ' ')
+        success "Generated destination address: $DESTINATION_ADDR"
+    else
+        info "Step 2: Using provided destination address: $DESTINATION_ADDR"
+    fi
+    
+    # Step 3: Test BIP38 encryption/decryption
+    info "Step 3: Test BIP38 encryption and decryption"
+    
+    # Generate a test key for BIP38
+    run_and_log "such generate_private_key (BIP38 test)" ./such -c generate_private_key $NETWORK_FLAG | tee "$TMPDIR/bip38_test_key.txt"
+    BIP38_TEST_WIF=$(grep "private key wif:" "$TMPDIR/bip38_test_key.txt" | cut -d: -f2 | tr -d ' ')
+    BIP38_TEST_HEX=$(grep "private key hex:" "$TMPDIR/bip38_test_key.txt" | cut -d: -f2 | tr -d ' ')
+    
+    run_and_log "such generate_public_key (BIP38 test)" ./such -c generate_public_key -p "$BIP38_TEST_WIF" $NETWORK_FLAG | tee "$TMPDIR/bip38_test_addr.txt"
+    BIP38_TEST_ADDR=$(grep "p2pkh address:" "$TMPDIR/bip38_test_addr.txt" | cut -d: -f2 | tr -d ' ')
+    
+    success "Generated test key for BIP38: WIF=$BIP38_TEST_WIF Address=$BIP38_TEST_ADDR"
+    
+    # Step 3b: Run BIP38 and sweep unit tests to verify library functionality
+    info "Step 3b: Running BIP38 and sweep unit tests..."
+    run_and_log "unit tests (BIP38+sweep)" ./tests 2>&1 | grep -E "bip38|sweep|BIP38|Sweep|PASSED|FAILED" | tee "$TMPDIR/unit_tests.txt"
+    
+    if grep -q "PASSED - test_sweep()" "$TMPDIR/unit_tests.txt"; then
+        success "BIP38 and sweep unit tests PASSED"
+    else
+        warn "BIP38/sweep unit tests may have issues - check logs"
+    fi
+    
+    # Step 4: Look up the full UTXO set for the funded address (multi-UTXO sweep)
+    info "Step 4: Looking up UTXOs for funded address (full set)..."
+    UTXO_AVAILABLE=0
+    if lookup_all_utxos "$FUNDED_ADDR"; then
+        UTXO_AVAILABLE=1
+    else
+        warn "Could not auto-lookup UTXOs. Will demonstrate SPV sync only."
+    fi
+
+    BROADCAST_RESULT_TXID=""
+    OUTPUT_VALUE_DOGE="N/A"
+    BIP38_SWEEP_KEY="N/A"
+
+    if [ "$UTXO_AVAILABLE" -eq 1 ]; then
+        # Step 5: Build the sweep API driver
+        info "Step 5: Build sweep API driver"
+        if ! build_sweep_driver; then
+            error "Could not build sweep API driver; cannot exercise sweep API"
+        fi
+
+        # Step 6: Run the live sweep via the sweep API (BIP38 encrypt -> decrypt ->
+        # create -> sign -> validate -> stats -> broadcast). One invocation
+        # exercises the full BIP38 API and the full sweep API and transmits the tx.
+        info "Step 6: Sweep all UTXOs to destination via the sweep API"
+        info "Funded WIF will be BIP38-encrypted (passphrase: $SWEEP_BIP38_PASSPHRASE) then decrypted and swept"
+
+        SWEEP_UTXO_ARGS=()
+        while IFS= read -r line; do
+            [ -n "$line" ] && SWEEP_UTXO_ARGS+=(--utxo "$line")
+        done < "$UTXO_LIST_FILE"
+
+        SWEEP_BROADCAST_FLAG=()
+        if [ "${SKIP_BROADCAST:-0}" = "1" ]; then
+            warn "SKIP_BROADCAST=1 set; sweep will be built/signed/validated but NOT broadcast"
+            SWEEP_BROADCAST_FLAG=(--no-broadcast)
+        fi
+
+        SWEEP_OUTPUT=$(run_and_log "sweep API driver" "$SWEEP_DRIVER" \
+            --wif "$FUNDED_WIF" \
+            --encrypt-bip38 "$SWEEP_BIP38_PASSPHRASE" \
+            --dest "$DESTINATION_ADDR" \
+            --fee-per-kb "$SWEEP_FEE_PER_KB" \
+            --min-fee "$SWEEP_MIN_FEE" \
+            --max-fee "$SWEEP_MAX_FEE" \
+            "${SWEEP_BROADCAST_FLAG[@]}" \
+            "${SWEEP_UTXO_ARGS[@]}" || true)
+        echo "$SWEEP_OUTPUT" | tee -a "$RUN_LOG"
+
+        BIP38_SWEEP_KEY=$(echo "$SWEEP_OUTPUT" | sed -n 's/.*BIP38 encrypted key:[[:space:]]*\(6P[A-Za-z0-9]\{1,\}\).*/\1/p' | head -n1)
+        BROADCAST_RESULT_TXID=$(echo "$SWEEP_OUTPUT" | sed -n 's/.*BROADCAST OK txid=\([0-9a-fA-F]\{64\}\).*/\1/p' | head -n1)
+        SWEEP_OUT_KOINU=$(echo "$SWEEP_OUTPUT" | sed -n 's/.*total_out=\([0-9]\{1,\}\) koinu.*/\1/p' | head -n1)
+        if [ -n "$SWEEP_OUT_KOINU" ]; then
+            OUTPUT_VALUE_DOGE=$(python3 -c "print(f'{$SWEEP_OUT_KOINU / 100000000:.8f}')")
+        fi
+
+        if echo "$SWEEP_OUTPUT" | grep -q "BROADCAST OK"; then
+            success "Sweep transaction broadcast via sweep API: $BROADCAST_RESULT_TXID"
+        elif echo "$SWEEP_OUTPUT" | grep -q "skipping broadcast"; then
+            success "Sweep transaction built/signed/validated via sweep API (broadcast skipped)"
+        else
+            warn "Sweep API broadcast may have failed - check logs for details"
+        fi
+    fi  # End of UTXO_AVAILABLE check
+    
+    # Step 8: SPV Node sync test (runs regardless of UTXO availability)
+    info "Step 8: SPV node sync with checkpoint mode"
+    
+    rm -f "$SPV_WALLET_FILE" "$SPV_HEADERS_FILE" 2>/dev/null
+    
+    info "Running spvnode with checkpoint (-p) and block mode (-b) for fast sync..."
+    
+    # Start spvnode in background
+    : > "$TMPDIR/spvnode.log"
+    timeout 120 ./spvnode $NETWORK_FLAG -l -h "$SPV_HEADERS_FILE" -w "$SPV_WALLET_FILE" -d -p -b -a "$FUNDED_ADDR $DESTINATION_ADDR" scan 2>&1 | tee "$TMPDIR/spvnode.log" | tee -a "$RUN_LOG" &
+    SPV_PID=$!
+    
+    info "SPV node started (PID=$SPV_PID), syncing for up to 60 seconds..."
+    
+    # Let SPV sync for a bit
+    sleep 60
+    
+    # Check if still running
+    if kill -0 "$SPV_PID" 2>/dev/null; then
+        info "SPV node still running, checking status..."
+        # Check headers synced
+        if [ -f "$SPV_HEADERS_FILE" ]; then
+            HEADERS_SIZE=$(stat -f%z "$SPV_HEADERS_FILE" 2>/dev/null || stat -c%s "$SPV_HEADERS_FILE" 2>/dev/null || echo "0")
+            info "Headers file size: $HEADERS_SIZE bytes"
+        fi
+        
+        # Stop spvnode
+        info "Stopping spvnode..."
+        kill "$SPV_PID" 2>/dev/null || true
+        wait "$SPV_PID" 2>/dev/null || true
+        success "SPV node sync test completed"
+    else
+        wait "$SPV_PID" 2>/dev/null
+        SPV_EXIT=$?
+        if [ "$SPV_EXIT" -eq 0 ]; then
+            success "SPV node sync completed"
+        else
+            warn "SPV node exited with code: $SPV_EXIT"
+        fi
+    fi
+    
+    # Print SPV log summary
+    info "SPV node log summary:"
+    grep -E "connected|synced|sync|checkpoint|block|header|peer" "$TMPDIR/spvnode.log" 2>/dev/null | tail -20 || true
+    
+    # Step 9: Summary
+    info "=========================================="
+    info "BIP38 and Sweep E2E Test Summary"
+    info "=========================================="
+    info "Funded Address: $FUNDED_ADDR"
+    info "Destination Address: $DESTINATION_ADDR"
+    info "BIP38 Test Address: $BIP38_TEST_ADDR"
+    info "Sweep UTXO count: ${SWEEP_UTXO_COUNT:-N/A} (total ${SWEEP_TOTAL_KOINU:-N/A} koinu)"
+    info "Sweep Amount: $OUTPUT_VALUE_DOGE DOGE"
+    info "BIP38 sweep key (6P...): ${BIP38_SWEEP_KEY:-N/A}"
+    info "BIP38 sweep passphrase: $SWEEP_BIP38_PASSPHRASE"
+    info "Broadcast TXID: ${BROADCAST_RESULT_TXID:-N/A}"
+    info "Log file: $RUN_LOG"
+    info "=========================================="
+    info "------------------------------------------"
+    info "FUND RETRIEVAL DETAILS (KEEP SAFE)"
+    info "Any DOGE swept during this test lands at the destination below and is"
+    info "spendable with the destination WIF. These are recorded so the funds"
+    info "can be recovered later (e.g. ./such -c generate_public_key -p <WIF>)."
+    info "  Destination address: $DESTINATION_ADDR"
+    info "  Destination WIF:     ${DEST_WIF:-(supplied externally: $DESTINATION_ADDR)}"
+    info "------------------------------------------"
+    
+    success "BIP38 and Paper Wallet Sweep E2E test completed!"
+    
+    # Cleanup
+    info "Temp files preserved in: $TMPDIR"
+}
+
+# Run main
+main "$@"

--- a/doc/sweep.md
+++ b/doc/sweep.md
@@ -233,7 +233,28 @@ dogecoin_sweep_get_stats(tx, opt, &inputs, &outputs, &in_value, &out_value, &fee
 
 ## Example program
 
-`contrib/examples/sweep_example.c` shows WIF and BIP38 sweep flows. Build from the repo root after `make`:
+`contrib/examples/sweep_example.c` shows WIF and BIP38 sweep flows (offline, no broadcast).
+
+`contrib/examples/mainnet_sweep_driver.c` is a CLI driver for the full sweep API on mainnet (create, sign, validate, optional broadcast). Built automatically by `contrib/mainnet_bip38_sweep_test.sh`, or manually:
+
+```bash
+gcc contrib/examples/mainnet_sweep_driver.c .libs/libdogecoin.a \
+    $(pkg-config --libs libevent) -lpthread -Iinclude -Iinclude/dogecoin \
+    -o mainnet_sweep_driver
+```
+
+### Mainnet end-to-end test script
+
+`contrib/mainnet_bip38_sweep_test.sh` runs unit tests, builds the sweep driver, sweeps all UTXOs from a funded address via the sweep API (with optional BIP38 encrypt/decrypt round trip), and exercises SPV checkpoint sync. **Requires** a funded mainnet wallet via environment variables (no credentials in the script):
+
+```bash
+export FUNDED_WIF="your_mainnet_wif"
+export FUNDED_ADDR="your_D_address"
+# optional: SKIP_BROADCAST=1
+./contrib/mainnet_bip38_sweep_test.sh
+```
+
+Build from the repo root after `make`:
 
 ```bash
 gcc contrib/examples/sweep_example.c .libs/libdogecoin.a -Iinclude/dogecoin -o sweep_example
@@ -323,5 +344,7 @@ Constants: `BIP38_ADDRESS_MATCH_MAINNET`, `BIP38_ADDRESS_MATCH_INTEROP`, buffer 
 ### Related
 
 - `include/dogecoin/scrypt.h` — `dogecoin_scrypt_rfc7914()` (RFC 7914 KDF used by BIP38; normally called internally)
-- `contrib/examples/sweep_example.c` — minimal integration sample
+- `contrib/examples/sweep_example.c` — minimal offline integration sample
+- `contrib/examples/mainnet_sweep_driver.c` — mainnet sweep API CLI driver
+- `contrib/mainnet_bip38_sweep_test.sh` — mainnet E2E test (requires `FUNDED_WIF` / `FUNDED_ADDR`)
 - `test/sweep_tests.c` — vectors and integration tests

--- a/doc/sweep.md
+++ b/doc/sweep.md
@@ -275,9 +275,9 @@ make check    # autotools
 | `dogecoin_bip38_is_compressed` | Compressed pubkey flag in key |
 | `dogecoin_bip38_is_ec_multiplied` | 0x43 EC-multiplied type |
 | `dogecoin_bip38_has_lot_sequence` | Lot/sequence present |
-| `dogecoin_bip38_get_address_hash` | Extract 4-byte address hash |
-| `dogecoin_bip38_verify_address_hash` | Compare embedded hash to address |
-| `dogecoin_bip38_get_flag_byte` | Raw BIP38 flag byte |
+| `dogecoin_bip38_get_address_hash` | Extract 4-byte address hash (valid BIP38 payload only) |
+| `dogecoin_bip38_verify_address_hash` | Compare embedded hash to one address string |
+| `dogecoin_bip38_get_flag_byte` | Raw BIP38 flag byte (valid payload; rejects bad magic/type/flags) |
 | `dogecoin_bip38_generate_lot_sequence` | Random lot + sequence for EC flow |
 
 Constants: `BIP38_ADDRESS_MATCH_MAINNET`, `BIP38_ADDRESS_MATCH_INTEROP`, buffer sizes (`BIP38_ENCRYPTED_KEY_LENGTH`, `BIP38_INTERMEDIATE_CODE_MAXLEN`, etc.) — see `include/dogecoin/bip38.h`.

--- a/doc/sweep.md
+++ b/doc/sweep.md
@@ -38,7 +38,7 @@ dogecoin_bip38_encrypt(privkey, passphrase, doge_address, compressed, enc_out, &
 
 // EC-multiplied (0x43): two-party flow
 dogecoin_bip38_generate_intermediate_code(passphrase, use_lot, lot, seq, NULL, intermediate, &isz);
-dogecoin_bip38_encrypt_from_intermediate(intermediate, compressed, NULL, "D…", NULL, enc, &esz, confirm, &csz);
+dogecoin_bip38_encrypt_from_intermediate(intermediate, compressed, NULL, "D…", enc, &esz, confirm, &csz);
 // Or one-shot: dogecoin_bip38_encrypt_ec_multiplied(passphrase, compressed, use_lot, lot, seq, "D…", priv, enc, &esz, confirm, &csz);
 
 // Decrypt (0x42 and 0x43)
@@ -78,7 +78,7 @@ Paper wallet wrapper (decrypt + derive `D…` address):
 dogecoin_paper_wallet* w = dogecoin_paper_wallet_new();
 dogecoin_paper_wallet_set_encrypted(w, "6P…", "passphrase", &dogecoin_chainparams_main);
 // or: dogecoin_paper_wallet_set_wif(w, wif, chain);
-// or: dogecoin_paper_wallet_set_hex(w, hex_privkey, chain);
+// or: dogecoin_paper_wallet_set_hex(w, hex_privkey, true /* compressed */, chain);
 
 char address[36];
 dogecoin_paper_wallet_get_address(w, address, sizeof(address));

--- a/doc/sweep.md
+++ b/doc/sweep.md
@@ -92,6 +92,23 @@ dogecoin_paper_wallet_free(w);
 
 `dogecoin_paper_wallet_set_encrypted()` uses Dogecoin-mainnet BIP38 decrypt semantics (`BIP38_ADDRESS_MATCH_MAINNET`). For strict Bitcoin-only BIP-0038 interop vectors, call `dogecoin_bip38_decrypt_ex()` with `BIP38_ADDRESS_MATCH_INTEROP` directly.
 
+### Address-match semantics (quick reference)
+
+| API | Mode | Accepts |
+|-----|------|---------|
+| `dogecoin_bip38_decrypt()` | mainnet (default) | Dogecoin mainnet P2PKH address hash |
+| `dogecoin_bip38_decrypt_ex(..., INTEROP, ...)` | interoperability | mainnet + testnet + regtest + legacy Bitcoin `1…` P2PKH |
+| `dogecoin_bip38_confirm_passphrase()` | mainnet (default) | Same mainnet check; outputs matching `D…` address |
+| `dogecoin_bip38_confirm_passphrase_ex(..., INTEROP, ...)` | interoperability | Same multi-chain/legacy matching as decrypt interop |
+| `dogecoin_paper_wallet_set_encrypted()` | mainnet wrapper | Decrypt via `MAINNET`; address from your `chain_params` |
+| `dogecoin_bip38_verify_address_hash()` | literal helper | Embedded hash vs one address string you supply (no mode flag) |
+
+Official BIP-0038 reference vectors that use legacy Bitcoin addresses require `BIP38_ADDRESS_MATCH_INTEROP` on the `_ex` decrypt/confirm helpers — plain `dogecoin_bip38_decrypt()` will reject them by design.
+
+### Scrypt note
+
+BIP38 passphrase KDF uses RFC 7914 scrypt with caller-chosen `N/r/p` via `dogecoin_scrypt_rfc7914()` in `scrypt.c`. That is separate from the fixed PoW entry point `scrypt_1024_1_1_256()` (mining parameters, 32-byte output). BIP38 calls the RFC helper internally; applications normally do not call it directly.
+
 ## Sweep API — caller supplies chain data
 
 ### Single UTXO
@@ -249,7 +266,7 @@ make check    # autotools
 | `dogecoin_bip38_encrypt_from_intermediate` | Printer-side EC encrypt from intermediate |
 | `dogecoin_bip38_encrypt_ec_multiplied` | One-shot EC encrypt (+ optional confirmation) |
 | `dogecoin_bip38_confirm_passphrase` | Verify confirmation code (mainnet address out) |
-| `dogecoin_bip38_confirm_passphrase_ex` | Verify confirmation with address-match mode |
+| `dogecoin_bip38_confirm_passphrase_ex` | Verify confirmation; `INTEROP` matches decrypt interop chains |
 | `dogecoin_bip38_private_key_to_wif` | Raw 32-byte key → WIF for chain |
 | `dogecoin_bip38_wif_to_private_key` | WIF → raw key |
 | `dogecoin_bip38_is_valid` | Valid `6P…` encrypted key |

--- a/doc/sweep.md
+++ b/doc/sweep.md
@@ -1,0 +1,310 @@
+# Paper Wallet Sweeping and BIP38 Support
+
+This document describes BIP-0038 private key encryption and paper-wallet sweeping in libdogecoin. The library builds and signs transactions; **your application** supplies UTXOs, fees, destination, and broadcast (same split as dogecoin-wallet uses with BlockCypher + bitcoinj).
+
+## Including the Headers
+
+```c
+#include <dogecoin/bip38.h>
+#include <dogecoin/sweep.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/ecc.h>
+```
+
+`libdogecoin.h` documents these APIs inline but does not include `bip38.h` / `sweep.h` (keeps enclave and minimal builds lean). Include the headers above when calling BIP38 or sweep functions.
+
+Call `dogecoin_ecc_start()` before any signing or BIP38 scrypt work, and `dogecoin_ecc_stop()` when finished.
+
+## Architecture (lib vs app)
+
+| Responsibility | Application (e.g. dogecoin-wallet) | libdogecoin |
+|----------------|-------------------------------------|-------------|
+| Scan / paste `6P…` BIP38 key | Yes | Decrypt via `dogecoin_bip38_decrypt` |
+| Passphrase UI | Yes | — |
+| Find UTXOs (indexer, node, wallet DB) | Yes | — |
+| `txid`, `vout`, amount per coin | Yes | `dogecoin_sweep_options_set_utxo` / `add_utxo` |
+| Fee policy | Yes | `dogecoin_sweep_options_set_fee` |
+| Destination address | Yes | `dogecoin_sweep_options_set_destination` |
+| Build + sign sweep tx | — | `dogecoin_sweep_paper_wallet` |
+| Broadcast | Yes (or `WITH_NET`) | Optional `dogecoin_sweep_broadcast_transaction` |
+
+## BIP-0038 API
+
+Passphrases are NFC-normalized (Unicode) before scrypt, per BIP-0038. Non-EC encrypt uses Dogecoin `D…` addresses; decrypt also accepts legacy Bitcoin interoperability vectors.
+
+```c
+// Non-EC (0x42): encrypt an existing private key
+dogecoin_bip38_encrypt(privkey, passphrase, doge_address, compressed, enc_out, &enc_sz);
+
+// EC-multiplied (0x43): two-party flow
+dogecoin_bip38_generate_intermediate_code(passphrase, use_lot, lot, seq, NULL, intermediate, &isz);
+dogecoin_bip38_encrypt_from_intermediate(intermediate, compressed, NULL, "D…", NULL, enc, &esz, confirm, &csz);
+// Or one-shot: dogecoin_bip38_encrypt_ec_multiplied(passphrase, compressed, use_lot, lot, seq, "D…", priv, enc, &esz, confirm, &csz);
+
+// Decrypt (0x42 and 0x43)
+dogecoin_bip38_decrypt(enc_key, passphrase, privkey_out, &compressed);
+dogecoin_bip38_decrypt_ex(enc_key, passphrase, BIP38_ADDRESS_MATCH_MAINNET, privkey_out, &compressed);
+/* BIP38_ADDRESS_MATCH_INTEROP — testnet/regtest + legacy Bitcoin P2PKH for BIP-0038 vectors */
+dogecoin_bip38_decrypt_passphrase(enc_key, passphrase_bytes, passphrase_len, privkey_out, &compressed);
+dogecoin_bip38_decrypt_passphrase_ex(enc_key, passphrase_bytes, passphrase_len, BIP38_ADDRESS_MATCH_MAINNET, privkey_out, &compressed);
+dogecoin_bip38_encrypt_passphrase(privkey, passphrase_bytes, passphrase_len, "D…", compressed, enc, &esz);
+dogecoin_bip38_decrypt_with_lot_sequence(enc_key, passphrase, privkey_out, &compressed, &lot, &seq);
+dogecoin_bip38_decrypt_with_lot_sequence_ex(enc_key, passphrase, BIP38_ADDRESS_MATCH_MAINNET, privkey_out, &compressed, &lot, &seq);
+
+// Owner verifies printer confirmation code (cfrm38…)
+dogecoin_bip38_confirm_passphrase(passphrase, confirm_code, address_out, sizeof(address_out), &compressed, &lot, &seq);
+dogecoin_bip38_confirm_passphrase_ex(passphrase, confirm_code, BIP38_ADDRESS_MATCH_MAINNET, address_out, sizeof(address_out), &compressed, &lot, &seq);
+
+// WIF helpers (chain-specific secret prefix from dogecoin_chainparams)
+dogecoin_bip38_private_key_to_wif(privkey, chain, compressed, wif_out, &wif_sz);
+dogecoin_bip38_wif_to_private_key(wif, chain, privkey_out, &compressed);
+
+// Introspection / validation
+dogecoin_bip38_is_valid(enc_key);
+dogecoin_bip38_is_intermediate_code(intermediate);
+dogecoin_bip38_is_confirmation_code(confirm_code);
+dogecoin_bip38_is_compressed(enc_key);
+dogecoin_bip38_is_ec_multiplied(enc_key);
+dogecoin_bip38_has_lot_sequence(enc_key);
+dogecoin_bip38_get_address_hash(enc_key, hash4_out);
+dogecoin_bip38_verify_address_hash(enc_key, "D…");
+dogecoin_bip38_get_flag_byte(enc_key, &flag);
+dogecoin_bip38_generate_lot_sequence(&lot, &seq);
+```
+
+Paper wallet wrapper (decrypt + derive `D…` address):
+
+```c
+dogecoin_paper_wallet* w = dogecoin_paper_wallet_new();
+dogecoin_paper_wallet_set_encrypted(w, "6P…", "passphrase", &dogecoin_chainparams_main);
+// or: dogecoin_paper_wallet_set_wif(w, wif, chain);
+// or: dogecoin_paper_wallet_set_hex(w, hex_privkey, chain);
+
+char address[36];
+dogecoin_paper_wallet_get_address(w, address, sizeof(address));
+uint8_t privkey[32];
+dogecoin_paper_wallet_get_private_key(w, privkey);
+char wif[PRIVKEYWIFLEN];
+dogecoin_paper_wallet_get_wif(w, wif, sizeof(wif));
+dogecoin_bool ok = dogecoin_paper_wallet_is_valid(w);
+dogecoin_paper_wallet_free(w);
+```
+
+`dogecoin_paper_wallet_set_encrypted()` uses Dogecoin-mainnet BIP38 decrypt semantics (`BIP38_ADDRESS_MATCH_MAINNET`). For strict Bitcoin-only BIP-0038 interop vectors, call `dogecoin_bip38_decrypt_ex()` with `BIP38_ADDRESS_MATCH_INTEROP` directly.
+
+## Sweep API — caller supplies chain data
+
+### Single UTXO
+
+```c
+dogecoin_sweep_options* opt = dogecoin_sweep_options_new(&dogecoin_chainparams_main);
+dogecoin_sweep_options_set_destination(opt, "D…");
+dogecoin_sweep_options_set_fee(opt, 1000, 1000, 1000000); /* per-byte, min, max koinu */
+dogecoin_sweep_options_set_utxo(opt, txid_hex, vout, "12.5"); /* amount in DOGE */
+
+dogecoin_sweep_result* r = dogecoin_sweep_paper_wallet(wallet, opt);
+if (r->success) {
+    /* or use accessors: */
+    dogecoin_sweep_result_get_transaction_hex(r);
+    dogecoin_sweep_result_get_transaction_id(r);
+    dogecoin_sweep_result_get_amount_swept(r);
+    dogecoin_sweep_result_get_fee_paid(r);
+    dogecoin_sweep_result_get_destination_address(r);
+} else {
+    dogecoin_sweep_result_get_error(r);
+}
+dogecoin_sweep_result_free(r);
+```
+
+Fee estimate before building (uses UTXO count on `opt`):
+
+```c
+uint64_t est = dogecoin_sweep_estimate_fee(wallet, opt);
+```
+
+### Multiple UTXOs (same private key — “empty wallet” sweep)
+
+Use when your indexer returns several coins at one address (like dogecoin-wallet `emptyWallet`):
+
+```c
+dogecoin_sweep_options_set_destination(opt, "D…");
+dogecoin_sweep_options_set_fee(opt, fee_per_byte, min_fee, max_fee);
+dogecoin_sweep_options_add_utxo(opt, txid1, vout1, "50.0");
+dogecoin_sweep_options_add_utxo(opt, txid2, vout2, "50.0");
+/* dogecoin_sweep_options_utxo_count(opt) == 2 */
+
+dogecoin_sweep_result* r = dogecoin_sweep_paper_wallet(wallet, opt);
+```
+
+`set_utxo` replaces the list with one entry; `add_utxo` appends.
+
+### Multiple paper wallets (one UTXO each)
+
+```c
+dogecoin_paper_wallet wallets[2];
+/* ... initialize each wallet (WIF or BIP38) ... */
+/* options must have exactly wallet_count UTXOs, in matching order */
+dogecoin_sweep_options_add_utxo(opt, txid_a, 0, "10.0");
+dogecoin_sweep_options_add_utxo(opt, txid_b, 1, "20.0");
+dogecoin_sweep_result* r = dogecoin_sweep_multiple_paper_wallets(wallets, 2, opt);
+```
+
+### Fee mapping from “per kB” (wallet UI)
+
+Many wallets expose fee per kilobyte. Convert before `set_fee`:
+
+```c
+uint64_t per_byte = dogecoin_sweep_fee_per_kb_to_per_byte(fee_per_kb_koinu);
+dogecoin_sweep_options_set_fee(opt, per_byte, min_fee, max_fee);
+```
+
+Fee estimate uses ~180 vbytes per P2PKH input + one P2PKH output.
+
+### Optional: RBF and locktime
+
+```c
+dogecoin_sweep_options_set_rbf(opt, true);      /* nSequence 0xfffffffd */
+dogecoin_sweep_options_set_locktime(opt, height_or_timestamp);
+```
+
+### Step-by-step (unsigned → sign → validate)
+
+```c
+dogecoin_transaction* tx = dogecoin_sweep_create_transaction(wallet, opt);
+dogecoin_sweep_sign_transaction(tx, wallet);
+dogecoin_sweep_validate_transaction(tx, wallet, opt);
+dogecoin_tx_free(tx);
+```
+
+### Broadcast (optional build flag)
+
+With `WITH_NET`:
+
+```c
+dogecoin_sweep_broadcast_transaction(tx, chain, txid_out, sizeof(txid_out));
+```
+
+Otherwise broadcast `r->transaction_hex` with your own node/RPC.
+
+### Balance (optional `WITH_WALLET`)
+
+Local wallet DB only — not a chain indexer:
+
+```c
+uint64_t bal;
+dogecoin_sweep_get_balance("D…", chain, &bal);
+```
+
+## Security
+
+1. Use strong BIP38 passphrases; scrypt may take tens of seconds (run off UI thread in apps).
+2. Clear sensitive buffers after use (`dogecoin_mem_zero` on privkeys).
+3. Verify decrypted keys match expected address (`dogecoin_bip38_verify_address_hash`).
+4. Confirm `txid` / `vout` / amounts from a trusted source before signing.
+
+## Validation and stats
+
+After signing, `dogecoin_sweep_validate_transaction` checks that inputs are signed, the destination appears in outputs, output value matches the fee math from your UTXO list, and optional RBF / locktime flags match.
+
+```c
+dogecoin_sweep_validate_transaction(tx, wallet, opt);
+
+uint64_t inputs, outputs, in_value, out_value, fee;
+dogecoin_sweep_get_stats(tx, opt, &inputs, &outputs, &in_value, &out_value, &fee);
+/* Pass opt (with UTXO amounts) so in_value and fee are filled; NULL leaves them zero. */
+```
+
+## Example program
+
+`contrib/examples/sweep_example.c` shows WIF and BIP38 sweep flows. Build from the repo root after `make`:
+
+```bash
+gcc contrib/examples/sweep_example.c .libs/libdogecoin.a -Iinclude/dogecoin -o sweep_example
+```
+
+## Testing
+
+Tests live in `test/sweep_tests.c`, run via `test_sweep()` in the unified `tests` binary:
+
+```bash
+make check    # autotools
+# or ./tests after build
+```
+
+## API reference
+
+### `bip38.h` — encryption / decryption
+
+| Function | Purpose |
+|----------|---------|
+| `dogecoin_bip38_encrypt` | Non-EC (0x42) encrypt existing key with passphrase + address |
+| `dogecoin_bip38_encrypt_passphrase` | Non-EC encrypt with explicit passphrase byte length (NFC) |
+| `dogecoin_bip38_decrypt` | Decrypt 0x42 or 0x43 key (mainnet address-hash match) |
+| `dogecoin_bip38_decrypt_ex` | Decrypt with `BIP38_ADDRESS_MATCH_MAINNET` or `_INTEROP` |
+| `dogecoin_bip38_decrypt_passphrase` | Decrypt with explicit passphrase bytes |
+| `dogecoin_bip38_decrypt_passphrase_ex` | Decrypt with passphrase bytes + address-match mode |
+| `dogecoin_bip38_decrypt_with_lot_sequence` | EC decrypt; returns lot/sequence when present |
+| `dogecoin_bip38_decrypt_with_lot_sequence_ex` | Same with explicit address-match mode |
+| `dogecoin_bip38_generate_intermediate_code` | Owner-side EC intermediate (`passphrase…`) |
+| `dogecoin_bip38_encrypt_from_intermediate` | Printer-side EC encrypt from intermediate |
+| `dogecoin_bip38_encrypt_ec_multiplied` | One-shot EC encrypt (+ optional confirmation) |
+| `dogecoin_bip38_confirm_passphrase` | Verify confirmation code (mainnet address out) |
+| `dogecoin_bip38_confirm_passphrase_ex` | Verify confirmation with address-match mode |
+| `dogecoin_bip38_private_key_to_wif` | Raw 32-byte key → WIF for chain |
+| `dogecoin_bip38_wif_to_private_key` | WIF → raw key |
+| `dogecoin_bip38_is_valid` | Valid `6P…` encrypted key |
+| `dogecoin_bip38_is_intermediate_code` | Valid `passphrase…` intermediate |
+| `dogecoin_bip38_is_confirmation_code` | Valid `cfrm…` confirmation |
+| `dogecoin_bip38_is_compressed` | Compressed pubkey flag in key |
+| `dogecoin_bip38_is_ec_multiplied` | 0x43 EC-multiplied type |
+| `dogecoin_bip38_has_lot_sequence` | Lot/sequence present |
+| `dogecoin_bip38_get_address_hash` | Extract 4-byte address hash |
+| `dogecoin_bip38_verify_address_hash` | Compare embedded hash to address |
+| `dogecoin_bip38_get_flag_byte` | Raw BIP38 flag byte |
+| `dogecoin_bip38_generate_lot_sequence` | Random lot + sequence for EC flow |
+
+Constants: `BIP38_ADDRESS_MATCH_MAINNET`, `BIP38_ADDRESS_MATCH_INTEROP`, buffer sizes (`BIP38_ENCRYPTED_KEY_LENGTH`, `BIP38_INTERMEDIATE_CODE_MAXLEN`, etc.) — see `include/dogecoin/bip38.h`.
+
+### `sweep.h` — paper wallets and sweep
+
+| Function | Purpose |
+|----------|---------|
+| `dogecoin_paper_wallet_new` / `_free` | Allocate / free paper wallet |
+| `dogecoin_paper_wallet_set_wif` | Load from WIF |
+| `dogecoin_paper_wallet_set_hex` | Load from hex private key |
+| `dogecoin_paper_wallet_set_encrypted` | Load from BIP38 `6P…` + passphrase |
+| `dogecoin_paper_wallet_get_address` | Derived P2PKH address |
+| `dogecoin_paper_wallet_get_private_key` | 32-byte secret |
+| `dogecoin_paper_wallet_get_wif` | WIF for chain |
+| `dogecoin_paper_wallet_is_valid` | Wallet has key + address |
+| `dogecoin_sweep_options_new` / `_free` | Options with defaults for chain |
+| `dogecoin_sweep_options_set_destination` | Payout address |
+| `dogecoin_sweep_options_set_fee` | Per-byte, min, max (koinu) |
+| `dogecoin_sweep_options_set_rbf` | Replace-by-fee sequence |
+| `dogecoin_sweep_options_set_locktime` | Transaction locktime |
+| `dogecoin_sweep_options_set_utxo` | Replace UTXO list with one prevout |
+| `dogecoin_sweep_options_add_utxo` | Append prevout (multi-UTXO sweep) |
+| `dogecoin_sweep_options_utxo_count` | Number of configured prevouts |
+| `dogecoin_sweep_fee_per_kb_to_per_byte` | Convert wallet UI fee units |
+| `dogecoin_sweep_paper_wallet` | Build, sign, return result |
+| `dogecoin_sweep_multiple_paper_wallets` | Multi-wallet / multi-UTXO sweep |
+| `dogecoin_sweep_estimate_fee` | Fee estimate from options |
+| `dogecoin_sweep_create_transaction` | Unsigned tx (`dogecoin_tx_free`) |
+| `dogecoin_sweep_sign_transaction` | Sign existing tx |
+| `dogecoin_sweep_validate_transaction` | Post-sign checks |
+| `dogecoin_sweep_get_stats` | Input/output counts and values |
+| `dogecoin_sweep_broadcast_transaction` | Broadcast (`WITH_NET`) |
+| `dogecoin_sweep_get_balance` | Local wallet DB balance (`WITH_WALLET`) |
+| `dogecoin_sweep_result_new` / `_free` | Result object lifecycle |
+| `dogecoin_sweep_result_get_error` | Failure message |
+| `dogecoin_sweep_result_get_transaction_hex` | Signed raw tx |
+| `dogecoin_sweep_result_get_transaction_id` | Tx hash |
+| `dogecoin_sweep_result_get_amount_swept` | Output to destination (koinu) |
+| `dogecoin_sweep_result_get_fee_paid` | Fee (koinu) |
+| `dogecoin_sweep_result_get_destination_address` | Destination string |
+
+### Related
+
+- `include/dogecoin/scrypt.h` — `dogecoin_scrypt_rfc7914()` (RFC 7914 KDF used by BIP38; normally called internally)
+- `contrib/examples/sweep_example.c` — minimal integration sample
+- `test/sweep_tests.c` — vectors and integration tests

--- a/include/dogecoin/bip38.h
+++ b/include/dogecoin/bip38.h
@@ -278,13 +278,15 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_generate_intermediate_code(
     size_t* intermediate_code_size
 );
 
-/* Printer-side: create encrypted key (+ optional confirmation code) from intermediate code. */
+/*
+ * Printer-side: create encrypted key (+ optional confirmation code) from intermediate code.
+ * The printer never holds the owner's private key; there is no private_key_out parameter.
+ */
 LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_encrypt_from_intermediate(
     const char* intermediate_code,
     dogecoin_bool compressed,
     const uint8_t* seedb_override,
     const char* address_chain_hint,
-    uint8_t* private_key_out,
     char* encrypted_key_out,
     size_t* encrypted_key_size,
     char* confirmation_code_out,

--- a/include/dogecoin/bip38.h
+++ b/include/dogecoin/bip38.h
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2024 The Dogecoin Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBDOGECOIN_BIP38_H__
+#define __LIBDOGECOIN_BIP38_H__
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifndef __LIBDOGECOIN_DOGECOIN_H__
+typedef uint8_t dogecoin_bool;
+#ifdef __cplusplus
+#define LIBDOGECOIN_BEGIN_DECL extern "C" {
+#define LIBDOGECOIN_END_DECL }
+#else
+#define LIBDOGECOIN_BEGIN_DECL
+#define LIBDOGECOIN_END_DECL
+#endif
+#ifndef LIBDOGECOIN_API
+#if defined(_WIN32)
+#ifdef LIBDOGECOIN_BUILD
+#define LIBDOGECOIN_API __declspec(dllexport)
+#else
+#define LIBDOGECOIN_API
+#endif
+#elif defined(__GNUC__) && defined(LIBDOGECOIN_BUILD)
+#define LIBDOGECOIN_API __attribute__((visibility("default")))
+#else
+#define LIBDOGECOIN_API
+#endif
+#endif
+#endif /* !__LIBDOGECOIN_DOGECOIN_H__ */
+
+#ifndef __LIBDOGECOIN_CHAINPARAMS_H__
+typedef struct dogecoin_chainparams_ dogecoin_chainparams;
+#endif
+
+LIBDOGECOIN_BEGIN_DECL
+
+/* BIP38 constants (non-EC multiplied keys: 0x01 0x42 + flag + addresshash + ciphertext) */
+#define BIP38_MAGIC_BYTE 0x01
+/** Second byte: non-EC multiplied key type (BIP38). */
+#define BIP38_TYPE_NON_EC 0x42
+/** Flag byte: top bits reserved per BIP38; bit 5 = compressed pubkey. */
+#define BIP38_FLAG_BASE 0xC0
+#define BIP38_SCRYPT_N 16384
+#define BIP38_SCRYPT_R 8
+#define BIP38_SCRYPT_P 8
+#define BIP38_SCRYPT_KEYSIZE 64
+#define BIP38_SCRYPT_SALTSIZE 4
+#define BIP38_SCRYPT_DERIVED_SIZE 64
+
+/* BIP38 encrypted key length */
+#define BIP38_ENCRYPTED_KEY_LENGTH 58
+
+/* Intermediate passphrase code and confirmation code buffer sizes */
+#define BIP38_INTERMEDIATE_CODE_MAXLEN 73
+#define BIP38_CONFIRMATION_CODE_MAXLEN 76
+#define BIP38_SEEDB_LEN 24
+#define BIP38_INTERMEDIATE_PAYLOAD_LEN 49
+#define BIP38_CONFIRMATION_PAYLOAD_LEN 51
+
+/* BIP38 address hash length */
+#define BIP38_ADDRESS_HASH_LENGTH 4
+
+/* BIP38 compressed flag */
+#define BIP38_COMPRESSED_FLAG 0x20
+
+/* BIP38 lot/sequence flag */
+#define BIP38_LOT_SEQUENCE_FLAG 0x04
+
+/* BIP38 has lot/sequence flag */
+#define BIP38_HAS_LOT_SEQUENCE_FLAG 0x08
+
+/*
+ * Address-hash verification mode for decrypt / confirmation helpers.
+ * Default (mainnet): embedded hash must match a Dogecoin mainnet P2PKH address.
+ * Interop: also accepts testnet, regtest, and legacy Bitcoin P2PKH (0x00) for
+ * strict BIP-0038 test vectors and cross-chain paper wallets.
+ */
+#define BIP38_ADDRESS_MATCH_MAINNET 0u
+#define BIP38_ADDRESS_MATCH_INTEROP 1u
+
+/* EC multiplied key type (second byte of payload). */
+#define BIP38_TYPE_EC_MULTIPLIED 0x43
+
+/* BIP38 encrypted key structure */
+typedef struct {
+    uint8_t magic_byte;
+    uint8_t flag_byte;
+    uint8_t address_hash[BIP38_ADDRESS_HASH_LENGTH];
+    uint8_t encrypted_key[32];
+    uint8_t checksum[4];
+} dogecoin_bip38_encrypted_key;
+
+/* BIP38 lot/sequence structure */
+typedef struct {
+    uint8_t lot[4];
+    uint8_t sequence[4];
+} dogecoin_bip38_lot_sequence;
+
+/* BIP38 EC multiplied structure */
+typedef struct {
+    uint8_t owner_entropy[8];
+    uint8_t encrypted_part1[8];
+    uint8_t encrypted_part2[16];
+} dogecoin_bip38_ec_multiplied;
+
+/*
+ * Function declarations
+ */
+
+/* Encrypt a private key using BIP38 */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_encrypt(
+    const uint8_t* private_key,
+    const char* passphrase,
+    const char* address,
+    dogecoin_bool compressed,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size
+);
+
+/* Decrypt a BIP38 encrypted private key */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_decrypt(
+    const char* encrypted_key,
+    const char* passphrase,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out
+);
+
+/* Decrypt with explicit address-hash matching mode (see BIP38_ADDRESS_MATCH_*). */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_decrypt_ex(
+    const char* encrypted_key,
+    const char* passphrase,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out
+);
+
+/* Decrypt with explicit passphrase byte length (NFC applied; supports embedded NUL). */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_decrypt_passphrase(
+    const char* encrypted_key,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out
+);
+
+/* Decrypt with explicit passphrase length and address-hash matching mode. */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_decrypt_passphrase_ex(
+    const char* encrypted_key,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out
+);
+
+/* Non-EC encrypt with explicit passphrase byte length (NFC applied; supports embedded NUL). */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_encrypt_passphrase(
+    const uint8_t* private_key,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    const char* address,
+    dogecoin_bool compressed,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size
+);
+
+/* Decrypt a BIP38 encrypted private key with lot/sequence */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_decrypt_with_lot_sequence(
+    const char* encrypted_key,
+    const char* passphrase,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out
+);
+
+/* Decrypt with lot/sequence and explicit address-hash matching mode. */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_decrypt_with_lot_sequence_ex(
+    const char* encrypted_key,
+    const char* passphrase,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out
+);
+
+/* Check if a string is a valid BIP38 encrypted key */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_is_valid(const char* encrypted_key);
+
+/* Get the address hash from a BIP38 encrypted key */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_get_address_hash(
+    const char* encrypted_key,
+    uint8_t* address_hash_out
+);
+
+/* Verify the address hash matches the given address */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_verify_address_hash(
+    const char* encrypted_key,
+    const char* address
+);
+
+/* Get the flag byte from a BIP38 encrypted key */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_get_flag_byte(
+    const char* encrypted_key,
+    uint8_t* flag_byte_out
+);
+
+/* Check if a BIP38 encrypted key is compressed */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_is_compressed(const char* encrypted_key);
+
+/* Check if a BIP38 encrypted key has lot/sequence */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_has_lot_sequence(const char* encrypted_key);
+
+/* Check if a BIP38 encrypted key is EC multiplied */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_is_ec_multiplied(const char* encrypted_key);
+
+/* Generate a random lot and sequence for BIP38 */
+LIBDOGECOIN_API void dogecoin_bip38_generate_lot_sequence(
+    uint32_t* lot_out,
+    uint32_t* sequence_out
+);
+
+/* Convert a private key to WIF format */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_private_key_to_wif(
+    const uint8_t* private_key,
+    const dogecoin_chainparams* chain,
+    dogecoin_bool compressed,
+    char* wif_out,
+    size_t* wif_size
+);
+
+/* Convert a WIF private key to raw format */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_wif_to_private_key(
+    const char* wif,
+    const dogecoin_chainparams* chain,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out
+);
+
+/*
+ * EC-multiplied BIP38 (0x43): intermediate codes, encryption, confirmation.
+ * EC mode generates a new key (passfactor * factorb); it does not wrap an arbitrary existing key.
+ */
+
+/* Owner-side intermediate passphrase string (starts with "passphrase"). */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_generate_intermediate_code(
+    const char* passphrase,
+    dogecoin_bool use_lot_sequence,
+    uint32_t lot,
+    uint32_t sequence,
+    const uint8_t* ownerentropy_override,
+    char* intermediate_code_out,
+    size_t* intermediate_code_size
+);
+
+/* Printer-side: create encrypted key (+ optional confirmation code) from intermediate code. */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_encrypt_from_intermediate(
+    const char* intermediate_code,
+    dogecoin_bool compressed,
+    const uint8_t* seedb_override,
+    const char* address_chain_hint,
+    uint8_t* private_key_out,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size,
+    char* confirmation_code_out,
+    size_t* confirmation_code_size
+);
+
+/* Owner verifies confirmation code matches passphrase (and optional lot/sequence). */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_confirm_passphrase(
+    const char* passphrase,
+    const char* confirmation_code,
+    char* address_out,
+    size_t address_size,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out
+);
+
+/* Owner verifies confirmation code (Dogecoin mainnet address output by default). */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
+    const char* passphrase,
+    const char* confirmation_code,
+    unsigned int address_match_mode,
+    char* address_out,
+    size_t address_size,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out
+);
+
+/* One-shot EC-multiplied encrypt (optional lot/sequence, optional confirmation code). */
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_encrypt_ec_multiplied(
+    const char* passphrase,
+    dogecoin_bool compressed,
+    dogecoin_bool use_lot_sequence,
+    uint32_t lot,
+    uint32_t sequence,
+    const char* address_chain_hint,
+    uint8_t* private_key_out,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size,
+    char* confirmation_code_out,
+    size_t* confirmation_code_size
+);
+
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_is_intermediate_code(const char* code);
+LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_is_confirmation_code(const char* code);
+
+LIBDOGECOIN_END_DECL
+
+#endif // __LIBDOGECOIN_BIP38_H__

--- a/include/dogecoin/bip38.h
+++ b/include/dogecoin/bip38.h
@@ -300,7 +300,8 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_confirm_passphrase(
     uint32_t* sequence_out
 );
 
-/* Owner verifies confirmation code (Dogecoin mainnet address output by default). */
+/* Owner verifies confirmation code (Dogecoin mainnet address output by default).
+ * INTEROP mode uses the same multi-chain address matching as decrypt_ex. */
 LIBDOGECOIN_API dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
     const char* passphrase,
     const char* confirmation_code,

--- a/include/dogecoin/bip38.h
+++ b/include/dogecoin/bip38.h
@@ -62,6 +62,8 @@ LIBDOGECOIN_BEGIN_DECL
 #define BIP38_TYPE_NON_EC 0x42
 /** Flag byte: top bits reserved per BIP38; bit 5 = compressed pubkey. */
 #define BIP38_FLAG_BASE 0xC0
+/** EC-multiplied flag byte: bit 4 is reserved and must be zero. */
+#define BIP38_FLAG_RESERVED_BIT 0x10
 #define BIP38_SCRYPT_N 16384
 #define BIP38_SCRYPT_R 8
 #define BIP38_SCRYPT_P 8

--- a/include/dogecoin/constants.h
+++ b/include/dogecoin/constants.h
@@ -35,7 +35,7 @@ LIBDOGECOIN_BEGIN_DECL
 #define MAX_INT32_STRINGLEN 12
 #define DERIVED_PATH_STRINGLEN 33
 /* NOTE: Path string composed of m/44/3/+32bits_Account+/+bool_ischange+/+32bits_Address + string terminator; for a total of 33 bytes. */
-#define KOINU_STRINGLEN 21
+#define KOINU_STRINGLEN 22
 #define SCRIPT_PUBKEY_STRINGLEN 51
 
 LIBDOGECOIN_END_DECL

--- a/include/dogecoin/ecc.h
+++ b/include/dogecoin/ecc.h
@@ -47,8 +47,22 @@ LIBDOGECOIN_API void dogecoin_ecc_get_pubkey(const uint8_t* private_key, uint8_t
 //!ec mul tweak on given private key
 LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_private_key_tweak_add(uint8_t* private_key, const uint8_t* tweak);
 
+//!ec scalar multiply on private key (mod n); used by BIP-0038 EC-multiplied decrypt
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_private_key_tweak_mul(uint8_t* private_key, const uint8_t* tweak);
+
 //!ec mul tweak on given public key
 LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_public_key_tweak_add(uint8_t* public_key_inout, const uint8_t* tweak);
+
+//!ec scalar multiply on compressed public key (33 bytes in/out); BIP-0038 EC-multiplied keys
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_public_key_tweak_mul(uint8_t* public_key_inout, const uint8_t* tweak);
+
+//!re-serialize point for BIP-0038 address-hash (compressed flag may differ from tweak_mul output)
+LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_point_serialize(
+    const uint8_t* point,
+    size_t point_len,
+    uint8_t* pubkey_out,
+    size_t* pubkey_len,
+    dogecoin_bool compressed);
 
 //!verifies a given 32byte key
 LIBDOGECOIN_API dogecoin_bool dogecoin_ecc_verify_privatekey(const uint8_t* private_key);

--- a/include/dogecoin/koinu.h
+++ b/include/dogecoin/koinu.h
@@ -33,7 +33,11 @@
 LIBDOGECOIN_BEGIN_DECL
 
 LIBDOGECOIN_API long double koinu_to_coins(uint64_t koinu);
-LIBDOGECOIN_API int koinu_to_coins_str(uint64_t koinu, char* str);
+/* Minimum str_size for small koinu (length < 9 decimal digits): "0.xxxxxxxx" + NUL. */
+#define KOINU_COINS_STR_MIN_LEN 11
+/* str_size for full uint64_t range (20 digits + '.' + 8 decimals + NUL). */
+#define KOINU_COINS_STR_MAX_LEN 22
+LIBDOGECOIN_API int koinu_to_coins_str(uint64_t koinu, char* str, size_t str_size);
 LIBDOGECOIN_API uint64_t coins_to_koinu_str(char* coins);
 LIBDOGECOIN_API unsigned long long coins_to_koinu(long double coins);
 

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -1358,7 +1358,6 @@ dogecoin_bool dogecoin_bip38_encrypt_from_intermediate(
     dogecoin_bool compressed,
     const uint8_t* seedb_override,
     const char* address_chain_hint,
-    uint8_t* private_key_out,
     char* encrypted_key_out,
     size_t* encrypted_key_size,
     char* confirmation_code_out,
@@ -1427,10 +1426,11 @@ dogecoin_bool dogecoin_paper_wallet_set_wif(
     dogecoin_paper_wallet* wallet,
     const char* wif_private_key,
     const dogecoin_chainparams* chain_params);
-/* Set paper wallet from hex private key */
+/* Set paper wallet from hex private key (compressed selects P2PKH address format) */
 dogecoin_bool dogecoin_paper_wallet_set_hex(
     dogecoin_paper_wallet* wallet,
     const char* hex_private_key,
+    dogecoin_bool compressed,
     const dogecoin_chainparams* chain_params);
 /* Set paper wallet from a BIP38 encrypted private key (Dogecoin-mainnet decrypt semantics) */
 dogecoin_bool dogecoin_paper_wallet_set_encrypted(

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -572,7 +572,7 @@ dogecoin_bool broadcast_raw_tx(const dogecoin_chainparams* chain, const char* ra
 /* Koinu functions
 --------------------------------------------------------------------------
 */
-int koinu_to_coins_str(uint64_t koinu, char* str);
+int koinu_to_coins_str(uint64_t koinu, char* str, size_t str_size);
 uint64_t coins_to_koinu_str(char* coins);
 
 

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -1239,3 +1239,310 @@ dogecoin_zk_err_t dogecoin_zk_generate_plonk_proof(
 
 /* Human-readable error string.  Never returns NULL. */
 const char* dogecoin_zk_strerror(dogecoin_zk_err_t err);
+
+/* BIP38 API
+--------------------------------------------------------------------------
+*/
+
+/* Encrypt a private key using BIP38 */
+dogecoin_bool dogecoin_bip38_encrypt(
+    const uint8_t* private_key,
+    const char* passphrase,
+    const char* address,
+    dogecoin_bool compressed,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size);
+/* Decrypt a BIP38 encrypted private key */
+dogecoin_bool dogecoin_bip38_decrypt(
+    const char* encrypted_key,
+    const char* passphrase,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out);
+/* Decrypt with explicit address-hash matching mode (see BIP38_ADDRESS_MATCH_* in bip38.h) */
+dogecoin_bool dogecoin_bip38_decrypt_ex(
+    const char* encrypted_key,
+    const char* passphrase,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out);
+/* Decrypt with explicit passphrase byte length (NFC applied; supports embedded NUL) */
+dogecoin_bool dogecoin_bip38_decrypt_passphrase(
+    const char* encrypted_key,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out);
+/* Decrypt with explicit passphrase length and address-hash matching mode */
+dogecoin_bool dogecoin_bip38_decrypt_passphrase_ex(
+    const char* encrypted_key,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out);
+/* Non-EC encrypt with explicit passphrase byte length (NFC applied; supports embedded NUL) */
+dogecoin_bool dogecoin_bip38_encrypt_passphrase(
+    const uint8_t* private_key,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    const char* address,
+    dogecoin_bool compressed,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size);
+/* Decrypt a BIP38 encrypted private key with lot/sequence */
+dogecoin_bool dogecoin_bip38_decrypt_with_lot_sequence(
+    const char* encrypted_key,
+    const char* passphrase,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out);
+/* Decrypt with lot/sequence and explicit address-hash matching mode */
+dogecoin_bool dogecoin_bip38_decrypt_with_lot_sequence_ex(
+    const char* encrypted_key,
+    const char* passphrase,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out);
+/* Check if a string is a valid BIP38 encrypted key */
+dogecoin_bool dogecoin_bip38_is_valid(const char* encrypted_key);
+/* Get the address hash from a BIP38 encrypted key */
+dogecoin_bool dogecoin_bip38_get_address_hash(
+    const char* encrypted_key,
+    uint8_t* address_hash_out);
+/* Verify the address hash matches the given address */
+dogecoin_bool dogecoin_bip38_verify_address_hash(
+    const char* encrypted_key,
+    const char* address);
+/* Get the flag byte from a BIP38 encrypted key */
+dogecoin_bool dogecoin_bip38_get_flag_byte(
+    const char* encrypted_key,
+    uint8_t* flag_byte_out);
+/* Check if a BIP38 encrypted key is compressed */
+dogecoin_bool dogecoin_bip38_is_compressed(const char* encrypted_key);
+/* Check if a BIP38 encrypted key has lot/sequence */
+dogecoin_bool dogecoin_bip38_has_lot_sequence(const char* encrypted_key);
+/* Check if a BIP38 encrypted key is EC multiplied */
+dogecoin_bool dogecoin_bip38_is_ec_multiplied(const char* encrypted_key);
+/* Generate a random lot and sequence for BIP38 */
+void dogecoin_bip38_generate_lot_sequence(
+    uint32_t* lot_out,
+    uint32_t* sequence_out);
+/* Convert a private key to WIF format */
+dogecoin_bool dogecoin_bip38_private_key_to_wif(
+    const uint8_t* private_key,
+    const dogecoin_chainparams* chain,
+    dogecoin_bool compressed,
+    char* wif_out,
+    size_t* wif_size);
+/* Convert a WIF private key to raw format */
+dogecoin_bool dogecoin_bip38_wif_to_private_key(
+    const char* wif,
+    const dogecoin_chainparams* chain,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out);
+/* Owner-side intermediate passphrase string (starts with "passphrase") */
+dogecoin_bool dogecoin_bip38_generate_intermediate_code(
+    const char* passphrase,
+    dogecoin_bool use_lot_sequence,
+    uint32_t lot,
+    uint32_t sequence,
+    const uint8_t* ownerentropy_override,
+    char* intermediate_code_out,
+    size_t* intermediate_code_size);
+/* Printer-side: create encrypted key (+ optional confirmation code) from intermediate code */
+dogecoin_bool dogecoin_bip38_encrypt_from_intermediate(
+    const char* intermediate_code,
+    dogecoin_bool compressed,
+    const uint8_t* seedb_override,
+    const char* address_chain_hint,
+    uint8_t* private_key_out,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size,
+    char* confirmation_code_out,
+    size_t* confirmation_code_size);
+/* Owner verifies confirmation code matches passphrase (and optional lot/sequence) */
+dogecoin_bool dogecoin_bip38_confirm_passphrase(
+    const char* passphrase,
+    const char* confirmation_code,
+    char* address_out,
+    size_t address_size,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out);
+/* Owner verifies confirmation code (Dogecoin mainnet address output by default) */
+dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
+    const char* passphrase,
+    const char* confirmation_code,
+    unsigned int address_match_mode,
+    char* address_out,
+    size_t address_size,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out);
+/* One-shot EC-multiplied encrypt (optional lot/sequence, optional confirmation code) */
+dogecoin_bool dogecoin_bip38_encrypt_ec_multiplied(
+    const char* passphrase,
+    dogecoin_bool compressed,
+    dogecoin_bool use_lot_sequence,
+    uint32_t lot,
+    uint32_t sequence,
+    const char* address_chain_hint,
+    uint8_t* private_key_out,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size,
+    char* confirmation_code_out,
+    size_t* confirmation_code_size);
+/* Check if a string is a BIP38 intermediate passphrase code */
+dogecoin_bool dogecoin_bip38_is_intermediate_code(const char* code);
+/* Check if a string is a BIP38 confirmation code */
+dogecoin_bool dogecoin_bip38_is_confirmation_code(const char* code);
+
+/* Paper wallet sweep API
+--------------------------------------------------------------------------
+*/
+
+typedef struct dogecoin_paper_wallet_ dogecoin_paper_wallet;
+typedef struct dogecoin_sweep_result_ dogecoin_sweep_result;
+typedef struct dogecoin_sweep_options_ dogecoin_sweep_options;
+typedef struct dogecoin_sweep_utxo_ dogecoin_sweep_utxo;
+typedef dogecoin_tx dogecoin_transaction;
+
+/* Initialize a paper wallet structure */
+dogecoin_paper_wallet* dogecoin_paper_wallet_new(void);
+/* Free a paper wallet structure */
+void dogecoin_paper_wallet_free(dogecoin_paper_wallet* wallet);
+/* Initialize a sweep result structure */
+dogecoin_sweep_result* dogecoin_sweep_result_new(void);
+/* Free a sweep result structure */
+void dogecoin_sweep_result_free(dogecoin_sweep_result* result);
+/* Initialize sweep options with defaults */
+dogecoin_sweep_options* dogecoin_sweep_options_new(const dogecoin_chainparams* chain_params);
+/* Free sweep options */
+void dogecoin_sweep_options_free(dogecoin_sweep_options* options);
+/* Set paper wallet from WIF private key */
+dogecoin_bool dogecoin_paper_wallet_set_wif(
+    dogecoin_paper_wallet* wallet,
+    const char* wif_private_key,
+    const dogecoin_chainparams* chain_params);
+/* Set paper wallet from hex private key */
+dogecoin_bool dogecoin_paper_wallet_set_hex(
+    dogecoin_paper_wallet* wallet,
+    const char* hex_private_key,
+    const dogecoin_chainparams* chain_params);
+/* Set paper wallet from a BIP38 encrypted private key (Dogecoin-mainnet decrypt semantics) */
+dogecoin_bool dogecoin_paper_wallet_set_encrypted(
+    dogecoin_paper_wallet* wallet,
+    const char* encrypted_private_key,
+    const char* passphrase,
+    const dogecoin_chainparams* chain_params);
+/* Get the address from a paper wallet */
+dogecoin_bool dogecoin_paper_wallet_get_address(
+    const dogecoin_paper_wallet* wallet,
+    char* address_out,
+    size_t address_size);
+/* Get the private key from a paper wallet */
+dogecoin_bool dogecoin_paper_wallet_get_private_key(
+    const dogecoin_paper_wallet* wallet,
+    uint8_t* private_key_out);
+/* Get the WIF private key from a paper wallet */
+dogecoin_bool dogecoin_paper_wallet_get_wif(
+    const dogecoin_paper_wallet* wallet,
+    char* wif_out,
+    size_t wif_size);
+/* Check if a paper wallet is valid */
+dogecoin_bool dogecoin_paper_wallet_is_valid(const dogecoin_paper_wallet* wallet);
+/* Sweep a paper wallet to a destination address (requires UTXO on options) */
+dogecoin_sweep_result* dogecoin_sweep_paper_wallet(
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options);
+/* Sweep multiple paper wallets to a destination address */
+dogecoin_sweep_result* dogecoin_sweep_multiple_paper_wallets(
+    const dogecoin_paper_wallet* wallets,
+    size_t wallet_count,
+    const dogecoin_sweep_options* options);
+/* Estimate the fee for sweeping a paper wallet */
+uint64_t dogecoin_sweep_estimate_fee(
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options);
+/* Get the balance of a paper wallet address */
+dogecoin_bool dogecoin_sweep_get_balance(
+    const char* address,
+    const dogecoin_chainparams* chain_params,
+    uint64_t* balance_out);
+/* Create an unsigned sweep transaction (free with dogecoin_tx_free) */
+dogecoin_transaction* dogecoin_sweep_create_transaction(
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options);
+/* Sign a sweep transaction */
+dogecoin_bool dogecoin_sweep_sign_transaction(
+    dogecoin_transaction* transaction,
+    const dogecoin_paper_wallet* wallet);
+/* Broadcast a sweep transaction */
+dogecoin_bool dogecoin_sweep_broadcast_transaction(
+    const dogecoin_transaction* transaction,
+    const dogecoin_chainparams* chain_params,
+    char* transaction_id_out,
+    size_t transaction_id_size);
+/* Validate a sweep transaction */
+dogecoin_bool dogecoin_sweep_validate_transaction(
+    const dogecoin_transaction* transaction,
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options);
+/* Get sweep transaction statistics */
+dogecoin_bool dogecoin_sweep_get_stats(
+    const dogecoin_transaction* transaction,
+    const dogecoin_sweep_options* options,
+    uint64_t* input_count_out,
+    uint64_t* output_count_out,
+    uint64_t* total_input_value_out,
+    uint64_t* total_output_value_out,
+    uint64_t* fee_out);
+/* Set sweep options destination address */
+dogecoin_bool dogecoin_sweep_options_set_destination(
+    dogecoin_sweep_options* options,
+    const char* destination_address);
+/* Set sweep options fee */
+dogecoin_bool dogecoin_sweep_options_set_fee(
+    dogecoin_sweep_options* options,
+    uint64_t fee_per_byte,
+    uint64_t min_fee,
+    uint64_t max_fee);
+/* Set sweep options RBF */
+void dogecoin_sweep_options_set_rbf(
+    dogecoin_sweep_options* options,
+    dogecoin_bool use_rbf);
+/* Set sweep options locktime */
+void dogecoin_sweep_options_set_locktime(
+    dogecoin_sweep_options* options,
+    uint32_t locktime);
+/* Replace all UTXOs with a single prevout */
+dogecoin_bool dogecoin_sweep_options_set_utxo(
+    dogecoin_sweep_options* options,
+    const char* txid_hex,
+    int vout,
+    const char* total_input_doge);
+/* Append a prevout for multi-UTXO sweeps */
+dogecoin_bool dogecoin_sweep_options_add_utxo(
+    dogecoin_sweep_options* options,
+    const char* txid_hex,
+    int vout,
+    const char* amount_doge);
+/* Number of prevouts configured on options */
+size_t dogecoin_sweep_options_utxo_count(const dogecoin_sweep_options* options);
+/* Map fee-per-kB to fee-per-byte for sweep options */
+uint64_t dogecoin_sweep_fee_per_kb_to_per_byte(uint64_t fee_per_kb);
+/* Get sweep result error message */
+const char* dogecoin_sweep_result_get_error(const dogecoin_sweep_result* result);
+/* Get sweep result transaction hex */
+const char* dogecoin_sweep_result_get_transaction_hex(const dogecoin_sweep_result* result);
+/* Get sweep result transaction ID */
+const char* dogecoin_sweep_result_get_transaction_id(const dogecoin_sweep_result* result);
+/* Get sweep result amount swept */
+uint64_t dogecoin_sweep_result_get_amount_swept(const dogecoin_sweep_result* result);
+/* Get sweep result fee paid */
+uint64_t dogecoin_sweep_result_get_fee_paid(const dogecoin_sweep_result* result);
+/* Get sweep result destination address */
+const char* dogecoin_sweep_result_get_destination_address(const dogecoin_sweep_result* result);

--- a/include/dogecoin/scrypt.h
+++ b/include/dogecoin/scrypt.h
@@ -27,6 +27,22 @@ extern void (*scrypt_1024_1_1_256_sp_detected)(const char *input, char *output, 
 #define scrypt_1024_1_1_256_sp(input, output, scratchpad) scrypt_1024_1_1_256_sp_generic((input), (output), (scratchpad))
 #endif
 
+/*
+ * RFC 7914 scrypt with caller-chosen N/r/p (BIP38 password KDF).
+ * Distinct from scrypt_1024_1_1_256 (fixed PoW parameters, 32-byte output).
+ * Returns 1 on success, 0 on failure.
+ */
+int dogecoin_scrypt_rfc7914(
+    const uint8_t* passwd,
+    size_t passwdlen,
+    const uint8_t* salt,
+    size_t saltlen,
+    uint64_t N,
+    uint32_t r,
+    uint32_t p,
+    uint8_t* buf,
+    size_t buflen);
+
 #ifdef __DragonFly__
 #include <sys/endian.h>
 #else

--- a/include/dogecoin/sweep.h
+++ b/include/dogecoin/sweep.h
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2024 The Dogecoin Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBDOGECOIN_SWEEP_H__
+#define __LIBDOGECOIN_SWEEP_H__
+
+#include <stdint.h>
+#include <stddef.h>
+#include <dogecoin/bip38.h>
+
+#ifndef __LIBDOGECOIN_TX_H__
+typedef struct dogecoin_tx_ dogecoin_tx;
+#endif
+
+/* Sweep APIs use the same transaction object as the rest of libdogecoin. */
+typedef dogecoin_tx dogecoin_transaction;
+
+LIBDOGECOIN_BEGIN_DECL
+
+/* Sweep result structure */
+typedef struct dogecoin_sweep_result_ {
+    dogecoin_bool success;
+    char* error_message;
+    char* transaction_hex;
+    char* transaction_id;
+    uint64_t amount_swept;
+    uint64_t fee_paid;
+    char* destination_address;
+} dogecoin_sweep_result;
+
+/* Paper wallet structure */
+typedef struct dogecoin_paper_wallet_ {
+    char* private_key_wif;
+    char* private_key_hex;
+    char* encrypted_private_key; /* BIP38 encrypted */
+    char* passphrase; /* For BIP38 decryption */
+    char* address;
+    dogecoin_bool compressed;
+    dogecoin_bool is_encrypted;
+    const dogecoin_chainparams* chain_params;
+} dogecoin_paper_wallet;
+
+/* One spendable prevout supplied by the caller (indexer, wallet, node). */
+typedef struct dogecoin_sweep_utxo_ {
+    char* txid;
+    int vout;
+    char* amount_doge;
+} dogecoin_sweep_utxo;
+
+/* Sweep options structure */
+typedef struct dogecoin_sweep_options_ {
+    char* destination_address;
+    uint64_t fee_per_byte; /* Fee in koinu per byte (see chain) */
+    uint64_t min_fee; /* Minimum fee in koinu */
+    uint64_t max_fee; /* Maximum fee in koinu */
+    dogecoin_bool use_rbf; /* Replace-by-fee (nSequence 0xfffffffd on inputs) */
+    uint32_t locktime; /* Locktime for transaction */
+    const dogecoin_chainparams* chain_params;
+    /*
+     * UTXO list: populate with dogecoin_sweep_options_set_utxo() (one input) or
+     * dogecoin_sweep_options_add_utxo() (several inputs, same private key).
+     * Amounts are Dogecoin decimal strings (same as transaction.c / finalize_transaction).
+     * libdogecoin does not query the chain; the application supplies prevouts.
+     */
+    dogecoin_sweep_utxo* utxos;
+    size_t utxo_count;
+    /* Mirrors first entry for backward compatibility */
+    char* utxo_txid;
+    int utxo_vout;
+    char* utxo_total_doge;
+} dogecoin_sweep_options;
+
+/* Default sweep options */
+#define DOGECOIN_SWEEP_DEFAULT_FEE_PER_BYTE 1000 /* 0.01 DOGE per KB */
+#define DOGECOIN_SWEEP_DEFAULT_MIN_FEE 1000 /* 0.01 DOGE */
+#define DOGECOIN_SWEEP_DEFAULT_MAX_FEE 1000000 /* 10 DOGE */
+
+/*
+ * Function declarations
+ */
+
+/* Initialize a paper wallet structure */
+LIBDOGECOIN_API dogecoin_paper_wallet* dogecoin_paper_wallet_new(void);
+
+/* Free a paper wallet structure */
+LIBDOGECOIN_API void dogecoin_paper_wallet_free(dogecoin_paper_wallet* wallet);
+
+/* Initialize a sweep result structure */
+LIBDOGECOIN_API dogecoin_sweep_result* dogecoin_sweep_result_new(void);
+
+/* Free a sweep result structure */
+LIBDOGECOIN_API void dogecoin_sweep_result_free(dogecoin_sweep_result* result);
+
+/* Initialize sweep options with defaults */
+LIBDOGECOIN_API dogecoin_sweep_options* dogecoin_sweep_options_new(const dogecoin_chainparams* chain_params);
+
+/* Free sweep options */
+LIBDOGECOIN_API void dogecoin_sweep_options_free(dogecoin_sweep_options* options);
+
+/* Set paper wallet from WIF private key */
+LIBDOGECOIN_API dogecoin_bool dogecoin_paper_wallet_set_wif(
+    dogecoin_paper_wallet* wallet,
+    const char* wif_private_key,
+    const dogecoin_chainparams* chain_params
+);
+
+/* Set paper wallet from hex private key */
+LIBDOGECOIN_API dogecoin_bool dogecoin_paper_wallet_set_hex(
+    dogecoin_paper_wallet* wallet,
+    const char* hex_private_key,
+    const dogecoin_chainparams* chain_params
+);
+
+/*
+ * Set paper wallet from a BIP38 encrypted private key.
+ * Uses Dogecoin-mainnet BIP38 decrypt semantics (BIP38_ADDRESS_MATCH_MAINNET):
+ * the key must decrypt for the address derived from chain_params. Official
+ * Bitcoin-only BIP38 interop vectors require dogecoin_bip38_decrypt_ex() with
+ * BIP38_ADDRESS_MATCH_INTEROP at the lower level instead of this wrapper.
+ */
+LIBDOGECOIN_API dogecoin_bool dogecoin_paper_wallet_set_encrypted(
+    dogecoin_paper_wallet* wallet,
+    const char* encrypted_private_key,
+    const char* passphrase,
+    const dogecoin_chainparams* chain_params
+);
+
+/* Get the address from a paper wallet */
+LIBDOGECOIN_API dogecoin_bool dogecoin_paper_wallet_get_address(
+    const dogecoin_paper_wallet* wallet,
+    char* address_out,
+    size_t address_size
+);
+
+/* Get the private key from a paper wallet */
+LIBDOGECOIN_API dogecoin_bool dogecoin_paper_wallet_get_private_key(
+    const dogecoin_paper_wallet* wallet,
+    uint8_t* private_key_out
+);
+
+/* Get the WIF private key from a paper wallet */
+LIBDOGECOIN_API dogecoin_bool dogecoin_paper_wallet_get_wif(
+    const dogecoin_paper_wallet* wallet,
+    char* wif_out,
+    size_t wif_size
+);
+
+/* Check if a paper wallet is valid */
+LIBDOGECOIN_API dogecoin_bool dogecoin_paper_wallet_is_valid(const dogecoin_paper_wallet* wallet);
+
+/*
+ * Sweep a paper wallet to a destination address.
+ * Requires dogecoin_ecc_start() before calling (same as other signing APIs).
+ * Options must include a destination and UTXO (dogecoin_sweep_options_set_utxo); this
+ * library does not query the chain for UTXOs.
+ */
+LIBDOGECOIN_API dogecoin_sweep_result* dogecoin_sweep_paper_wallet(
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options
+);
+
+/* Sweep multiple paper wallets to a destination address */
+LIBDOGECOIN_API dogecoin_sweep_result* dogecoin_sweep_multiple_paper_wallets(
+    const dogecoin_paper_wallet* wallets,
+    size_t wallet_count,
+    const dogecoin_sweep_options* options
+);
+
+/* Estimate the fee for sweeping a paper wallet */
+LIBDOGECOIN_API uint64_t dogecoin_sweep_estimate_fee(
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options
+);
+
+/* Get the balance of a paper wallet address */
+LIBDOGECOIN_API dogecoin_bool dogecoin_sweep_get_balance(
+    const char* address,
+    const dogecoin_chainparams* chain_params,
+    uint64_t* balance_out
+);
+
+/* Create an unsigned sweep transaction (free with dogecoin_tx_free). Requires UTXO fields on options. */
+LIBDOGECOIN_API dogecoin_transaction* dogecoin_sweep_create_transaction(
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options
+);
+
+/* Sign a sweep transaction */
+LIBDOGECOIN_API dogecoin_bool dogecoin_sweep_sign_transaction(
+    dogecoin_transaction* transaction,
+    const dogecoin_paper_wallet* wallet
+);
+
+/* Broadcast a sweep transaction */
+LIBDOGECOIN_API dogecoin_bool dogecoin_sweep_broadcast_transaction(
+    const dogecoin_transaction* transaction,
+    const dogecoin_chainparams* chain_params,
+    char* transaction_id_out,
+    size_t transaction_id_size
+);
+
+/* Validate a sweep transaction */
+LIBDOGECOIN_API dogecoin_bool dogecoin_sweep_validate_transaction(
+    const dogecoin_transaction* transaction,
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options
+);
+
+/* Get sweep transaction statistics (pass options when input amounts / fee are known). */
+LIBDOGECOIN_API dogecoin_bool dogecoin_sweep_get_stats(
+    const dogecoin_transaction* transaction,
+    const dogecoin_sweep_options* options,
+    uint64_t* input_count_out,
+    uint64_t* output_count_out,
+    uint64_t* total_input_value_out,
+    uint64_t* total_output_value_out,
+    uint64_t* fee_out
+);
+
+/* Set sweep options destination address */
+LIBDOGECOIN_API dogecoin_bool dogecoin_sweep_options_set_destination(
+    dogecoin_sweep_options* options,
+    const char* destination_address
+);
+
+/* Set sweep options fee */
+LIBDOGECOIN_API dogecoin_bool dogecoin_sweep_options_set_fee(
+    dogecoin_sweep_options* options,
+    uint64_t fee_per_byte,
+    uint64_t min_fee,
+    uint64_t max_fee
+);
+
+/* Set sweep options RBF */
+LIBDOGECOIN_API void dogecoin_sweep_options_set_rbf(
+    dogecoin_sweep_options* options,
+    dogecoin_bool use_rbf
+);
+
+/* Set sweep options locktime */
+LIBDOGECOIN_API void dogecoin_sweep_options_set_locktime(
+    dogecoin_sweep_options* options,
+    uint32_t locktime
+);
+
+/* Replace all UTXOs with a single prevout (txid hex, vout, amount as doge string). */
+LIBDOGECOIN_API dogecoin_bool dogecoin_sweep_options_set_utxo(
+    dogecoin_sweep_options* options,
+    const char* txid_hex,
+    int vout,
+    const char* total_input_doge);
+
+/* Append a prevout (use for empty-wallet sweep with multiple UTXOs, same key). */
+LIBDOGECOIN_API dogecoin_bool dogecoin_sweep_options_add_utxo(
+    dogecoin_sweep_options* options,
+    const char* txid_hex,
+    int vout,
+    const char* amount_doge);
+
+/* Number of prevouts configured on options. */
+LIBDOGECOIN_API size_t dogecoin_sweep_options_utxo_count(const dogecoin_sweep_options* options);
+
+/* Map fee-per-kB (e.g. from a wallet UI) to fee-per-byte for sweep options. */
+LIBDOGECOIN_API uint64_t dogecoin_sweep_fee_per_kb_to_per_byte(uint64_t fee_per_kb);
+
+/* Get sweep result error message */
+LIBDOGECOIN_API const char* dogecoin_sweep_result_get_error(const dogecoin_sweep_result* result);
+
+/* Get sweep result transaction hex */
+LIBDOGECOIN_API const char* dogecoin_sweep_result_get_transaction_hex(const dogecoin_sweep_result* result);
+
+/* Get sweep result transaction ID */
+LIBDOGECOIN_API const char* dogecoin_sweep_result_get_transaction_id(const dogecoin_sweep_result* result);
+
+/* Get sweep result amount swept */
+LIBDOGECOIN_API uint64_t dogecoin_sweep_result_get_amount_swept(const dogecoin_sweep_result* result);
+
+/* Get sweep result fee paid */
+LIBDOGECOIN_API uint64_t dogecoin_sweep_result_get_fee_paid(const dogecoin_sweep_result* result);
+
+/* Get sweep result destination address */
+LIBDOGECOIN_API const char* dogecoin_sweep_result_get_destination_address(const dogecoin_sweep_result* result);
+
+LIBDOGECOIN_END_DECL
+
+#endif // __LIBDOGECOIN_SWEEP_H__

--- a/include/dogecoin/sweep.h
+++ b/include/dogecoin/sweep.h
@@ -47,7 +47,7 @@ typedef struct dogecoin_sweep_result_ {
     char* destination_address;
 } dogecoin_sweep_result;
 
-/* Paper wallet structure */
+/* Paper wallet structure (chain_params required when using WIF). */
 typedef struct dogecoin_paper_wallet_ {
     char* private_key_wif;
     char* private_key_hex;
@@ -123,10 +123,11 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_paper_wallet_set_wif(
     const dogecoin_chainparams* chain_params
 );
 
-/* Set paper wallet from hex private key */
+/* Set paper wallet from hex private key (compressed selects P2PKH address format). */
 LIBDOGECOIN_API dogecoin_bool dogecoin_paper_wallet_set_hex(
     dogecoin_paper_wallet* wallet,
     const char* hex_private_key,
+    dogecoin_bool compressed,
     const dogecoin_chainparams* chain_params
 );
 

--- a/src/bip38.c
+++ b/src/bip38.c
@@ -132,7 +132,7 @@ static dogecoin_bool bip38_validate_flags(uint8_t type_byte, uint8_t flag_byte)
         return true;
     }
     if (type_byte == BIP38_TYPE_EC_MULTIPLIED) {
-        if ((flag_byte & 0x10) != 0) {
+        if ((flag_byte & BIP38_FLAG_RESERVED_BIT) != 0) {
             return false;
         }
         if ((flag_byte & BIP38_HAS_LOT_SEQUENCE_FLAG) != 0) {
@@ -256,6 +256,8 @@ static void bip38_decrypt_halves(
     AES256_decrypt(&ctx, 1, block, encrypted + 16);
     for (unsigned i = 0; i < 16; i++)
         private_key_out[16 + i] = block[i] ^ derivedhalf1[16 + i];
+
+    dogecoin_mem_zero(block, sizeof(block));
 }
 
 static void bip38_aes256_decrypt_block(
@@ -272,6 +274,8 @@ static void bip38_aes256_decrypt_block(
     AES256_decrypt(&ctx, 1, block, cipher);
     for (unsigned i = 0; i < 16; i++)
         plain[i] = block[i] ^ derivedhalf1[derivedhalf1_offset + i];
+
+    dogecoin_mem_zero(block, sizeof(block));
 }
 
 static void bip38_aes256_encrypt_block(
@@ -811,6 +815,7 @@ static dogecoin_bool bip38_decrypt_ec_multiplied_bytes(
             derived,
             BIP38_SCRYPT_DERIVED_SIZE)) {
         dogecoin_mem_zero(passfactor, sizeof(passfactor));
+        dogecoin_mem_zero(passpoint, sizeof(passpoint));
         return false;
     }
 
@@ -831,8 +836,11 @@ static dogecoin_bool bip38_decrypt_ec_multiplied_bytes(
 
     memcpy(private_key_out, passfactor, 32);
     dogecoin_mem_zero(passfactor, sizeof(passfactor));
+    dogecoin_mem_zero(passpoint, sizeof(passpoint));
     dogecoin_mem_zero(derived, sizeof(derived));
     dogecoin_mem_zero(seedb, sizeof(seedb));
+    dogecoin_mem_zero(decrypted2, sizeof(decrypted2));
+    dogecoin_mem_zero(encryptedpart1_full, sizeof(encryptedpart1_full));
 
     if (!dogecoin_ecc_private_key_tweak_mul(private_key_out, factorb)) {
         dogecoin_mem_zero(private_key_out, DOGECOIN_ECKEY_PKEY_LENGTH);

--- a/src/bip38.c
+++ b/src/bip38.c
@@ -194,14 +194,6 @@ static dogecoin_bool bip38_derive_key_bytes(
     return ok;
 }
 
-static dogecoin_bool bip38_derive_key(
-    const char* passphrase,
-    const uint8_t salt[4],
-    uint8_t derived_key[64])
-{
-    return bip38_derive_key_bytes((const uint8_t*)passphrase, 0, salt, derived_key);
-}
-
 static void bip38_encrypt_halves(
     const uint8_t* private_key,
     const uint8_t* derived_64,
@@ -646,26 +638,22 @@ static dogecoin_bool bip38_encrypt_ec_with_passphrase(
     char* confirmation_code_out,
     size_t* confirmation_code_size);
 
-static dogecoin_bool bip38_privkey_matches_addresshash(
-    const uint8_t* private_key,
-    dogecoin_bool compressed,
+static dogecoin_bool bip38_pubkey_find_matching_address(
+    const dogecoin_pubkey* pubkey,
     const uint8_t expected_hash[4],
-    unsigned int address_match_mode)
+    unsigned int address_match_mode,
+    char* address_out)
 {
-    dogecoin_pubkey pubkey;
-    dogecoin_pubkey_init(&pubkey);
-    size_t pubkey_len = compressed ? DOGECOIN_ECKEY_COMPRESSED_LENGTH : DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH;
-    dogecoin_ecc_get_pubkey(private_key, pubkey.pubkey, &pubkey_len, compressed);
-    pubkey.compressed = compressed;
+    char address[P2PKHLEN];
+    uint8_t calc_hash[4];
 
-    {
-        char address[P2PKHLEN];
-        if (dogecoin_pubkey_getaddr_p2pkh(&pubkey, &dogecoin_chainparams_main, address)) {
-            uint8_t calc_hash[4];
-            bip38_address_hash(address, calc_hash);
-            if (bip38_mem_eq(calc_hash, expected_hash, 4)) {
-                return true;
+    if (dogecoin_pubkey_getaddr_p2pkh(pubkey, &dogecoin_chainparams_main, address)) {
+        bip38_address_hash(address, calc_hash);
+        if (bip38_mem_eq(calc_hash, expected_hash, 4)) {
+            if (address_out) {
+                memcpy(address_out, address, P2PKHLEN);
             }
+            return true;
         }
     }
 
@@ -680,38 +668,52 @@ static dogecoin_bool bip38_privkey_matches_addresshash(
         };
         size_t i;
         for (i = 0; i < sizeof(chains) / sizeof(chains[0]); i++) {
-            char address[P2PKHLEN];
-            if (!dogecoin_pubkey_getaddr_p2pkh(&pubkey, chains[i], address)) {
+            if (!dogecoin_pubkey_getaddr_p2pkh(pubkey, chains[i], address)) {
                 continue;
             }
-            uint8_t calc_hash[4];
             bip38_address_hash(address, calc_hash);
             if (bip38_mem_eq(calc_hash, expected_hash, 4)) {
+                if (address_out) {
+                    memcpy(address_out, address, P2PKHLEN);
+                }
                 return true;
             }
         }
     }
 
-    /*
-     * BIP-0038 interoperability: some encrypted keys (e.g. spec test vectors) embed an
-     * address hash from a legacy P2PKH prefix (0x00).
-     */
     {
         uint8_t hash160[sizeof(uint160_t)];
-        dogecoin_pubkey_get_hash160(&pubkey, hash160);
-        char address[P2PKHLEN];
+        dogecoin_pubkey_get_hash160(pubkey, hash160);
         uint8_t payload[21];
         payload[0] = 0x00;
         memcpy(payload + 1, hash160, sizeof(hash160));
         if (dogecoin_base58_encode_check(payload, 21, address, sizeof(address)) != 0) {
-            uint8_t calc_hash[4];
             bip38_address_hash(address, calc_hash);
             if (bip38_mem_eq(calc_hash, expected_hash, 4)) {
+                if (address_out) {
+                    memcpy(address_out, address, P2PKHLEN);
+                }
                 return true;
             }
         }
     }
     return false;
+}
+
+static dogecoin_bool bip38_privkey_matches_addresshash(
+    const uint8_t* private_key,
+    dogecoin_bool compressed,
+    const uint8_t expected_hash[4],
+    unsigned int address_match_mode)
+{
+    dogecoin_pubkey pubkey;
+    dogecoin_pubkey_init(&pubkey);
+    size_t pubkey_len = compressed ? DOGECOIN_ECKEY_COMPRESSED_LENGTH : DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH;
+    dogecoin_ecc_get_pubkey(private_key, pubkey.pubkey, &pubkey_len, compressed);
+    pubkey.compressed = compressed;
+
+    return bip38_pubkey_find_matching_address(
+        &pubkey, expected_hash, address_match_mode, NULL);
 }
 
 static dogecoin_bool bip38_decrypt_non_ec_bytes(
@@ -1035,13 +1037,13 @@ dogecoin_bool dogecoin_bip38_get_address_hash(
     const char* encrypted_key,
     uint8_t* address_hash_out)
 {
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen;
+
     if (!encrypted_key || !address_hash_out) {
         return false;
     }
-
-    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
-    size_t declen = dogecoin_base58_decode_check(encrypted_key, decoded, sizeof(decoded));
-    if (declen != BIP38_PAYLOAD_LEN + 4) {
+    if (!bip38_decode_encrypted_payload(encrypted_key, decoded, &declen)) {
         return false;
     }
 
@@ -1070,13 +1072,13 @@ dogecoin_bool dogecoin_bip38_get_flag_byte(
     const char* encrypted_key,
     uint8_t* flag_byte_out)
 {
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen;
+
     if (!encrypted_key || !flag_byte_out) {
         return false;
     }
-
-    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
-    size_t declen = dogecoin_base58_decode_check(encrypted_key, decoded, sizeof(decoded));
-    if (declen != BIP38_PAYLOAD_LEN + 4) {
+    if (!bip38_decode_encrypted_payload(encrypted_key, decoded, &declen)) {
         return false;
     }
 
@@ -1234,7 +1236,7 @@ dogecoin_bool dogecoin_bip38_is_confirmation_code(const char* code)
     if (declen != BIP38_CONFIRMATION_PAYLOAD_LEN + 4) {
         return false;
     }
-    return memcmp(decoded, BIP38_CONFIRMATION_MAGIC, 5) == 0;
+    return bip38_mem_eq(decoded, BIP38_CONFIRMATION_MAGIC, 5);
 }
 
 dogecoin_bool dogecoin_bip38_encrypt_ec_multiplied(
@@ -1477,7 +1479,6 @@ dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
     size_t pointb_len;
     dogecoin_bool has_lot_sequence;
     dogecoin_bool compressed;
-    const dogecoin_chainparams* chain;
 
     if (!passphrase || !confirmation_code || !address_out || address_size < P2PKHLEN) {
         return false;
@@ -1532,32 +1533,24 @@ dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
     dogecoin_mem_zero(passfactor, sizeof(passfactor));
     (void)passpoint;
 
-    chain = (address_match_mode == BIP38_ADDRESS_MATCH_INTEROP)
-        ? NULL
-        : &dogecoin_chainparams_main;
-
     {
-        char candidate_address[P2PKHLEN];
+        dogecoin_pubkey pubkey;
         uint8_t pubkey_buf[DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH];
         size_t pubkey_len = compressed ? 33u : 65u;
+
+        dogecoin_pubkey_init(&pubkey);
         if (!dogecoin_ecc_point_serialize(pointb, 33, pubkey_buf, &pubkey_len, compressed)) {
             dogecoin_mem_zero(derived, sizeof(derived));
             return false;
         }
-        if (!bip38_pubkey_to_address(pubkey_buf, pubkey_len, compressed, chain, candidate_address)) {
+        memcpy(pubkey.pubkey, pubkey_buf, pubkey_len);
+        pubkey.compressed = compressed;
+
+        if (!bip38_pubkey_find_matching_address(
+                &pubkey, addresshash, address_match_mode, address_out)) {
             dogecoin_mem_zero(derived, sizeof(derived));
             return false;
         }
-
-        {
-            uint8_t calc_hash[4];
-            bip38_address_hash(candidate_address, calc_hash);
-            if (!bip38_mem_eq(calc_hash, addresshash, 4)) {
-                dogecoin_mem_zero(derived, sizeof(derived));
-                return false;
-            }
-        }
-        memcpy(address_out, candidate_address, P2PKHLEN);
     }
 
     if (compressed_out) {

--- a/src/bip38.c
+++ b/src/bip38.c
@@ -1,0 +1,1648 @@
+/*
+ * Copyright (c) 2024 The Dogecoin Foundation
+ *
+ * BIP-0038: non-EC (0x42) and EC-multiplied (0x43) keys, intermediate codes, confirmation.
+ */
+
+#include <dogecoin/bip38.h>
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/base58.h>
+#include <dogecoin/ctaes.h>
+#include <dogecoin/scrypt.h>
+#include <dogecoin/sha2.h>
+#include <dogecoin/random.h>
+#include <dogecoin/mem.h>
+#include <dogecoin/key.h>
+#include <dogecoin/ecc.h>
+#include <dogecoin/address.h>
+#include <dogecoin/utf8proc.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+typedef struct {
+    const uint8_t* data;
+    size_t len;
+    uint8_t* allocated;
+} bip38_passphrase_buf;
+
+static void bip38_passphrase_acquire_bytes(
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    bip38_passphrase_buf* out)
+{
+    utf8proc_uint8_t* mapped = NULL;
+    utf8proc_ssize_t mapped_len;
+
+    out->allocated = NULL;
+    out->data = NULL;
+    out->len = 0;
+    if (!passphrase) {
+        return;
+    }
+    if (passphrase_len == 0) {
+        passphrase_len = strlen((const char*)passphrase);
+    }
+    mapped_len = utf8proc_map(
+        passphrase,
+        (utf8proc_ssize_t)passphrase_len,
+        &mapped,
+        UTF8PROC_STABLE | UTF8PROC_COMPOSE);
+    if (mapped_len >= 0 && mapped) {
+        out->allocated = mapped;
+        out->data = mapped;
+        out->len = (size_t)mapped_len;
+        return;
+    }
+    out->data = passphrase;
+    out->len = passphrase_len;
+}
+
+static void bip38_passphrase_acquire(const char* passphrase, bip38_passphrase_buf* out)
+{
+    bip38_passphrase_acquire_bytes((const uint8_t*)passphrase, 0, out);
+}
+
+static void bip38_passphrase_release(bip38_passphrase_buf* buf)
+{
+    if (buf && buf->allocated) {
+        dogecoin_mem_zero(buf->allocated, buf->len);
+        free(buf->allocated);
+        buf->allocated = NULL;
+        buf->data = NULL;
+        buf->len = 0;
+    }
+}
+
+#define BIP38_LOT_MAX 1048575u
+#define BIP38_SEQUENCE_MAX 4095u
+#define BIP38_PAYLOAD_LEN 39
+/* dogecoin_base58_decode_check() requires data[] length >= strlen(base58 string). */
+#define BIP38_BASE58_DECODE_BUFLEN 128
+
+static dogecoin_bool bip38_mem_eq(const uint8_t* a, const uint8_t* b, size_t len)
+{
+    uint8_t diff = 0;
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        diff |= a[i] ^ b[i];
+    }
+    return diff == 0;
+}
+
+static dogecoin_bool bip38_validate_flags(uint8_t type_byte, uint8_t flag_byte)
+{
+    if (type_byte == BIP38_TYPE_NON_EC) {
+        if (flag_byte != BIP38_FLAG_BASE && flag_byte != (BIP38_FLAG_BASE | BIP38_COMPRESSED_FLAG)) {
+            return false;
+        }
+        if ((flag_byte & BIP38_LOT_SEQUENCE_FLAG) != 0) {
+            return false;
+        }
+        if ((flag_byte & BIP38_HAS_LOT_SEQUENCE_FLAG) != 0) {
+            return false;
+        }
+        return true;
+    }
+    if (type_byte == BIP38_TYPE_EC_MULTIPLIED) {
+        if ((flag_byte & 0x10) != 0) {
+            return false;
+        }
+        if ((flag_byte & BIP38_HAS_LOT_SEQUENCE_FLAG) != 0) {
+            return false;
+        }
+        if ((flag_byte & ~(BIP38_COMPRESSED_FLAG | BIP38_LOT_SEQUENCE_FLAG)) != 0) {
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+static dogecoin_bool bip38_decode_encrypted_payload(
+    const char* encrypted_key,
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN],
+    size_t* declen_out)
+{
+    size_t declen;
+
+    if (!encrypted_key || !declen_out) {
+        return false;
+    }
+
+    declen = dogecoin_base58_decode_check(encrypted_key, decoded, BIP38_BASE58_DECODE_BUFLEN);
+    if (declen != BIP38_PAYLOAD_LEN + 4) {
+        return false;
+    }
+    if (decoded[0] != BIP38_MAGIC_BYTE) {
+        return false;
+    }
+    if (decoded[1] != BIP38_TYPE_NON_EC && decoded[1] != BIP38_TYPE_EC_MULTIPLIED) {
+        return false;
+    }
+    if (!bip38_validate_flags(decoded[1], decoded[2])) {
+        return false;
+    }
+    *declen_out = declen;
+    return true;
+}
+
+static const uint8_t BIP38_INTERMEDIATE_MAGIC_LOT[8] =
+    {0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2, 0x51};
+static const uint8_t BIP38_INTERMEDIATE_MAGIC_NOLOT[8] =
+    {0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2, 0x53};
+static const uint8_t BIP38_CONFIRMATION_MAGIC[5] =
+    {0x64, 0x3B, 0xF6, 0xA8, 0x9A};
+
+/* First four bytes of SHA256(SHA256(utf8 address)). */
+static void bip38_address_hash(const char* address, uint8_t address_hash_out[4])
+{
+    uint8_t h[SHA256_DIGEST_LENGTH];
+    sha256_raw((const uint8_t*)address, strlen(address), h);
+    sha256_raw(h, SHA256_DIGEST_LENGTH, h);
+    memcpy(address_hash_out, h, 4);
+}
+
+static dogecoin_bool bip38_derive_key_bytes(
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    const uint8_t salt[4],
+    uint8_t derived_key[64])
+{
+    bip38_passphrase_buf norm;
+    dogecoin_bool ok;
+
+    bip38_passphrase_acquire_bytes(passphrase, passphrase_len, &norm);
+    if (!norm.data || norm.len == 0) {
+        bip38_passphrase_release(&norm);
+        return false;
+    }
+    ok = dogecoin_scrypt_rfc7914(
+        norm.data,
+        norm.len,
+        salt,
+        4,
+        BIP38_SCRYPT_N,
+        BIP38_SCRYPT_R,
+        BIP38_SCRYPT_P,
+        derived_key,
+        BIP38_SCRYPT_DERIVED_SIZE);
+    bip38_passphrase_release(&norm);
+    return ok;
+}
+
+static dogecoin_bool bip38_derive_key(
+    const char* passphrase,
+    const uint8_t salt[4],
+    uint8_t derived_key[64])
+{
+    return bip38_derive_key_bytes((const uint8_t*)passphrase, 0, salt, derived_key);
+}
+
+static void bip38_encrypt_halves(
+    const uint8_t* private_key,
+    const uint8_t* derived_64,
+    uint8_t encrypted[32])
+{
+    const uint8_t* derivedhalf1 = derived_64;
+    const uint8_t* derivedhalf2 = derived_64 + 32;
+    uint8_t block[16];
+    AES256_ctx ctx;
+    AES256_init(&ctx, derivedhalf2);
+
+    for (unsigned i = 0; i < 16; i++)
+        block[i] = private_key[i] ^ derivedhalf1[i];
+    AES256_encrypt(&ctx, 1, encrypted, block);
+
+    for (unsigned i = 0; i < 16; i++)
+        block[i] = private_key[16 + i] ^ derivedhalf1[16 + i];
+    AES256_encrypt(&ctx, 1, encrypted + 16, block);
+}
+
+static void bip38_decrypt_halves(
+    const uint8_t encrypted[32],
+    const uint8_t* derived_64,
+    uint8_t private_key_out[32])
+{
+    const uint8_t* derivedhalf1 = derived_64;
+    const uint8_t* derivedhalf2 = derived_64 + 32;
+    uint8_t block[16];
+    AES256_ctx ctx;
+    AES256_init(&ctx, derivedhalf2);
+
+    AES256_decrypt(&ctx, 1, block, encrypted);
+    for (unsigned i = 0; i < 16; i++)
+        private_key_out[i] = block[i] ^ derivedhalf1[i];
+
+    AES256_decrypt(&ctx, 1, block, encrypted + 16);
+    for (unsigned i = 0; i < 16; i++)
+        private_key_out[16 + i] = block[i] ^ derivedhalf1[16 + i];
+}
+
+static void bip38_aes256_decrypt_block(
+    const uint8_t* derived_64,
+    const uint8_t* cipher,
+    unsigned derivedhalf1_offset,
+    uint8_t* plain)
+{
+    const uint8_t* derivedhalf1 = derived_64;
+    const uint8_t* derivedhalf2 = derived_64 + 32;
+    uint8_t block[16];
+    AES256_ctx ctx;
+    AES256_init(&ctx, derivedhalf2);
+    AES256_decrypt(&ctx, 1, block, cipher);
+    for (unsigned i = 0; i < 16; i++)
+        plain[i] = block[i] ^ derivedhalf1[derivedhalf1_offset + i];
+}
+
+static void bip38_aes256_encrypt_block(
+    const uint8_t* derived_64,
+    const uint8_t* plain,
+    unsigned derivedhalf1_offset,
+    uint8_t* cipher)
+{
+    const uint8_t* derivedhalf1 = derived_64;
+    const uint8_t* derivedhalf2 = derived_64 + 32;
+    uint8_t block[16];
+    unsigned i;
+    AES256_ctx ctx;
+    for (i = 0; i < 16; i++) {
+        block[i] = plain[i] ^ derivedhalf1[derivedhalf1_offset + i];
+    }
+    AES256_init(&ctx, derivedhalf2);
+    AES256_encrypt(&ctx, 1, cipher, block);
+}
+
+static void bip38_factorb_from_seedb(const uint8_t seedb[24], uint8_t factorb_out[32])
+{
+    sha256_raw(seedb, 24, factorb_out);
+    sha256_raw(factorb_out, 32, factorb_out);
+}
+
+static const dogecoin_chainparams* bip38_chain_from_address_hint(const char* address)
+{
+    if (!address || !address[0]) {
+        return NULL;
+    }
+    if (address[0] == 'D') {
+        return &dogecoin_chainparams_main;
+    }
+    if (address[0] == 'n' || address[0] == 'm') {
+        return &dogecoin_chainparams_test;
+    }
+    return NULL;
+}
+
+static dogecoin_bool bip38_pubkey_to_address(
+    const uint8_t* pubkey,
+    size_t pubkey_len,
+    dogecoin_bool compressed,
+    const dogecoin_chainparams* chain,
+    char* address_out)
+{
+    dogecoin_pubkey pk;
+    dogecoin_pubkey_init(&pk);
+    memcpy(pk.pubkey, pubkey, pubkey_len);
+    pk.compressed = compressed;
+    if (chain) {
+        return dogecoin_pubkey_getaddr_p2pkh(&pk, chain, address_out);
+    }
+    {
+        uint8_t hash160[sizeof(uint160_t)];
+        dogecoin_pubkey_get_hash160(&pk, hash160);
+        uint8_t payload[21];
+        payload[0] = 0x00;
+        memcpy(payload + 1, hash160, sizeof(hash160));
+        return dogecoin_base58_encode_check(payload, 21, address_out, P2PKHLEN) != 0;
+    }
+}
+
+static dogecoin_bool bip38_ec_derived_key(
+    const uint8_t passpoint[33],
+    const uint8_t addresshash[4],
+    const uint8_t ownerentropy[8],
+    uint8_t derived_out[64])
+{
+    uint8_t scrypt_salt[12];
+    memcpy(scrypt_salt, addresshash, 4);
+    memcpy(scrypt_salt + 4, ownerentropy, 8);
+    return dogecoin_scrypt_rfc7914(
+        passpoint,
+        DOGECOIN_ECKEY_COMPRESSED_LENGTH,
+        scrypt_salt,
+        sizeof(scrypt_salt),
+        1024,
+        1,
+        1,
+        derived_out,
+        BIP38_SCRYPT_DERIVED_SIZE);
+}
+
+static void bip38_ownerentropy_generate(
+    dogecoin_bool use_lot_sequence,
+    uint32_t lot,
+    uint32_t sequence,
+    uint8_t ownerentropy_out[8])
+{
+    if (use_lot_sequence) {
+        uint32_t lotsequence = lot * 4096u + sequence;
+        dogecoin_random_bytes(ownerentropy_out, 4, 1);
+        ownerentropy_out[4] = (uint8_t)((lotsequence >> 24) & 0xff);
+        ownerentropy_out[5] = (uint8_t)((lotsequence >> 16) & 0xff);
+        ownerentropy_out[6] = (uint8_t)((lotsequence >> 8) & 0xff);
+        ownerentropy_out[7] = (uint8_t)(lotsequence & 0xff);
+    } else {
+        dogecoin_random_bytes(ownerentropy_out, 8, 1);
+    }
+}
+
+static dogecoin_bool bip38_parse_intermediate_code(
+    const char* intermediate_code,
+    uint8_t ownerentropy_out[8],
+    uint8_t passpoint_out[33],
+    dogecoin_bool* has_lot_sequence_out)
+{
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen;
+    const uint8_t* magic;
+
+    if (!intermediate_code || !ownerentropy_out || !passpoint_out || !has_lot_sequence_out) {
+        return false;
+    }
+
+    declen = dogecoin_base58_decode_check(intermediate_code, decoded, sizeof(decoded));
+    if (declen != BIP38_INTERMEDIATE_PAYLOAD_LEN + 4) {
+        return false;
+    }
+
+    if (memcmp(decoded, BIP38_INTERMEDIATE_MAGIC_LOT, 8) == 0) {
+        magic = BIP38_INTERMEDIATE_MAGIC_LOT;
+        *has_lot_sequence_out = true;
+    } else if (memcmp(decoded, BIP38_INTERMEDIATE_MAGIC_NOLOT, 8) == 0) {
+        magic = BIP38_INTERMEDIATE_MAGIC_NOLOT;
+        *has_lot_sequence_out = false;
+    } else {
+        return false;
+    }
+    (void)magic;
+
+    memcpy(ownerentropy_out, decoded + 8, 8);
+    memcpy(passpoint_out, decoded + 16, 33);
+    return true;
+}
+
+static dogecoin_bool bip38_confirmation_encode(
+    uint8_t flagbyte,
+    const uint8_t addresshash[4],
+    const uint8_t ownerentropy[8],
+    const uint8_t factorb[32],
+    const uint8_t derived[64],
+    char* confirmation_code_out,
+    size_t* confirmation_code_size)
+{
+    uint8_t pointb[33];
+    size_t pointb_len = DOGECOIN_ECKEY_COMPRESSED_LENGTH;
+    uint8_t encryptedpointb[33];
+    uint8_t pointbx1[16];
+    uint8_t pointbx2[16];
+    uint8_t payload[BIP38_CONFIRMATION_PAYLOAD_LEN];
+    size_t written;
+
+    if (!confirmation_code_out || !confirmation_code_size) {
+        return false;
+    }
+    if (*confirmation_code_size < BIP38_CONFIRMATION_CODE_MAXLEN) {
+        return false;
+    }
+
+    dogecoin_ecc_get_pubkey(factorb, pointb, &pointb_len, true);
+    encryptedpointb[0] = (uint8_t)(pointb[0] ^ (derived[63] & 0x01));
+    bip38_aes256_encrypt_block(derived, pointb + 1, 0, pointbx1);
+    bip38_aes256_encrypt_block(derived, pointb + 17, 16, pointbx2);
+    memcpy(encryptedpointb + 1, pointbx1, 16);
+    memcpy(encryptedpointb + 17, pointbx2, 16);
+
+    memcpy(payload, BIP38_CONFIRMATION_MAGIC, 5);
+    payload[5] = flagbyte;
+    memcpy(payload + 6, addresshash, 4);
+    memcpy(payload + 10, ownerentropy, 8);
+    memcpy(payload + 18, encryptedpointb, 33);
+
+    written = dogecoin_base58_encode_check(payload, BIP38_CONFIRMATION_PAYLOAD_LEN,
+        confirmation_code_out, *confirmation_code_size);
+    if (written == 0) {
+        return false;
+    }
+    *confirmation_code_size = written;
+    return true;
+}
+
+static dogecoin_bool bip38_encrypt_ec_core(
+    const uint8_t passpoint[33],
+    const uint8_t ownerentropy[8],
+    dogecoin_bool has_lot_sequence,
+    dogecoin_bool compressed,
+    const uint8_t seedb[24],
+    const dogecoin_chainparams* chain,
+    const uint8_t* passfactor_optional,
+    uint8_t* private_key_out,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size,
+    char* confirmation_code_out,
+    size_t* confirmation_code_size)
+{
+    uint8_t factorb[32];
+    uint8_t passpoint_work[33];
+    uint8_t addresshash[4];
+    uint8_t derived[BIP38_SCRYPT_DERIVED_SIZE];
+    uint8_t encryptedpart1[16];
+    uint8_t encryptedpart2[16];
+    uint8_t block2[16];
+    uint8_t flagbyte;
+    char generated_address[P2PKHLEN];
+    uint8_t payload[BIP38_PAYLOAD_LEN];
+    uint8_t pubkey_buf[DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH];
+    size_t pubkey_len;
+    size_t written;
+
+    if (!passpoint || !ownerentropy || !seedb || !encrypted_key_out || !encrypted_key_size) {
+        return false;
+    }
+    if (*encrypted_key_size < BIP38_ENCRYPTED_KEY_LENGTH + 1) {
+        return false;
+    }
+
+    bip38_factorb_from_seedb(seedb, factorb);
+
+    if (passfactor_optional) {
+        uint8_t priv[32];
+        size_t pk_len = compressed ? DOGECOIN_ECKEY_COMPRESSED_LENGTH : DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH;
+        memcpy(priv, passfactor_optional, 32);
+        if (!dogecoin_ecc_private_key_tweak_mul(priv, factorb)) {
+            dogecoin_mem_zero(factorb, sizeof(factorb));
+            dogecoin_mem_zero(priv, sizeof(priv));
+            return false;
+        }
+        dogecoin_ecc_get_pubkey(priv, pubkey_buf, &pk_len, compressed);
+        if (private_key_out) {
+            memcpy(private_key_out, priv, 32);
+        }
+        dogecoin_mem_zero(priv, sizeof(priv));
+        pubkey_len = pk_len;
+    } else {
+        memcpy(passpoint_work, passpoint, 33);
+        if (!dogecoin_ecc_public_key_tweak_mul(passpoint_work, factorb)) {
+            dogecoin_mem_zero(factorb, sizeof(factorb));
+            return false;
+        }
+        pubkey_len = compressed ? DOGECOIN_ECKEY_COMPRESSED_LENGTH : DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH;
+        if (!dogecoin_ecc_point_serialize(passpoint_work, 33, pubkey_buf, &pubkey_len, compressed)) {
+            dogecoin_mem_zero(factorb, sizeof(factorb));
+            return false;
+        }
+    }
+
+    if (!bip38_pubkey_to_address(pubkey_buf, pubkey_len, compressed, chain, generated_address)) {
+        dogecoin_mem_zero(factorb, sizeof(factorb));
+        return false;
+    }
+    bip38_address_hash(generated_address, addresshash);
+
+    if (!bip38_ec_derived_key(passpoint, addresshash, ownerentropy, derived)) {
+        dogecoin_mem_zero(factorb, sizeof(factorb));
+        return false;
+    }
+
+    bip38_aes256_encrypt_block(derived, seedb, 0, encryptedpart1);
+    memcpy(block2, encryptedpart1 + 8, 8);
+    memcpy(block2 + 8, seedb + 16, 8);
+    bip38_aes256_encrypt_block(derived, block2, 16, encryptedpart2);
+
+    flagbyte = 0;
+    if (compressed) {
+        flagbyte |= BIP38_COMPRESSED_FLAG;
+    }
+    if (has_lot_sequence) {
+        flagbyte |= BIP38_LOT_SEQUENCE_FLAG;
+    }
+
+    payload[0] = BIP38_MAGIC_BYTE;
+    payload[1] = BIP38_TYPE_EC_MULTIPLIED;
+    payload[2] = flagbyte;
+    memcpy(payload + 3, addresshash, 4);
+    memcpy(payload + 7, ownerentropy, 8);
+    memcpy(payload + 15, encryptedpart1, 8);
+    memcpy(payload + 23, encryptedpart2, 16);
+
+    written = dogecoin_base58_encode_check(payload, BIP38_PAYLOAD_LEN, encrypted_key_out, *encrypted_key_size);
+    if (written == 0) {
+        dogecoin_mem_zero(derived, sizeof(derived));
+        dogecoin_mem_zero(factorb, sizeof(factorb));
+        return false;
+    }
+    *encrypted_key_size = written;
+
+    if (confirmation_code_out && confirmation_code_size) {
+        if (!bip38_confirmation_encode(flagbyte, addresshash, ownerentropy, factorb, derived,
+                confirmation_code_out, confirmation_code_size)) {
+            dogecoin_mem_zero(derived, sizeof(derived));
+            dogecoin_mem_zero(factorb, sizeof(factorb));
+            return false;
+        }
+    }
+
+    dogecoin_mem_zero(derived, sizeof(derived));
+    dogecoin_mem_zero(factorb, sizeof(factorb));
+    return true;
+}
+
+static dogecoin_bool bip38_derive_passfactor_buf(
+    const bip38_passphrase_buf* norm,
+    const uint8_t ownerentropy[8],
+    dogecoin_bool has_lot_sequence,
+    uint8_t passfactor_out[32])
+{
+    const uint8_t* ownersalt = ownerentropy;
+    size_t ownersalt_len = has_lot_sequence ? 4 : 8;
+    uint8_t prefactor[32];
+
+    if (!norm || !norm->data || norm->len == 0) {
+        return false;
+    }
+    if (!dogecoin_scrypt_rfc7914(
+            norm->data,
+            norm->len,
+            ownersalt,
+            ownersalt_len,
+            BIP38_SCRYPT_N,
+            BIP38_SCRYPT_R,
+            BIP38_SCRYPT_P,
+            prefactor,
+            32)) {
+        return false;
+    }
+
+    if (has_lot_sequence) {
+        uint8_t buf[40];
+        memcpy(buf, prefactor, 32);
+        memcpy(buf + 32, ownerentropy, 8);
+        uint8_t hash[SHA256_DIGEST_LENGTH];
+        sha256_raw(buf, sizeof(buf), hash);
+        sha256_raw(hash, SHA256_DIGEST_LENGTH, hash);
+        memcpy(passfactor_out, hash, 32);
+    } else {
+        memcpy(passfactor_out, prefactor, 32);
+    }
+    dogecoin_mem_zero(prefactor, sizeof(prefactor));
+    return true;
+}
+
+static dogecoin_bool bip38_derive_passfactor(
+    const char* passphrase,
+    const uint8_t ownerentropy[8],
+    dogecoin_bool has_lot_sequence,
+    uint8_t passfactor_out[32])
+{
+    bip38_passphrase_buf norm;
+    dogecoin_bool ok;
+
+    bip38_passphrase_acquire(passphrase, &norm);
+    ok = bip38_derive_passfactor_buf(&norm, ownerentropy, has_lot_sequence, passfactor_out);
+    bip38_passphrase_release(&norm);
+    return ok;
+}
+
+static dogecoin_bool bip38_derive_passfactor_bytes(
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    const uint8_t ownerentropy[8],
+    dogecoin_bool has_lot_sequence,
+    uint8_t passfactor_out[32])
+{
+    bip38_passphrase_buf norm;
+    dogecoin_bool ok;
+
+    bip38_passphrase_acquire_bytes(passphrase, passphrase_len, &norm);
+    ok = bip38_derive_passfactor_buf(&norm, ownerentropy, has_lot_sequence, passfactor_out);
+    bip38_passphrase_release(&norm);
+    return ok;
+}
+
+static dogecoin_bool bip38_encrypt_ec_with_passphrase(
+    const char* passphrase,
+    dogecoin_bool use_lot_sequence,
+    uint32_t lot,
+    uint32_t sequence,
+    dogecoin_bool compressed,
+    const uint8_t* ownerentropy_override,
+    const uint8_t* seedb_override,
+    const char* address_hint,
+    uint8_t* private_key_out,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size,
+    char* confirmation_code_out,
+    size_t* confirmation_code_size);
+
+static dogecoin_bool bip38_privkey_matches_addresshash(
+    const uint8_t* private_key,
+    dogecoin_bool compressed,
+    const uint8_t expected_hash[4],
+    unsigned int address_match_mode)
+{
+    dogecoin_pubkey pubkey;
+    dogecoin_pubkey_init(&pubkey);
+    size_t pubkey_len = compressed ? DOGECOIN_ECKEY_COMPRESSED_LENGTH : DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH;
+    dogecoin_ecc_get_pubkey(private_key, pubkey.pubkey, &pubkey_len, compressed);
+    pubkey.compressed = compressed;
+
+    {
+        char address[P2PKHLEN];
+        if (dogecoin_pubkey_getaddr_p2pkh(&pubkey, &dogecoin_chainparams_main, address)) {
+            uint8_t calc_hash[4];
+            bip38_address_hash(address, calc_hash);
+            if (bip38_mem_eq(calc_hash, expected_hash, 4)) {
+                return true;
+            }
+        }
+    }
+
+    if (address_match_mode != BIP38_ADDRESS_MATCH_INTEROP) {
+        return false;
+    }
+
+    {
+        const dogecoin_chainparams* chains[] = {
+            &dogecoin_chainparams_test,
+            &dogecoin_chainparams_regtest,
+        };
+        size_t i;
+        for (i = 0; i < sizeof(chains) / sizeof(chains[0]); i++) {
+            char address[P2PKHLEN];
+            if (!dogecoin_pubkey_getaddr_p2pkh(&pubkey, chains[i], address)) {
+                continue;
+            }
+            uint8_t calc_hash[4];
+            bip38_address_hash(address, calc_hash);
+            if (bip38_mem_eq(calc_hash, expected_hash, 4)) {
+                return true;
+            }
+        }
+    }
+
+    /*
+     * BIP-0038 interoperability: some encrypted keys (e.g. spec test vectors) embed an
+     * address hash from a legacy P2PKH prefix (0x00).
+     */
+    {
+        uint8_t hash160[sizeof(uint160_t)];
+        dogecoin_pubkey_get_hash160(&pubkey, hash160);
+        char address[P2PKHLEN];
+        uint8_t payload[21];
+        payload[0] = 0x00;
+        memcpy(payload + 1, hash160, sizeof(hash160));
+        if (dogecoin_base58_encode_check(payload, 21, address, sizeof(address)) != 0) {
+            uint8_t calc_hash[4];
+            bip38_address_hash(address, calc_hash);
+            if (bip38_mem_eq(calc_hash, expected_hash, 4)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static dogecoin_bool bip38_decrypt_non_ec_bytes(
+    const uint8_t* decoded,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out)
+{
+    uint8_t salt[4];
+    memcpy(salt, decoded + 3, 4);
+    const uint8_t* encrypted_body = decoded + 7;
+
+    uint8_t derived[BIP38_SCRYPT_DERIVED_SIZE];
+    if (!bip38_derive_key_bytes(passphrase, passphrase_len, salt, derived)) {
+        return false;
+    }
+
+    bip38_decrypt_halves(encrypted_body, derived, private_key_out);
+    dogecoin_mem_zero(derived, sizeof(derived));
+
+    *compressed_out = (decoded[2] & BIP38_COMPRESSED_FLAG) != 0;
+
+    /* Address hash check (wrong passphrase yields garbage key without this). */
+    if (!bip38_privkey_matches_addresshash(
+            private_key_out, *compressed_out, decoded + 3, address_match_mode)) {
+        dogecoin_mem_zero(private_key_out, DOGECOIN_ECKEY_PKEY_LENGTH);
+        return false;
+    }
+    return true;
+}
+
+static dogecoin_bool bip38_decrypt_ec_multiplied_bytes(
+    const uint8_t* decoded,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out)
+{
+    const uint8_t flagbyte = decoded[2];
+    const uint8_t* addresshash = decoded + 3;
+    const uint8_t* ownerentropy = decoded + 7;
+    const uint8_t* encryptedpart1 = decoded + 15;
+    const uint8_t* encryptedpart2 = decoded + 23;
+    dogecoin_bool has_lot_sequence = (flagbyte & BIP38_LOT_SEQUENCE_FLAG) != 0;
+
+    uint8_t passfactor[32];
+    if (!bip38_derive_passfactor_bytes(passphrase, passphrase_len, ownerentropy, has_lot_sequence, passfactor)) {
+        return false;
+    }
+
+    uint8_t passpoint[33];
+    size_t passpoint_len = DOGECOIN_ECKEY_COMPRESSED_LENGTH;
+    dogecoin_ecc_get_pubkey(passfactor, passpoint, &passpoint_len, true);
+
+    uint8_t scrypt_salt[12];
+    memcpy(scrypt_salt, addresshash, 4);
+    memcpy(scrypt_salt + 4, ownerentropy, 8);
+
+    uint8_t derived[BIP38_SCRYPT_DERIVED_SIZE];
+    if (!dogecoin_scrypt_rfc7914(
+            passpoint,
+            DOGECOIN_ECKEY_COMPRESSED_LENGTH,
+            scrypt_salt,
+            sizeof(scrypt_salt),
+            1024,
+            1,
+            1,
+            derived,
+            BIP38_SCRYPT_DERIVED_SIZE)) {
+        dogecoin_mem_zero(passfactor, sizeof(passfactor));
+        return false;
+    }
+
+    uint8_t decrypted2[16];
+    bip38_aes256_decrypt_block(derived, encryptedpart2, 16, decrypted2);
+
+    uint8_t encryptedpart1_full[16];
+    memcpy(encryptedpart1_full, encryptedpart1, 8);
+    memcpy(encryptedpart1_full + 8, decrypted2, 8);
+
+    uint8_t seedb[24];
+    bip38_aes256_decrypt_block(derived, encryptedpart1_full, 0, seedb);
+    memcpy(seedb + 16, decrypted2 + 8, 8);
+
+    uint8_t factorb[32];
+    sha256_raw(seedb, sizeof(seedb), factorb);
+    sha256_raw(factorb, sizeof(factorb), factorb);
+
+    memcpy(private_key_out, passfactor, 32);
+    dogecoin_mem_zero(passfactor, sizeof(passfactor));
+    dogecoin_mem_zero(derived, sizeof(derived));
+    dogecoin_mem_zero(seedb, sizeof(seedb));
+
+    if (!dogecoin_ecc_private_key_tweak_mul(private_key_out, factorb)) {
+        dogecoin_mem_zero(private_key_out, DOGECOIN_ECKEY_PKEY_LENGTH);
+        dogecoin_mem_zero(factorb, sizeof(factorb));
+        return false;
+    }
+    dogecoin_mem_zero(factorb, sizeof(factorb));
+
+    *compressed_out = (flagbyte & BIP38_COMPRESSED_FLAG) != 0;
+
+    /* Address hash check (passphrase incorrect if mismatch). */
+    if (!bip38_privkey_matches_addresshash(private_key_out, *compressed_out, addresshash, address_match_mode)) {
+        dogecoin_mem_zero(private_key_out, DOGECOIN_ECKEY_PKEY_LENGTH);
+        return false;
+    }
+    return true;
+}
+
+static dogecoin_bool bip38_decrypt_decoded(
+    const uint8_t* decoded,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out)
+{
+    if (decoded[0] != BIP38_MAGIC_BYTE) {
+        return false;
+    }
+    if (!bip38_validate_flags(decoded[1], decoded[2])) {
+        return false;
+    }
+    if (decoded[1] == BIP38_TYPE_NON_EC) {
+        return bip38_decrypt_non_ec_bytes(
+            decoded, passphrase, passphrase_len, address_match_mode, private_key_out, compressed_out);
+    }
+    if (decoded[1] == BIP38_TYPE_EC_MULTIPLIED) {
+        return bip38_decrypt_ec_multiplied_bytes(
+            decoded, passphrase, passphrase_len, address_match_mode, private_key_out, compressed_out);
+    }
+    return false;
+}
+
+static dogecoin_bool bip38_encrypt_non_ec_bytes(
+    const uint8_t* private_key,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    const char* address,
+    dogecoin_bool compressed,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size)
+{
+    uint8_t address_hash[4];
+    uint8_t derived[BIP38_SCRYPT_DERIVED_SIZE];
+    uint8_t encrypted[32];
+    uint8_t payload[BIP38_PAYLOAD_LEN];
+    size_t encsz;
+    size_t w;
+
+    if (!private_key || !passphrase || !address || !encrypted_key_out || !encrypted_key_size) {
+        return false;
+    }
+    if (passphrase_len == 0) {
+        passphrase_len = strlen((const char*)passphrase);
+    }
+    if (passphrase_len == 0) {
+        return false;
+    }
+    if (*encrypted_key_size < BIP38_ENCRYPTED_KEY_LENGTH + 1) {
+        return false;
+    }
+
+    bip38_address_hash(address, address_hash);
+    if (!bip38_derive_key_bytes(passphrase, passphrase_len, address_hash, derived)) {
+        return false;
+    }
+
+    bip38_encrypt_halves(private_key, derived, encrypted);
+    dogecoin_mem_zero(derived, sizeof(derived));
+
+    payload[0] = BIP38_MAGIC_BYTE;
+    payload[1] = BIP38_TYPE_NON_EC;
+    payload[2] = (uint8_t)(BIP38_FLAG_BASE | (compressed ? BIP38_COMPRESSED_FLAG : 0));
+    memcpy(payload + 3, address_hash, 4);
+    memcpy(payload + 7, encrypted, 32);
+
+    encsz = *encrypted_key_size;
+    w = dogecoin_base58_encode_check(payload, BIP38_PAYLOAD_LEN, encrypted_key_out, encsz);
+    if (w == 0) {
+        return false;
+    }
+    *encrypted_key_size = w;
+    return true;
+}
+
+dogecoin_bool dogecoin_bip38_encrypt(
+    const uint8_t* private_key,
+    const char* passphrase,
+    const char* address,
+    dogecoin_bool compressed,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size)
+{
+    if (!passphrase) {
+        return false;
+    }
+    return bip38_encrypt_non_ec_bytes(
+        private_key,
+        (const uint8_t*)passphrase,
+        0,
+        address,
+        compressed,
+        encrypted_key_out,
+        encrypted_key_size);
+}
+
+dogecoin_bool dogecoin_bip38_encrypt_passphrase(
+    const uint8_t* private_key,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    const char* address,
+    dogecoin_bool compressed,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size)
+{
+    return bip38_encrypt_non_ec_bytes(
+        private_key,
+        passphrase,
+        passphrase_len,
+        address,
+        compressed,
+        encrypted_key_out,
+        encrypted_key_size);
+}
+
+dogecoin_bool dogecoin_bip38_decrypt(
+    const char* encrypted_key,
+    const char* passphrase,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out)
+{
+    return dogecoin_bip38_decrypt_ex(
+        encrypted_key,
+        passphrase,
+        BIP38_ADDRESS_MATCH_MAINNET,
+        private_key_out,
+        compressed_out);
+}
+
+dogecoin_bool dogecoin_bip38_decrypt_ex(
+    const char* encrypted_key,
+    const char* passphrase,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out)
+{
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen;
+
+    if (!encrypted_key || !passphrase || !private_key_out || !compressed_out) {
+        return false;
+    }
+    if (!bip38_decode_encrypted_payload(encrypted_key, decoded, &declen)) {
+        return false;
+    }
+
+    return bip38_decrypt_decoded(
+        decoded,
+        (const uint8_t*)passphrase,
+        0,
+        address_match_mode,
+        private_key_out,
+        compressed_out);
+}
+
+dogecoin_bool dogecoin_bip38_decrypt_passphrase(
+    const char* encrypted_key,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out)
+{
+    return dogecoin_bip38_decrypt_passphrase_ex(
+        encrypted_key,
+        passphrase,
+        passphrase_len,
+        BIP38_ADDRESS_MATCH_MAINNET,
+        private_key_out,
+        compressed_out);
+}
+
+dogecoin_bool dogecoin_bip38_decrypt_passphrase_ex(
+    const char* encrypted_key,
+    const uint8_t* passphrase,
+    size_t passphrase_len,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out)
+{
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen;
+
+    if (!encrypted_key || !passphrase || passphrase_len == 0 || !private_key_out || !compressed_out) {
+        return false;
+    }
+    if (!bip38_decode_encrypted_payload(encrypted_key, decoded, &declen)) {
+        return false;
+    }
+
+    return bip38_decrypt_decoded(
+        decoded, passphrase, passphrase_len, address_match_mode, private_key_out, compressed_out);
+}
+
+dogecoin_bool dogecoin_bip38_is_valid(const char* encrypted_key)
+{
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen;
+
+    if (!encrypted_key) {
+        return false;
+    }
+    return bip38_decode_encrypted_payload(encrypted_key, decoded, &declen);
+}
+
+dogecoin_bool dogecoin_bip38_get_address_hash(
+    const char* encrypted_key,
+    uint8_t* address_hash_out)
+{
+    if (!encrypted_key || !address_hash_out) {
+        return false;
+    }
+
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen = dogecoin_base58_decode_check(encrypted_key, decoded, sizeof(decoded));
+    if (declen != BIP38_PAYLOAD_LEN + 4) {
+        return false;
+    }
+
+    memcpy(address_hash_out, decoded + 3, 4);
+    return true;
+}
+
+dogecoin_bool dogecoin_bip38_verify_address_hash(
+    const char* encrypted_key,
+    const char* address)
+{
+    if (!encrypted_key || !address) {
+        return false;
+    }
+
+    uint8_t embedded[4];
+    uint8_t calc[4];
+    if (!dogecoin_bip38_get_address_hash(encrypted_key, embedded)) {
+        return false;
+    }
+    bip38_address_hash(address, calc);
+    return bip38_mem_eq(embedded, calc, 4);
+}
+
+dogecoin_bool dogecoin_bip38_get_flag_byte(
+    const char* encrypted_key,
+    uint8_t* flag_byte_out)
+{
+    if (!encrypted_key || !flag_byte_out) {
+        return false;
+    }
+
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen = dogecoin_base58_decode_check(encrypted_key, decoded, sizeof(decoded));
+    if (declen != BIP38_PAYLOAD_LEN + 4) {
+        return false;
+    }
+
+    *flag_byte_out = decoded[2];
+    return true;
+}
+
+dogecoin_bool dogecoin_bip38_is_compressed(const char* encrypted_key)
+{
+    uint8_t flag_byte;
+    if (!dogecoin_bip38_get_flag_byte(encrypted_key, &flag_byte)) {
+        return false;
+    }
+    return (flag_byte & BIP38_COMPRESSED_FLAG) != 0;
+}
+
+dogecoin_bool dogecoin_bip38_has_lot_sequence(const char* encrypted_key)
+{
+    uint8_t flag_byte;
+    if (!dogecoin_bip38_get_flag_byte(encrypted_key, &flag_byte)) {
+        return false;
+    }
+    return (flag_byte & BIP38_LOT_SEQUENCE_FLAG) != 0;
+}
+
+dogecoin_bool dogecoin_bip38_is_ec_multiplied(const char* encrypted_key)
+{
+    if (!encrypted_key) {
+        return false;
+    }
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen = dogecoin_base58_decode_check(encrypted_key, decoded, sizeof(decoded));
+    if (declen != BIP38_PAYLOAD_LEN + 4) {
+        return false;
+    }
+    return (decoded[0] == BIP38_MAGIC_BYTE && decoded[1] == BIP38_TYPE_EC_MULTIPLIED);
+}
+
+void dogecoin_bip38_generate_lot_sequence(
+    uint32_t* lot_out,
+    uint32_t* sequence_out)
+{
+    uint32_t lot_raw;
+    uint32_t sequence_raw;
+
+    if (!lot_out || !sequence_out) {
+        return;
+    }
+
+    dogecoin_random_bytes((uint8_t*)&lot_raw, sizeof(lot_raw), 1);
+    dogecoin_random_bytes((uint8_t*)&sequence_raw, sizeof(sequence_raw), 1);
+    *lot_out = (lot_raw % BIP38_LOT_MAX) + 1u;
+    *sequence_out = sequence_raw % (BIP38_SEQUENCE_MAX + 1u);
+}
+
+dogecoin_bool dogecoin_bip38_private_key_to_wif(
+    const uint8_t* private_key,
+    const dogecoin_chainparams* chain,
+    dogecoin_bool compressed,
+    char* wif_out,
+    size_t* wif_size)
+{
+    if (!private_key || !chain || !wif_out || !wif_size) {
+        return false;
+    }
+
+    uint8_t payload[34];
+    payload[0] = chain->b58prefix_secret_address;
+    memcpy(payload + 1, private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
+    size_t payload_len = compressed ? 34 : 33;
+    if (compressed) {
+        payload[33] = 1;
+    }
+    if (dogecoin_base58_encode_check(payload, payload_len, wif_out, *wif_size) == 0) {
+        return false;
+    }
+    dogecoin_mem_zero(payload, sizeof(payload));
+    return true;
+}
+
+static dogecoin_bool bip38_decode_wif_payload(
+    const char* wif,
+    const dogecoin_chainparams* chain,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out)
+{
+    if (!wif || !chain || !private_key_out || !compressed_out) {
+        return false;
+    }
+
+    const size_t wif_len = strlen(wif);
+    if (wif_len < 46) {
+        return false;
+    }
+
+    uint8_t* payload = (uint8_t*)dogecoin_calloc(1, wif_len + 1);
+    if (!payload) {
+        return false;
+    }
+
+    size_t outlen = dogecoin_base58_decode_check(wif, payload, wif_len + 1);
+    /* decode_check length includes 4-byte checksum (33+4 or 34+4). */
+    size_t payload_len = 0;
+    if (outlen == 37) {
+        payload_len = 33;
+    } else if (outlen == 38) {
+        payload_len = 34;
+    } else {
+        dogecoin_free(payload);
+        return false;
+    }
+    if (payload[0] != chain->b58prefix_secret_address) {
+        dogecoin_free(payload);
+        return false;
+    }
+
+    memcpy(private_key_out, payload + 1, DOGECOIN_ECKEY_PKEY_LENGTH);
+    if (payload_len == 34) {
+        *compressed_out = (payload[33] == 1);
+    } else {
+        *compressed_out = false;
+    }
+    dogecoin_mem_zero(payload, wif_len);
+    dogecoin_free(payload);
+    return true;
+}
+
+dogecoin_bool dogecoin_bip38_wif_to_private_key(
+    const char* wif,
+    const dogecoin_chainparams* chain,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out)
+{
+    return bip38_decode_wif_payload(wif, chain, private_key_out, compressed_out);
+}
+
+dogecoin_bool dogecoin_bip38_is_intermediate_code(const char* code)
+{
+    uint8_t ownerentropy[8];
+    uint8_t passpoint[33];
+    dogecoin_bool has_lot_sequence;
+
+    return bip38_parse_intermediate_code(code, ownerentropy, passpoint, &has_lot_sequence);
+}
+
+dogecoin_bool dogecoin_bip38_is_confirmation_code(const char* code)
+{
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen;
+
+    if (!code) {
+        return false;
+    }
+    declen = dogecoin_base58_decode_check(code, decoded, sizeof(decoded));
+    if (declen != BIP38_CONFIRMATION_PAYLOAD_LEN + 4) {
+        return false;
+    }
+    return memcmp(decoded, BIP38_CONFIRMATION_MAGIC, 5) == 0;
+}
+
+dogecoin_bool dogecoin_bip38_encrypt_ec_multiplied(
+    const char* passphrase,
+    dogecoin_bool compressed,
+    dogecoin_bool use_lot_sequence,
+    uint32_t lot,
+    uint32_t sequence,
+    const char* address_chain_hint,
+    uint8_t* private_key_out,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size,
+    char* confirmation_code_out,
+    size_t* confirmation_code_size)
+{
+    return bip38_encrypt_ec_with_passphrase(
+        passphrase,
+        use_lot_sequence,
+        lot,
+        sequence,
+        compressed,
+        NULL,
+        NULL,
+        address_chain_hint,
+        private_key_out,
+        encrypted_key_out,
+        encrypted_key_size,
+        confirmation_code_out,
+        confirmation_code_size);
+}
+
+static dogecoin_bool bip38_encrypt_ec_with_passphrase(
+    const char* passphrase,
+    dogecoin_bool use_lot_sequence,
+    uint32_t lot,
+    uint32_t sequence,
+    dogecoin_bool compressed,
+    const uint8_t* ownerentropy_override,
+    const uint8_t* seedb_override,
+    const char* address_hint,
+    uint8_t* private_key_out,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size,
+    char* confirmation_code_out,
+    size_t* confirmation_code_size)
+{
+    uint8_t ownerentropy[8];
+    uint8_t passfactor[32];
+    uint8_t passpoint[33];
+    uint8_t seedb[BIP38_SEEDB_LEN];
+    size_t passpoint_len;
+    const dogecoin_chainparams* chain;
+    dogecoin_bool ok;
+
+    if (use_lot_sequence && (lot == 0 || lot > BIP38_LOT_MAX || sequence > BIP38_SEQUENCE_MAX)) {
+        return false;
+    }
+
+    if (ownerentropy_override) {
+        memcpy(ownerentropy, ownerentropy_override, 8);
+    } else {
+        bip38_ownerentropy_generate(use_lot_sequence, lot, sequence, ownerentropy);
+    }
+
+    if (!bip38_derive_passfactor(passphrase, ownerentropy, use_lot_sequence, passfactor)) {
+        return false;
+    }
+
+    passpoint_len = DOGECOIN_ECKEY_COMPRESSED_LENGTH;
+    dogecoin_ecc_get_pubkey(passfactor, passpoint, &passpoint_len, true);
+
+    if (seedb_override) {
+        memcpy(seedb, seedb_override, BIP38_SEEDB_LEN);
+    } else {
+        dogecoin_random_bytes(seedb, BIP38_SEEDB_LEN, 1);
+    }
+
+    chain = bip38_chain_from_address_hint(address_hint);
+
+    ok = bip38_encrypt_ec_core(
+        passpoint,
+        ownerentropy,
+        use_lot_sequence,
+        compressed,
+        seedb,
+        chain,
+        passfactor,
+        private_key_out,
+        encrypted_key_out,
+        encrypted_key_size,
+        confirmation_code_out,
+        confirmation_code_size);
+
+    dogecoin_mem_zero(passfactor, sizeof(passfactor));
+    return ok;
+}
+
+dogecoin_bool dogecoin_bip38_generate_intermediate_code(
+    const char* passphrase,
+    dogecoin_bool use_lot_sequence,
+    uint32_t lot,
+    uint32_t sequence,
+    const uint8_t* ownerentropy_override,
+    char* intermediate_code_out,
+    size_t* intermediate_code_size)
+{
+    uint8_t ownerentropy[8];
+    uint8_t passfactor[32];
+    uint8_t passpoint[33];
+    uint8_t payload[BIP38_INTERMEDIATE_PAYLOAD_LEN];
+    size_t passpoint_len;
+    size_t written;
+
+    if (!passphrase || !intermediate_code_out || !intermediate_code_size) {
+        return false;
+    }
+    if (use_lot_sequence && (lot == 0 || lot > BIP38_LOT_MAX || sequence > BIP38_SEQUENCE_MAX)) {
+        return false;
+    }
+    if (*intermediate_code_size < BIP38_INTERMEDIATE_CODE_MAXLEN) {
+        return false;
+    }
+
+    if (ownerentropy_override) {
+        memcpy(ownerentropy, ownerentropy_override, 8);
+    } else {
+        bip38_ownerentropy_generate(use_lot_sequence, lot, sequence, ownerentropy);
+    }
+
+    if (!bip38_derive_passfactor(passphrase, ownerentropy, use_lot_sequence, passfactor)) {
+        return false;
+    }
+
+    passpoint_len = DOGECOIN_ECKEY_COMPRESSED_LENGTH;
+    dogecoin_ecc_get_pubkey(passfactor, passpoint, &passpoint_len, true);
+    dogecoin_mem_zero(passfactor, sizeof(passfactor));
+
+    memcpy(payload, use_lot_sequence ? BIP38_INTERMEDIATE_MAGIC_LOT : BIP38_INTERMEDIATE_MAGIC_NOLOT, 8);
+    memcpy(payload + 8, ownerentropy, 8);
+    memcpy(payload + 16, passpoint, 33);
+
+    written = dogecoin_base58_encode_check(payload, BIP38_INTERMEDIATE_PAYLOAD_LEN,
+        intermediate_code_out, *intermediate_code_size);
+    if (written == 0) {
+        return false;
+    }
+    *intermediate_code_size = written;
+    return true;
+}
+
+dogecoin_bool dogecoin_bip38_encrypt_from_intermediate(
+    const char* intermediate_code,
+    dogecoin_bool compressed,
+    const uint8_t* seedb_override,
+    const char* address_chain_hint,
+    uint8_t* private_key_out,
+    char* encrypted_key_out,
+    size_t* encrypted_key_size,
+    char* confirmation_code_out,
+    size_t* confirmation_code_size)
+{
+    uint8_t ownerentropy[8];
+    uint8_t passpoint[33];
+    uint8_t seedb[BIP38_SEEDB_LEN];
+    dogecoin_bool has_lot_sequence;
+    const dogecoin_chainparams* chain;
+
+    if (!intermediate_code || !encrypted_key_out || !encrypted_key_size) {
+        return false;
+    }
+
+    if (!bip38_parse_intermediate_code(intermediate_code, ownerentropy, passpoint, &has_lot_sequence)) {
+        return false;
+    }
+
+    if (seedb_override) {
+        memcpy(seedb, seedb_override, BIP38_SEEDB_LEN);
+    } else {
+        dogecoin_random_bytes(seedb, BIP38_SEEDB_LEN, 1);
+    }
+
+    chain = bip38_chain_from_address_hint(address_chain_hint);
+    (void)private_key_out;
+
+    return bip38_encrypt_ec_core(
+        passpoint,
+        ownerentropy,
+        has_lot_sequence,
+        compressed,
+        seedb,
+        chain,
+        NULL,
+        NULL,
+        encrypted_key_out,
+        encrypted_key_size,
+        confirmation_code_out,
+        confirmation_code_size);
+}
+
+dogecoin_bool dogecoin_bip38_confirm_passphrase(
+    const char* passphrase,
+    const char* confirmation_code,
+    char* address_out,
+    size_t address_size,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out)
+{
+    return dogecoin_bip38_confirm_passphrase_ex(
+        passphrase,
+        confirmation_code,
+        BIP38_ADDRESS_MATCH_MAINNET,
+        address_out,
+        address_size,
+        compressed_out,
+        lot_out,
+        sequence_out);
+}
+
+dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
+    const char* passphrase,
+    const char* confirmation_code,
+    unsigned int address_match_mode,
+    char* address_out,
+    size_t address_size,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out)
+{
+    uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+    size_t declen;
+    uint8_t flagbyte;
+    uint8_t addresshash[4];
+    uint8_t ownerentropy[8];
+    const uint8_t* encryptedpointb;
+    uint8_t passfactor[32];
+    uint8_t passpoint[33];
+    uint8_t derived[BIP38_SCRYPT_DERIVED_SIZE];
+    uint8_t pointb[33];
+    size_t pointb_len;
+    dogecoin_bool has_lot_sequence;
+    dogecoin_bool compressed;
+    const dogecoin_chainparams* chain;
+
+    if (!passphrase || !confirmation_code || !address_out || address_size < P2PKHLEN) {
+        return false;
+    }
+
+    declen = dogecoin_base58_decode_check(confirmation_code, decoded, sizeof(decoded));
+    if (declen != BIP38_CONFIRMATION_PAYLOAD_LEN + 4) {
+        return false;
+    }
+    if (memcmp(decoded, BIP38_CONFIRMATION_MAGIC, 5) != 0) {
+        return false;
+    }
+
+    flagbyte = decoded[5];
+    if (!bip38_validate_flags(BIP38_TYPE_EC_MULTIPLIED, flagbyte)) {
+        return false;
+    }
+
+    memcpy(addresshash, decoded + 6, 4);
+    memcpy(ownerentropy, decoded + 10, 8);
+    encryptedpointb = decoded + 18;
+
+    has_lot_sequence = (flagbyte & BIP38_LOT_SEQUENCE_FLAG) != 0;
+    compressed = (flagbyte & BIP38_COMPRESSED_FLAG) != 0;
+
+    pointb_len = DOGECOIN_ECKEY_COMPRESSED_LENGTH;
+    if (!bip38_derive_passfactor(passphrase, ownerentropy, has_lot_sequence, passfactor)) {
+        return false;
+    }
+    dogecoin_ecc_get_pubkey(passfactor, passpoint, &pointb_len, true);
+
+    if (!bip38_ec_derived_key(passpoint, addresshash, ownerentropy, derived)) {
+        dogecoin_mem_zero(passfactor, sizeof(passfactor));
+        return false;
+    }
+    dogecoin_mem_zero(passfactor, sizeof(passfactor));
+
+    pointb[0] = (uint8_t)(encryptedpointb[0] ^ (derived[63] & 0x01));
+    bip38_aes256_decrypt_block(derived, encryptedpointb + 1, 0, pointb + 1);
+    bip38_aes256_decrypt_block(derived, encryptedpointb + 17, 16, pointb + 17);
+
+    if (!bip38_derive_passfactor(passphrase, ownerentropy, has_lot_sequence, passfactor)) {
+        dogecoin_mem_zero(derived, sizeof(derived));
+        return false;
+    }
+
+    if (!dogecoin_ecc_public_key_tweak_mul(pointb, passfactor)) {
+        dogecoin_mem_zero(passfactor, sizeof(passfactor));
+        dogecoin_mem_zero(derived, sizeof(derived));
+        return false;
+    }
+    dogecoin_mem_zero(passfactor, sizeof(passfactor));
+    (void)passpoint;
+
+    chain = (address_match_mode == BIP38_ADDRESS_MATCH_INTEROP)
+        ? NULL
+        : &dogecoin_chainparams_main;
+
+    {
+        char candidate_address[P2PKHLEN];
+        uint8_t pubkey_buf[DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH];
+        size_t pubkey_len = compressed ? 33u : 65u;
+        if (!dogecoin_ecc_point_serialize(pointb, 33, pubkey_buf, &pubkey_len, compressed)) {
+            dogecoin_mem_zero(derived, sizeof(derived));
+            return false;
+        }
+        if (!bip38_pubkey_to_address(pubkey_buf, pubkey_len, compressed, chain, candidate_address)) {
+            dogecoin_mem_zero(derived, sizeof(derived));
+            return false;
+        }
+
+        {
+            uint8_t calc_hash[4];
+            bip38_address_hash(candidate_address, calc_hash);
+            if (!bip38_mem_eq(calc_hash, addresshash, 4)) {
+                dogecoin_mem_zero(derived, sizeof(derived));
+                return false;
+            }
+        }
+        memcpy(address_out, candidate_address, P2PKHLEN);
+    }
+
+    if (compressed_out) {
+        *compressed_out = compressed;
+    }
+    if (has_lot_sequence) {
+        uint32_t lotsequence = ((uint32_t)ownerentropy[4] << 24)
+            | ((uint32_t)ownerentropy[5] << 16)
+            | ((uint32_t)ownerentropy[6] << 8)
+            | (uint32_t)ownerentropy[7];
+        if (lot_out) {
+            *lot_out = lotsequence / 4096u;
+        }
+        if (sequence_out) {
+            *sequence_out = lotsequence % 4096u;
+        }
+    } else {
+        if (lot_out) {
+            *lot_out = 0;
+        }
+        if (sequence_out) {
+            *sequence_out = 0;
+        }
+    }
+
+    dogecoin_mem_zero(derived, sizeof(derived));
+    return true;
+}
+
+dogecoin_bool dogecoin_bip38_decrypt_with_lot_sequence(
+    const char* encrypted_key,
+    const char* passphrase,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out)
+{
+    return dogecoin_bip38_decrypt_with_lot_sequence_ex(
+        encrypted_key,
+        passphrase,
+        BIP38_ADDRESS_MATCH_MAINNET,
+        private_key_out,
+        compressed_out,
+        lot_out,
+        sequence_out);
+}
+
+dogecoin_bool dogecoin_bip38_decrypt_with_lot_sequence_ex(
+    const char* encrypted_key,
+    const char* passphrase,
+    unsigned int address_match_mode,
+    uint8_t* private_key_out,
+    dogecoin_bool* compressed_out,
+    uint32_t* lot_out,
+    uint32_t* sequence_out)
+{
+    if (lot_out) {
+        *lot_out = 0;
+    }
+    if (sequence_out) {
+        *sequence_out = 0;
+    }
+
+    if (!dogecoin_bip38_decrypt_ex(
+            encrypted_key, passphrase, address_match_mode, private_key_out, compressed_out)) {
+        return false;
+    }
+
+    if (dogecoin_bip38_is_ec_multiplied(encrypted_key) && dogecoin_bip38_has_lot_sequence(encrypted_key)) {
+        uint8_t decoded[BIP38_BASE58_DECODE_BUFLEN];
+        size_t declen;
+        if (!bip38_decode_encrypted_payload(encrypted_key, decoded, &declen)) {
+            return false;
+        }
+        const uint8_t* ownerentropy = decoded + 7;
+        uint32_t lotsequence = ((uint32_t)ownerentropy[4] << 24)
+            | ((uint32_t)ownerentropy[5] << 16)
+            | ((uint32_t)ownerentropy[6] << 8)
+            | (uint32_t)ownerentropy[7];
+        if (lot_out) {
+            *lot_out = lotsequence / 4096;
+        }
+        if (sequence_out) {
+            *sequence_out = lotsequence % 4096;
+        }
+    }
+    return true;
+}

--- a/src/bip38.c
+++ b/src/bip38.c
@@ -1,6 +1,30 @@
 /*
- * Copyright (c) 2024 The Dogecoin Foundation
- *
+
+ The MIT License (MIT)
+
+ Copyright (c) 2024 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+ */
+
+/*
  * BIP-0038: non-EC (0x42) and EC-multiplied (0x43) keys, intermediate codes, confirmation.
  */
 
@@ -642,7 +666,7 @@ static dogecoin_bool bip38_pubkey_find_matching_address(
     const dogecoin_pubkey* pubkey,
     const uint8_t expected_hash[4],
     unsigned int address_match_mode,
-    char* address_out)
+    char* address_out) /* when non-NULL, must point to at least P2PKHLEN bytes */
 {
     char address[P2PKHLEN];
     uint8_t calc_hash[4];

--- a/src/bip38.c
+++ b/src/bip38.c
@@ -1576,8 +1576,12 @@ dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
 
     if (!bip38_ec_derived_key(passpoint, addresshash, ownerentropy, derived)) {
         dogecoin_mem_zero(passfactor, sizeof(passfactor));
+        dogecoin_mem_zero(passpoint, sizeof(passpoint));
         return false;
     }
+    /* passpoint is not used past this point; clear the public point so it is
+     * not left live on the stack across the remaining KDF/decrypt steps. */
+    dogecoin_mem_zero(passpoint, sizeof(passpoint));
     dogecoin_mem_zero(passfactor, sizeof(passfactor));
 
     pointb[0] = (uint8_t)(encryptedpointb[0] ^ (derived[63] & 0x01));
@@ -1586,16 +1590,17 @@ dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
 
     if (!bip38_derive_passfactor(passphrase, ownerentropy, has_lot_sequence, passfactor)) {
         dogecoin_mem_zero(derived, sizeof(derived));
+        dogecoin_mem_zero(pointb, sizeof(pointb));
         return false;
     }
 
     if (!dogecoin_ecc_public_key_tweak_mul(pointb, passfactor)) {
         dogecoin_mem_zero(passfactor, sizeof(passfactor));
         dogecoin_mem_zero(derived, sizeof(derived));
+        dogecoin_mem_zero(pointb, sizeof(pointb));
         return false;
     }
     dogecoin_mem_zero(passfactor, sizeof(passfactor));
-    (void)passpoint;
 
     {
         dogecoin_pubkey pubkey;

--- a/src/bip38.c
+++ b/src/bip38.c
@@ -454,9 +454,15 @@ static dogecoin_bool bip38_confirmation_encode(
     written = dogecoin_base58_encode_check(payload, BIP38_CONFIRMATION_PAYLOAD_LEN,
         confirmation_code_out, *confirmation_code_size);
     if (written == 0) {
+        dogecoin_mem_zero(pointb, sizeof(pointb));
+        dogecoin_mem_zero(pointbx1, sizeof(pointbx1));
+        dogecoin_mem_zero(pointbx2, sizeof(pointbx2));
         return false;
     }
     *confirmation_code_size = written;
+    dogecoin_mem_zero(pointb, sizeof(pointb));
+    dogecoin_mem_zero(pointbx1, sizeof(pointbx1));
+    dogecoin_mem_zero(pointbx2, sizeof(pointbx2));
     return true;
 }
 
@@ -516,23 +522,30 @@ static dogecoin_bool bip38_encrypt_ec_core(
         memcpy(passpoint_work, passpoint, 33);
         if (!dogecoin_ecc_public_key_tweak_mul(passpoint_work, factorb)) {
             dogecoin_mem_zero(factorb, sizeof(factorb));
+            dogecoin_mem_zero(passpoint_work, sizeof(passpoint_work));
             return false;
         }
         pubkey_len = compressed ? DOGECOIN_ECKEY_COMPRESSED_LENGTH : DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH;
         if (!dogecoin_ecc_point_serialize(passpoint_work, 33, pubkey_buf, &pubkey_len, compressed)) {
             dogecoin_mem_zero(factorb, sizeof(factorb));
+            dogecoin_mem_zero(passpoint_work, sizeof(passpoint_work));
+            dogecoin_mem_zero(pubkey_buf, sizeof(pubkey_buf));
             return false;
         }
     }
 
     if (!bip38_pubkey_to_address(pubkey_buf, pubkey_len, compressed, chain, generated_address)) {
         dogecoin_mem_zero(factorb, sizeof(factorb));
+        dogecoin_mem_zero(passpoint_work, sizeof(passpoint_work));
+        dogecoin_mem_zero(pubkey_buf, sizeof(pubkey_buf));
         return false;
     }
     bip38_address_hash(generated_address, addresshash);
 
     if (!bip38_ec_derived_key(passpoint, addresshash, ownerentropy, derived)) {
         dogecoin_mem_zero(factorb, sizeof(factorb));
+        dogecoin_mem_zero(passpoint_work, sizeof(passpoint_work));
+        dogecoin_mem_zero(pubkey_buf, sizeof(pubkey_buf));
         return false;
     }
 
@@ -561,6 +574,11 @@ static dogecoin_bool bip38_encrypt_ec_core(
     if (written == 0) {
         dogecoin_mem_zero(derived, sizeof(derived));
         dogecoin_mem_zero(factorb, sizeof(factorb));
+        dogecoin_mem_zero(passpoint_work, sizeof(passpoint_work));
+        dogecoin_mem_zero(pubkey_buf, sizeof(pubkey_buf));
+        dogecoin_mem_zero(block2, sizeof(block2));
+        dogecoin_mem_zero(encryptedpart1, sizeof(encryptedpart1));
+        dogecoin_mem_zero(encryptedpart2, sizeof(encryptedpart2));
         return false;
     }
     *encrypted_key_size = written;
@@ -570,12 +588,22 @@ static dogecoin_bool bip38_encrypt_ec_core(
                 confirmation_code_out, confirmation_code_size)) {
             dogecoin_mem_zero(derived, sizeof(derived));
             dogecoin_mem_zero(factorb, sizeof(factorb));
+            dogecoin_mem_zero(passpoint_work, sizeof(passpoint_work));
+            dogecoin_mem_zero(pubkey_buf, sizeof(pubkey_buf));
+            dogecoin_mem_zero(block2, sizeof(block2));
+            dogecoin_mem_zero(encryptedpart1, sizeof(encryptedpart1));
+            dogecoin_mem_zero(encryptedpart2, sizeof(encryptedpart2));
             return false;
         }
     }
 
     dogecoin_mem_zero(derived, sizeof(derived));
     dogecoin_mem_zero(factorb, sizeof(factorb));
+    dogecoin_mem_zero(passpoint_work, sizeof(passpoint_work));
+    dogecoin_mem_zero(pubkey_buf, sizeof(pubkey_buf));
+    dogecoin_mem_zero(block2, sizeof(block2));
+    dogecoin_mem_zero(encryptedpart1, sizeof(encryptedpart1));
+    dogecoin_mem_zero(encryptedpart2, sizeof(encryptedpart2));
     return true;
 }
 
@@ -1413,9 +1441,11 @@ dogecoin_bool dogecoin_bip38_generate_intermediate_code(
     written = dogecoin_base58_encode_check(payload, BIP38_INTERMEDIATE_PAYLOAD_LEN,
         intermediate_code_out, *intermediate_code_size);
     if (written == 0) {
+        dogecoin_mem_zero(passpoint, sizeof(passpoint));
         return false;
     }
     *intermediate_code_size = written;
+    dogecoin_mem_zero(passpoint, sizeof(passpoint));
     return true;
 }
 
@@ -1424,7 +1454,6 @@ dogecoin_bool dogecoin_bip38_encrypt_from_intermediate(
     dogecoin_bool compressed,
     const uint8_t* seedb_override,
     const char* address_chain_hint,
-    uint8_t* private_key_out,
     char* encrypted_key_out,
     size_t* encrypted_key_size,
     char* confirmation_code_out,
@@ -1435,6 +1464,7 @@ dogecoin_bool dogecoin_bip38_encrypt_from_intermediate(
     uint8_t seedb[BIP38_SEEDB_LEN];
     dogecoin_bool has_lot_sequence;
     const dogecoin_chainparams* chain;
+    dogecoin_bool ok;
 
     if (!intermediate_code || !encrypted_key_out || !encrypted_key_size) {
         return false;
@@ -1451,9 +1481,8 @@ dogecoin_bool dogecoin_bip38_encrypt_from_intermediate(
     }
 
     chain = bip38_chain_from_address_hint(address_chain_hint);
-    (void)private_key_out;
 
-    return bip38_encrypt_ec_core(
+    ok = bip38_encrypt_ec_core(
         passpoint,
         ownerentropy,
         has_lot_sequence,
@@ -1466,6 +1495,9 @@ dogecoin_bool dogecoin_bip38_encrypt_from_intermediate(
         encrypted_key_size,
         confirmation_code_out,
         confirmation_code_size);
+    dogecoin_mem_zero(passpoint, sizeof(passpoint));
+    dogecoin_mem_zero(seedb, sizeof(seedb));
+    return ok;
 }
 
 dogecoin_bool dogecoin_bip38_confirm_passphrase(
@@ -1573,6 +1605,7 @@ dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
         dogecoin_pubkey_init(&pubkey);
         if (!dogecoin_ecc_point_serialize(pointb, 33, pubkey_buf, &pubkey_len, compressed)) {
             dogecoin_mem_zero(derived, sizeof(derived));
+            dogecoin_mem_zero(pointb, sizeof(pointb));
             return false;
         }
         memcpy(pubkey.pubkey, pubkey_buf, pubkey_len);
@@ -1581,6 +1614,7 @@ dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
         if (!bip38_pubkey_find_matching_address(
                 &pubkey, addresshash, address_match_mode, address_out)) {
             dogecoin_mem_zero(derived, sizeof(derived));
+            dogecoin_mem_zero(pointb, sizeof(pointb));
             return false;
         }
     }
@@ -1609,6 +1643,7 @@ dogecoin_bool dogecoin_bip38_confirm_passphrase_ex(
     }
 
     dogecoin_mem_zero(derived, sizeof(derived));
+    dogecoin_mem_zero(pointb, sizeof(pointb));
     return true;
 }
 

--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -504,8 +504,8 @@ void transaction_output_menu(int txindex, int is_testnet) {
     int running_transaction_output_menu = 1;
     while (running_transaction_output_menu) {
         char* destinationaddress;
-        char* coin_amount[KOINU_STRINGLEN];
-        dogecoin_mem_zero(coin_amount, KOINU_STRINGLEN);
+        char coin_amount[KOINU_STRINGLEN];
+        dogecoin_mem_zero(coin_amount, sizeof(coin_amount));
         uint64_t koinu_amount;
         uint64_t tx_out_total = 0;
         const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
@@ -519,8 +519,8 @@ void transaction_output_menu(int txindex, int is_testnet) {
             printf("\n--------------------------------\n");
             printf("output index:       %d\n", i);
             printf("script public key:  %s\n", utils_uint8_to_hex((const uint8_t*)tx_out->script_pubkey->str, tx_out->script_pubkey->len));
-            koinu_to_coins_str(tx_out->value, (char*)coin_amount, KOINU_STRINGLEN);
-            printf("amount:             %s\n", (char*)coin_amount);
+            koinu_to_coins_str(tx_out->value, coin_amount, sizeof(coin_amount));
+            printf("amount:             %s\n", coin_amount);
             // selected should only equal anything other than -1 upon setting
             // loop index in conditional targetting last iteration:
             selected == i ? printf("selected:           [X]\n") : 0;
@@ -541,14 +541,23 @@ void transaction_output_menu(int txindex, int is_testnet) {
                                             break;
                                             }
                                         else {
-                                            koinu_amount = coins_to_koinu_str((char*)coin_amount);
+                                            koinu_amount = coins_to_koinu_str(coin_amount);
                                             vector_remove_idx(tx->transaction->vout, i);
                                             dogecoin_tx_add_address_out(tx->transaction, chain, koinu_amount, destinationaddress);
                                             }
                                         break;
                                     case 2:
-                                        memcpy_safe(coin_amount, (char*)getl("new amount"), KOINU_STRINGLEN);
-                                        koinu_amount = coins_to_koinu_str((char*)coin_amount);
+                                        {
+                                            const char* new_amount = getl("new amount");
+                                            size_t new_amount_len = strlen(new_amount);
+                                            if (new_amount_len >= sizeof(coin_amount)) {
+                                                printf("number is invalid or set to 0\n");
+                                                break;
+                                            }
+                                            memcpy_safe(coin_amount, new_amount, new_amount_len);
+                                            coin_amount[new_amount_len] = '\0';
+                                        }
+                                        koinu_amount = coins_to_koinu_str(coin_amount);
                                         if (!koinu_amount) {
                                             printf("number is invalid or set to 0\n");
                                         } else tx_out->value = koinu_amount;
@@ -571,10 +580,10 @@ void transaction_output_menu(int txindex, int is_testnet) {
             // escape encompassing while loop so we return to previous menu
             if (i == length - 1) {
                 printf("\n\n");
-                char* subtotal[KOINU_STRINGLEN];
-                dogecoin_mem_zero(subtotal, KOINU_STRINGLEN);
-                koinu_to_coins_str(tx_out_total, (char*)subtotal, KOINU_STRINGLEN);
-                printf("subtotal - desired fee: %s\n", (char*)subtotal);
+                char subtotal[KOINU_STRINGLEN];
+                dogecoin_mem_zero(subtotal, sizeof(subtotal));
+                koinu_to_coins_str(tx_out_total, subtotal, sizeof(subtotal));
+                printf("subtotal - desired fee: %s\n", subtotal);
                 printf("\n");
                 printf("1. select output to edit\n");
                 printf("2. main menu\n");

--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -56,6 +56,7 @@
 #include <dogecoin/bip44.h>
 #include <dogecoin/cstr.h>
 #include <dogecoin/chainparams.h>
+#include <dogecoin/constants.h>
 #include <dogecoin/ecc.h>
 #include <dogecoin/eckey.h>
 #include <dogecoin/koinu.h>
@@ -503,8 +504,8 @@ void transaction_output_menu(int txindex, int is_testnet) {
     int running_transaction_output_menu = 1;
     while (running_transaction_output_menu) {
         char* destinationaddress;
-        char* coin_amount[21];
-        dogecoin_mem_zero(coin_amount, 21);
+        char* coin_amount[KOINU_STRINGLEN];
+        dogecoin_mem_zero(coin_amount, KOINU_STRINGLEN);
         uint64_t koinu_amount;
         uint64_t tx_out_total = 0;
         const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
@@ -518,7 +519,7 @@ void transaction_output_menu(int txindex, int is_testnet) {
             printf("\n--------------------------------\n");
             printf("output index:       %d\n", i);
             printf("script public key:  %s\n", utils_uint8_to_hex((const uint8_t*)tx_out->script_pubkey->str, tx_out->script_pubkey->len));
-            koinu_to_coins_str(tx_out->value, (char*)coin_amount, 21);
+            koinu_to_coins_str(tx_out->value, (char*)coin_amount, KOINU_STRINGLEN);
             printf("amount:             %s\n", (char*)coin_amount);
             // selected should only equal anything other than -1 upon setting
             // loop index in conditional targetting last iteration:
@@ -546,7 +547,7 @@ void transaction_output_menu(int txindex, int is_testnet) {
                                             }
                                         break;
                                     case 2:
-                                        memcpy_safe(coin_amount, (char*)getl("new amount"), 21);
+                                        memcpy_safe(coin_amount, (char*)getl("new amount"), KOINU_STRINGLEN);
                                         koinu_amount = coins_to_koinu_str((char*)coin_amount);
                                         if (!koinu_amount) {
                                             printf("number is invalid or set to 0\n");
@@ -570,9 +571,9 @@ void transaction_output_menu(int txindex, int is_testnet) {
             // escape encompassing while loop so we return to previous menu
             if (i == length - 1) {
                 printf("\n\n");
-                char* subtotal[21];
-                dogecoin_mem_zero(subtotal, 21);
-                koinu_to_coins_str(tx_out_total, (char*)subtotal, 21);
+                char* subtotal[KOINU_STRINGLEN];
+                dogecoin_mem_zero(subtotal, KOINU_STRINGLEN);
+                koinu_to_coins_str(tx_out_total, (char*)subtotal, KOINU_STRINGLEN);
                 printf("subtotal - desired fee: %s\n", (char*)subtotal);
                 printf("\n");
                 printf("1. select output to edit\n");

--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -518,7 +518,7 @@ void transaction_output_menu(int txindex, int is_testnet) {
             printf("\n--------------------------------\n");
             printf("output index:       %d\n", i);
             printf("script public key:  %s\n", utils_uint8_to_hex((const uint8_t*)tx_out->script_pubkey->str, tx_out->script_pubkey->len));
-            koinu_to_coins_str(tx_out->value, (char*)coin_amount);
+            koinu_to_coins_str(tx_out->value, (char*)coin_amount, 21);
             printf("amount:             %s\n", (char*)coin_amount);
             // selected should only equal anything other than -1 upon setting
             // loop index in conditional targetting last iteration:
@@ -572,7 +572,7 @@ void transaction_output_menu(int txindex, int is_testnet) {
                 printf("\n\n");
                 char* subtotal[21];
                 dogecoin_mem_zero(subtotal, 21);
-                koinu_to_coins_str(tx_out_total, (char*)subtotal);
+                koinu_to_coins_str(tx_out_total, (char*)subtotal, 21);
                 printf("subtotal - desired fee: %s\n", (char*)subtotal);
                 printf("\n");
                 printf("1. select output to edit\n");

--- a/src/ecc.c
+++ b/src/ecc.c
@@ -66,6 +66,16 @@ dogecoin_bool dogecoin_ecc_private_key_tweak_add(uint8_t* private_key, const uin
     return ok;
 }
 
+/* BIP-0038 EC-multiplied (0x43) decrypt: derived privkey = passfactor * factorB (mod n). */
+dogecoin_bool dogecoin_ecc_private_key_tweak_mul(uint8_t* private_key, const uint8_t* tweak)
+{
+    assert(secp256k1_ctx);
+    enable_DIT();
+    dogecoin_bool ok = secp256k1_ec_privkey_tweak_mul(secp256k1_ctx, (unsigned char*)private_key, (const unsigned char*)tweak);
+    disable_DIT();
+    return ok;
+}
+
 dogecoin_bool dogecoin_ecc_public_key_tweak_add(uint8_t* public_key_inout, const uint8_t* tweak)
 {
     size_t out = DOGECOIN_ECKEY_COMPRESSED_LENGTH;
@@ -78,6 +88,45 @@ dogecoin_bool dogecoin_ecc_public_key_tweak_add(uint8_t* public_key_inout, const
     if (!secp256k1_ec_pubkey_serialize(secp256k1_ctx, public_key_inout, &out, &pubkey, SECP256K1_EC_COMPRESSED))
         return false;
     return true;
+}
+
+/* BIP-0038 EC-multiplied encrypt/decrypt: scalar-multiply passpoint or pointB in place. */
+dogecoin_bool dogecoin_ecc_public_key_tweak_mul(uint8_t* public_key_inout, const uint8_t* tweak)
+{
+    size_t out = DOGECOIN_ECKEY_COMPRESSED_LENGTH;
+    secp256k1_pubkey pubkey;
+    assert(secp256k1_ctx);
+    if (!secp256k1_ec_pubkey_parse(secp256k1_ctx, &pubkey, public_key_inout, 33))
+        return false;
+    if (!secp256k1_ec_pubkey_tweak_mul(secp256k1_ctx, &pubkey, (const unsigned char*)tweak))
+        return false;
+    if (!secp256k1_ec_pubkey_serialize(secp256k1_ctx, public_key_inout, &out, &pubkey, SECP256K1_EC_COMPRESSED))
+        return false;
+    return true;
+}
+
+/* BIP-0038 address-hash step: tweak_mul leaves a 33-byte point; re-encode for compressed flag. */
+dogecoin_bool dogecoin_ecc_point_serialize(
+    const uint8_t* point,
+    size_t point_len,
+    uint8_t* pubkey_out,
+    size_t* pubkey_len,
+    dogecoin_bool compressed)
+{
+    secp256k1_pubkey pubkey;
+    assert(secp256k1_ctx);
+    if (!point || !pubkey_out || !pubkey_len) {
+        return false;
+    }
+    if (!secp256k1_ec_pubkey_parse(secp256k1_ctx, &pubkey, point, point_len)) {
+        return false;
+    }
+    return secp256k1_ec_pubkey_serialize(
+        secp256k1_ctx,
+        pubkey_out,
+        pubkey_len,
+        &pubkey,
+        compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
 }
 
 dogecoin_bool dogecoin_ecc_verify_privatekey(const uint8_t* private_key)

--- a/src/koinu.c
+++ b/src/koinu.c
@@ -176,7 +176,7 @@ int koinu_to_coins_str(uint64_t koinu, char* str, size_t str_size) {
         str[10] = '\0';
         free(swap);
     } else {
-        char tmp[21];
+        char tmp[KOINU_COINS_STR_MAX_LEN];
         string(koinu, tmp);
         for (; i < length; i++) {
             if (i < target) str[i] = tmp[i];

--- a/src/koinu.c
+++ b/src/koinu.c
@@ -138,9 +138,21 @@ void string(uint64_t input, char output[]) {
     output[length] = '\0';
 }
 
-int koinu_to_coins_str(uint64_t koinu, char* str) {
+static size_t koinu_coins_str_required_size(uint64_t koinu)
+{
+    size_t length = (size_t)calc_length(koinu);
+    if (length < 9) {
+        return KOINU_COINS_STR_MIN_LEN;
+    }
+    return length + 2;
+}
+
+int koinu_to_coins_str(uint64_t koinu, char* str, size_t str_size) {
     enum conversion_type state = validate_conversion(koinu, NULL, NULL, NULL);
     if (state != CONVERSION_SUCCESS) return false;
+    if (!str || str_size < koinu_coins_str_required_size(koinu)) {
+        return false;
+    }
 
     uint64_t i = 0, j =0, length = calc_length(koinu),
     target = length < 9 ? 10 - length : length - 9;

--- a/src/koinu.c
+++ b/src/koinu.c
@@ -157,6 +157,11 @@ int koinu_to_coins_str(uint64_t koinu, char* str) {
             } else str[i] = '0';
         }
         for (; i < 10; i++, j++) str[i] = swap[j];
+        /* length < 9 always writes 10 chars to str[0..9]; terminate here (the
+         * length >= 9 branch already null-terminates). Found during BIP38
+         * paper-wallet sweep work: small fee koinu hit this path and
+         * finalize_transaction failed without a proper C string. */
+        str[10] = '\0';
         free(swap);
     } else {
         char tmp[21];

--- a/src/rest.c
+++ b/src/rest.c
@@ -75,8 +75,8 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
     if (strcmp(path, "/getBalance") == 0) {
         /* Spendable balance across the wallet's wtx set, honoring coinbase
          * maturity and the spends index. */
-        char wallet_total[21];
-        dogecoin_mem_zero(wallet_total, 21);
+        char wallet_total[KOINU_STRINGLEN];
+        dogecoin_mem_zero(wallet_total, sizeof(wallet_total));
         int64_t balance = dogecoin_wallet_get_balance(wallet);
         koinu_to_coins_str(balance < 0 ? 0 : (uint64_t)balance, wallet_total, sizeof(wallet_total));
         evbuffer_add_printf(evb, "Wallet balance: %s\n", wallet_total);
@@ -91,8 +91,8 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
     } else if (strcmp(path, "/getTransactions") == 0) {
         /* Spent UTXOs received externally; skip change from our own txs to
          * avoid double-counting re-spent coins along the change chain. */
-        char wallet_total[21];
-        dogecoin_mem_zero(wallet_total, 21);
+        char wallet_total[KOINU_STRINGLEN];
+        dogecoin_mem_zero(wallet_total, sizeof(wallet_total));
         uint64_t wallet_total_u64 = 0;
 
         if (HASH_COUNT(wallet->utxos) > 0) {
@@ -129,8 +129,8 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
         koinu_to_coins_str(wallet_total_u64, wallet_total, sizeof(wallet_total));
         evbuffer_add_printf(evb, "Spent Balance: %s\n", wallet_total);
     } else if (strcmp(path, "/getUTXOs") == 0) {
-        char wallet_total[21];
-        dogecoin_mem_zero(wallet_total, 21);
+        char wallet_total[KOINU_STRINGLEN];
+        dogecoin_mem_zero(wallet_total, sizeof(wallet_total));
         uint64_t wallet_total_u64_unspent = 0;
 
         dogecoin_utxo* utxo;

--- a/src/rest.c
+++ b/src/rest.c
@@ -78,7 +78,7 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
         char wallet_total[21];
         dogecoin_mem_zero(wallet_total, 21);
         int64_t balance = dogecoin_wallet_get_balance(wallet);
-        koinu_to_coins_str(balance < 0 ? 0 : (uint64_t)balance, wallet_total);
+        koinu_to_coins_str(balance < 0 ? 0 : (uint64_t)balance, wallet_total, sizeof(wallet_total));
         evbuffer_add_printf(evb, "Wallet balance: %s\n", wallet_total);
     } else if (strcmp(path, "/getAddresses") == 0) {
         vector_t* addresses = vector_new(10, dogecoin_free);
@@ -126,7 +126,7 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
         }
 
         // Convert and print totals for spent UTXOs.
-        koinu_to_coins_str(wallet_total_u64, wallet_total);
+        koinu_to_coins_str(wallet_total_u64, wallet_total, sizeof(wallet_total));
         evbuffer_add_printf(evb, "Spent Balance: %s\n", wallet_total);
     } else if (strcmp(path, "/getUTXOs") == 0) {
         char wallet_total[21];
@@ -155,7 +155,7 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
         }
 
         // Convert and print totals for unspent UTXOs.
-        koinu_to_coins_str(wallet_total_u64_unspent, wallet_total);
+        koinu_to_coins_str(wallet_total_u64_unspent, wallet_total, sizeof(wallet_total));
         evbuffer_add_printf(evb, "Total Unspent: %s\n", wallet_total);
     } else if (strcmp(path, "/getSpends") == 0) {
         /* Outgoing-tx history from vec_wtxes: for each is_from_me wtx, emit
@@ -193,11 +193,11 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
             char sent_str[KOINU_STRINGLEN]   = {0};
             char change_str[KOINU_STRINGLEN] = {0};
             char fee_str[KOINU_STRINGLEN]    = {0};
-            koinu_to_coins_str((uint64_t)debit_in,  debit_str);
-            koinu_to_coins_str((uint64_t)total_out, total_str);
-            koinu_to_coins_str((uint64_t)ext_out,   sent_str);
-            koinu_to_coins_str((uint64_t)mine_out,  change_str);
-            koinu_to_coins_str((uint64_t)fee,       fee_str);
+            koinu_to_coins_str((uint64_t)debit_in,  debit_str, sizeof(debit_str));
+            koinu_to_coins_str((uint64_t)total_out, total_str, sizeof(total_str));
+            koinu_to_coins_str((uint64_t)ext_out,   sent_str, sizeof(sent_str));
+            koinu_to_coins_str((uint64_t)mine_out,  change_str, sizeof(change_str));
+            koinu_to_coins_str((uint64_t)fee,       fee_str, sizeof(fee_str));
 
             evbuffer_add_printf(evb, "----------------------\n");
             evbuffer_add_printf(evb, "txid:           %s\n", txid_hex);
@@ -220,7 +220,7 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
                 }
 
                 char amt_str[KOINU_STRINGLEN] = {0};
-                koinu_to_coins_str((uint64_t)o->value, amt_str);
+                koinu_to_coins_str((uint64_t)o->value, amt_str, sizeof(amt_str));
 
                 evbuffer_add_printf(evb, "  output:\n");
                 evbuffer_add_printf(evb, "    vout:           %u\n", j);
@@ -234,7 +234,7 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
         }
 
         char total_sent_str[KOINU_STRINGLEN] = {0};
-        koinu_to_coins_str(total_sent_u64, total_sent_str);
+        koinu_to_coins_str(total_sent_u64, total_sent_str, sizeof(total_sent_str));
         evbuffer_add_printf(evb, "----------------------\n");
         evbuffer_add_printf(evb, "Outgoing transactions: %u\n", outgoing_count);
         evbuffer_add_printf(evb, "Total Sent (excl. change): %s\n", total_sent_str);
@@ -532,11 +532,11 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
     char avg_fee_str[32]    = {0};
     char med_fee_kb_str[32] = {0};
     char avg_fee_kb_str[32] = {0};
-    koinu_to_coins_str(sum_out_value, vol_str);
-    koinu_to_coins_str(median_fee,    med_fee_str);
-    koinu_to_coins_str(avg_fee,       avg_fee_str);
-    koinu_to_coins_str(median_fee_per_kb, med_fee_kb_str);
-    koinu_to_coins_str(avg_fee_per_kb,     avg_fee_kb_str);
+    koinu_to_coins_str(sum_out_value, vol_str, sizeof(vol_str));
+    koinu_to_coins_str(median_fee,    med_fee_str, sizeof(med_fee_str));
+    koinu_to_coins_str(avg_fee,       avg_fee_str, sizeof(avg_fee_str));
+    koinu_to_coins_str(median_fee_per_kb, med_fee_kb_str, sizeof(med_fee_kb_str));
+    koinu_to_coins_str(avg_fee_per_kb,     avg_fee_kb_str, sizeof(avg_fee_kb_str));
 
     evbuffer_add_printf(evb, "=== Stats (window=%u s) ===\n", window);
     evbuffer_add_printf(evb, "blocks: %u\n", blocks);
@@ -568,8 +568,8 @@ void dogecoin_http_request_cb(struct evhttp_request *req, void *arg) {
 
         char total_out_str[32]  = {0};
         char total_fees_str[32] = {0};
-        koinu_to_coins_str(client->stats_out_value_total, total_out_str);
-        koinu_to_coins_str(client->stats_fees_total, total_fees_str);
+        koinu_to_coins_str(client->stats_out_value_total, total_out_str, sizeof(total_out_str));
+        koinu_to_coins_str(client->stats_fees_total, total_fees_str, sizeof(total_fees_str));
 
         evbuffer_add_printf(evb, "=== Chain Stats (SPV session) ===\n");
         if (tip) {

--- a/src/scrypt.c
+++ b/src/scrypt.c
@@ -217,3 +217,197 @@ void scrypt_1024_1_1_256(const char *input, char *output)
     memset(scratchpad, 0, sizeof(scratchpad));
     scrypt_1024_1_1_256_sp(input, output, scratchpad);
 }
+
+/* --- RFC 7914 scrypt (BIP38 and other password KDFs) --- */
+
+static void scrypt_rfc7914_blkxor(uint32_t* dest, const uint32_t* src, size_t len)
+{
+    size_t i;
+    for (i = 0; i < len / 4; i++)
+        dest[i] ^= src[i];
+}
+
+static void scrypt_rfc7914_salsa20_8(uint32_t B[16])
+{
+    uint32_t x[16];
+    size_t i;
+
+    memcpy(x, B, 64);
+    for (i = 0; i < 8; i += 2) {
+#define R(a, b) (((a) << (b)) | ((a) >> (32 - (b))))
+        x[4] ^= R(x[0] + x[12], 7);
+        x[8] ^= R(x[4] + x[0], 9);
+        x[12] ^= R(x[8] + x[4], 13);
+        x[0] ^= R(x[12] + x[8], 18);
+
+        x[9] ^= R(x[5] + x[1], 7);
+        x[13] ^= R(x[9] + x[5], 9);
+        x[1] ^= R(x[13] + x[9], 13);
+        x[5] ^= R(x[1] + x[13], 18);
+
+        x[14] ^= R(x[10] + x[6], 7);
+        x[2] ^= R(x[14] + x[10], 9);
+        x[6] ^= R(x[2] + x[14], 13);
+        x[10] ^= R(x[6] + x[2], 18);
+
+        x[3] ^= R(x[15] + x[11], 7);
+        x[7] ^= R(x[3] + x[15], 9);
+        x[11] ^= R(x[7] + x[3], 13);
+        x[15] ^= R(x[11] + x[7], 18);
+
+        x[1] ^= R(x[0] + x[3], 7);
+        x[2] ^= R(x[1] + x[0], 9);
+        x[3] ^= R(x[2] + x[1], 13);
+        x[0] ^= R(x[3] + x[2], 18);
+
+        x[6] ^= R(x[5] + x[4], 7);
+        x[7] ^= R(x[6] + x[5], 9);
+        x[4] ^= R(x[7] + x[6], 13);
+        x[5] ^= R(x[4] + x[7], 18);
+
+        x[11] ^= R(x[10] + x[9], 7);
+        x[8] ^= R(x[11] + x[10], 9);
+        x[9] ^= R(x[8] + x[11], 13);
+        x[10] ^= R(x[9] + x[8], 18);
+
+        x[12] ^= R(x[15] + x[14], 7);
+        x[13] ^= R(x[12] + x[15], 9);
+        x[14] ^= R(x[13] + x[12], 13);
+        x[15] ^= R(x[14] + x[13], 18);
+#undef R
+    }
+    for (i = 0; i < 16; i++)
+        B[i] += x[i];
+}
+
+static void scrypt_rfc7914_blockmix_salsa8(uint32_t* Bin, uint32_t* Bout, uint32_t* X, size_t r)
+{
+    size_t i;
+
+    memcpy(X, &Bin[(2 * r - 1) * 16], 64);
+
+    for (i = 0; i < 2 * r; i += 2) {
+        scrypt_rfc7914_blkxor(X, &Bin[i * 16], 64);
+        scrypt_rfc7914_salsa20_8(X);
+
+        memcpy(&Bout[i * 8], X, 64);
+
+        scrypt_rfc7914_blkxor(X, &Bin[i * 16 + 16], 64);
+        scrypt_rfc7914_salsa20_8(X);
+
+        memcpy(&Bout[i * 8 + r * 16], X, 64);
+    }
+}
+
+static uint64_t scrypt_rfc7914_integerify(uint32_t* B, size_t r)
+{
+    const uint32_t* X = B + (2 * r - 1) * 16;
+    return (((uint64_t)(X[1]) << 32) + X[0]);
+}
+
+static void scrypt_rfc7914_smix(uint8_t* B, size_t r, uint64_t N, uint32_t* V, uint32_t* XY)
+{
+    uint32_t* X = XY;
+    uint32_t* Y = &XY[32 * r];
+    uint32_t* Z = &XY[64 * r];
+    uint64_t i;
+    uint64_t j;
+    size_t k;
+
+    for (k = 0; k < 32 * r; k++)
+        X[k] = le32dec(&B[4 * k]);
+
+    for (i = 0; i < N; i += 2) {
+        memcpy(&V[i * (32 * r)], X, 128 * r);
+        scrypt_rfc7914_blockmix_salsa8(X, Y, Z, r);
+
+        memcpy(&V[(i + 1) * (32 * r)], Y, 128 * r);
+        scrypt_rfc7914_blockmix_salsa8(Y, X, Z, r);
+    }
+
+    for (i = 0; i < N; i += 2) {
+        j = scrypt_rfc7914_integerify(X, r) & (N - 1);
+
+        scrypt_rfc7914_blkxor(X, &V[j * (32 * r)], 128 * r);
+        scrypt_rfc7914_blockmix_salsa8(X, Y, Z, r);
+
+        j = scrypt_rfc7914_integerify(Y, r) & (N - 1);
+
+        scrypt_rfc7914_blkxor(Y, &V[j * (32 * r)], 128 * r);
+        scrypt_rfc7914_blockmix_salsa8(Y, X, Z, r);
+    }
+
+    for (k = 0; k < 32 * r; k++)
+        le32enc(&B[4 * k], X[k]);
+}
+
+static void* scrypt_rfc7914_alloc_aligned(size_t size, size_t align, void** base_out)
+{
+    void* p = malloc(size + align - 1);
+    *base_out = p;
+    if (!p)
+        return NULL;
+    return (void*)(((uintptr_t)p + align - 1) & ~(uintptr_t)(align - 1));
+}
+
+int dogecoin_scrypt_rfc7914(
+    const uint8_t* passwd,
+    size_t passwdlen,
+    const uint8_t* salt,
+    size_t saltlen,
+    uint64_t N,
+    uint32_t r,
+    uint32_t p,
+    uint8_t* buf,
+    size_t buflen)
+{
+    void *B0 = NULL, *V0 = NULL, *XY0 = NULL;
+    uint8_t* B;
+    uint32_t* V;
+    uint32_t* XY;
+    uint32_t i;
+
+    if (buflen > (((uint64_t)1 << 32) - 1) * 32)
+        return 0;
+    if ((uint64_t)r * (uint64_t)p >= (1ULL << 30))
+        return 0;
+    if (r == 0 || p == 0)
+        return 0;
+    if (((N & (N - 1)) != 0) || (N < 2))
+        return 0;
+    if (r > SIZE_MAX / 128 / p)
+        return 0;
+    if (N > SIZE_MAX / 128 / r)
+        return 0;
+
+    B = (uint8_t*)scrypt_rfc7914_alloc_aligned(128 * r * p + 63, 64, &B0);
+    if (!B0)
+        return 0;
+    XY = (uint32_t*)scrypt_rfc7914_alloc_aligned((256 * r + 64) + 63, 64, &XY0);
+    if (!XY0) {
+        free(B0);
+        return 0;
+    }
+    V = (uint32_t*)scrypt_rfc7914_alloc_aligned(128 * r * N + 63, 64, &V0);
+    if (!V0) {
+        free(XY0);
+        free(B0);
+        return 0;
+    }
+
+    pbkdf2_hmac_sha256(passwd, (int)passwdlen, salt, (int)saltlen, 1, B, (int)(p * 128 * r));
+
+    for (i = 0; i < p; i++) {
+        scrypt_rfc7914_smix(&B[i * 128 * r], r, N, V, XY);
+    }
+
+    pbkdf2_hmac_sha256(passwd, (int)passwdlen, B, (int)(p * 128 * r), 1, buf, (int)buflen);
+
+    dogecoin_mem_zero(V0, 128 * r * N + 63);
+    dogecoin_mem_zero(XY0, (256 * r + 64) + 63);
+    dogecoin_mem_zero(B0, 128 * r * p + 63);
+    free(V0);
+    free(XY0);
+    free(B0);
+    return 1;
+}

--- a/src/sweep.c
+++ b/src/sweep.c
@@ -1,0 +1,1377 @@
+/*
+ * Copyright (c) 2024 The Dogecoin Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <dogecoin/sweep.h>
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/bip38.h>
+#include <dogecoin/key.h>
+#include <dogecoin/address.h>
+#include <dogecoin/transaction.h>
+#include <dogecoin/koinu.h>
+#include <dogecoin/tx.h>
+#include <dogecoin/cstr.h>
+#include <dogecoin/script.h>
+#include <dogecoin/utils.h>
+#include <dogecoin/mem.h>
+#include <dogecoin/sha2.h>
+#include <dogecoin/rmd160.h>
+#include <dogecoin/constants.h>
+#include <dogecoin/ecc.h>
+#ifdef WITH_WALLET
+#include <dogecoin/wallet.h>
+#endif
+#ifdef WITH_NET
+#include <dogecoin/net.h>
+#endif
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static dogecoin_bool sweep_pubkey_from_privkey(
+    const uint8_t* private_key,
+    dogecoin_bool compressed,
+    dogecoin_pubkey* pubkey_out)
+{
+    if (!private_key || !pubkey_out) {
+        return false;
+    }
+    dogecoin_pubkey_init(pubkey_out);
+    size_t pubkey_len = compressed ? DOGECOIN_ECKEY_COMPRESSED_LENGTH : DOGECOIN_ECKEY_UNCOMPRESSED_LENGTH;
+    dogecoin_ecc_get_pubkey(private_key, pubkey_out->pubkey, &pubkey_len, compressed);
+    pubkey_out->compressed = compressed;
+    return true;
+}
+
+static void sweep_secure_free(char* s)
+{
+    if (!s) {
+        return;
+    }
+    dogecoin_mem_zero(s, strlen(s));
+    dogecoin_free(s);
+}
+
+static void sweep_result_fail(dogecoin_sweep_result* r, const char* msg)
+{
+    if (!r || !msg) return;
+    if (r->error_message) dogecoin_free(r->error_message);
+    r->error_message = dogecoin_calloc(1, strlen(msg) + 1);
+    if (r->error_message) strcpy(r->error_message, msg);
+    r->success = false;
+}
+
+/* Sweep txs are small; use a modest heap buffer (not TXHEXMAXLEN) to ease armhf CI. */
+#define SWEEP_TX_HEX_BUF_SIZE 65536U
+
+static char* sweep_tx_hex_alloc(void)
+{
+    return (char*)dogecoin_calloc(1, SWEEP_TX_HEX_BUF_SIZE);
+}
+
+static void sweep_options_clear_utxos(dogecoin_sweep_options* options)
+{
+    size_t i;
+    if (!options || !options->utxos) {
+        if (options) {
+            options->utxo_count = 0;
+        }
+        return;
+    }
+    for (i = 0; i < options->utxo_count; i++) {
+        if (options->utxos[i].txid) {
+            dogecoin_free(options->utxos[i].txid);
+        }
+        if (options->utxos[i].amount_doge) {
+            dogecoin_free(options->utxos[i].amount_doge);
+        }
+    }
+    dogecoin_free(options->utxos);
+    options->utxos = NULL;
+    options->utxo_count = 0;
+}
+
+static void sweep_options_sync_legacy(dogecoin_sweep_options* options)
+{
+    if (!options) {
+        return;
+    }
+    if (options->utxo_txid) {
+        dogecoin_free(options->utxo_txid);
+        options->utxo_txid = NULL;
+    }
+    if (options->utxo_total_doge) {
+        dogecoin_free(options->utxo_total_doge);
+        options->utxo_total_doge = NULL;
+    }
+    options->utxo_vout = -1;
+    if (options->utxo_count == 0) {
+        return;
+    }
+    options->utxo_txid = dogecoin_calloc(1, strlen(options->utxos[0].txid) + 1);
+    options->utxo_total_doge = dogecoin_calloc(1, strlen(options->utxos[0].amount_doge) + 1);
+    if (options->utxo_txid && options->utxo_total_doge) {
+        strcpy(options->utxo_txid, options->utxos[0].txid);
+        strcpy(options->utxo_total_doge, options->utxos[0].amount_doge);
+        options->utxo_vout = options->utxos[0].vout;
+    }
+}
+
+static dogecoin_bool sweep_options_utxo_ok(const dogecoin_sweep_options* o)
+{
+    size_t i;
+    if (!o || o->utxo_count == 0) {
+        return false;
+    }
+    for (i = 0; i < o->utxo_count; i++) {
+        const dogecoin_sweep_utxo* u = &o->utxos[i];
+        if (!u->txid || !u->txid[0] || u->vout < 0 || !u->amount_doge || !u->amount_doge[0]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static uint64_t sweep_options_total_koinu(const dogecoin_sweep_options* options)
+{
+    uint64_t total = 0;
+    size_t i;
+    for (i = 0; i < options->utxo_count; i++) {
+        total += coins_to_koinu_str(options->utxos[i].amount_doge);
+    }
+    return total;
+}
+
+static size_t sweep_estimate_vsize(size_t input_count)
+{
+    if (input_count == 0) {
+        input_count = 1;
+    }
+    /* version + varints + N signed P2PKH inputs + 1 P2PKH output + locktime */
+    return 10u + input_count * 180u + 34u;
+}
+
+static dogecoin_bool sweep_compute_amounts(
+    const dogecoin_sweep_options* options,
+    uint64_t* fee_koinu_out,
+    uint64_t* out_koinu_out,
+    char* fee_doge,
+    char* out_doge)
+{
+    uint64_t total_koinu = sweep_options_total_koinu(options);
+    size_t est_vsize = sweep_estimate_vsize(options->utxo_count);
+    uint64_t fee_koinu = options->fee_per_byte * est_vsize;
+    if (fee_koinu < options->min_fee) {
+        fee_koinu = options->min_fee;
+    }
+    if (fee_koinu > options->max_fee) {
+        fee_koinu = options->max_fee;
+    }
+    if (total_koinu <= fee_koinu) {
+        return false;
+    }
+    uint64_t out_koinu = total_koinu - fee_koinu;
+    if (!koinu_to_coins_str(fee_koinu, fee_doge)) {
+        return false;
+    }
+    if (!koinu_to_coins_str(out_koinu, out_doge)) {
+        return false;
+    }
+    *fee_koinu_out = fee_koinu;
+    *out_koinu_out = out_koinu;
+    return true;
+}
+
+static void sweep_apply_tx_flags(const dogecoin_sweep_options* options, int txindex)
+{
+    working_transaction* tx;
+    size_t i;
+    if (!options) {
+        return;
+    }
+    tx = find_transaction(txindex);
+    if (!tx || !tx->transaction) {
+        return;
+    }
+    if (options->locktime) {
+        tx->transaction->locktime = options->locktime;
+    }
+    if (options->use_rbf) {
+        for (i = 0; i < tx->transaction->vin->len; i++) {
+            dogecoin_tx_in* vin = vector_idx(tx->transaction->vin, i);
+            vin->sequence = 0xfffffffd;
+        }
+    }
+}
+
+/* Full P2PKH scriptPubKey hex: 6 + 40 + 4 hex chars + NUL (see transaction_tests.c). */
+#define SWEEP_SCRIPTPUBKEY_HEX_LEN (40 + 6 + 4 + 1)
+
+static char* sweep_script_pubkey_from_wallet(const dogecoin_paper_wallet* wallet)
+{
+    char* script;
+    if (!wallet || !wallet->address) {
+        return NULL;
+    }
+    script = dogecoin_calloc(1, SWEEP_SCRIPTPUBKEY_HEX_LEN);
+    if (!script) {
+        return NULL;
+    }
+    if (!dogecoin_p2pkh_address_to_pubkey_hash(wallet->address, script)) {
+        dogecoin_free(script);
+        return NULL;
+    }
+    return script;
+}
+
+static dogecoin_bool sweep_wallet_get_wif(
+    const dogecoin_paper_wallet* wallet,
+    char* wif_out,
+    size_t wif_size)
+{
+    return dogecoin_paper_wallet_get_wif(wallet, wif_out, wif_size);
+}
+
+static dogecoin_bool sweep_build_unsigned_tx(
+    const dogecoin_sweep_options* options,
+    const char* fee_doge,
+    const char* out_doge,
+    int* txindex_out)
+{
+    char dest_copy[P2PKHLEN];
+    char total_copy[64];
+    size_t i;
+    int txindex;
+
+    strncpy(dest_copy, options->destination_address, sizeof(dest_copy) - 1);
+    dest_copy[sizeof(dest_copy) - 1] = '\0';
+    if (!koinu_to_coins_str(sweep_options_total_koinu(options), total_copy)) {
+        return false;
+    }
+
+    /* Working-transaction table is global; clear stale entries from prior API use. */
+    remove_all();
+
+    txindex = start_transaction();
+    for (i = 0; i < options->utxo_count; i++) {
+        if (!add_utxo(txindex, options->utxos[i].txid, options->utxos[i].vout)) {
+            clear_transaction(txindex);
+            return false;
+        }
+    }
+    if (!add_output(txindex, dest_copy, (char*)out_doge)) {
+        clear_transaction(txindex);
+        return false;
+    }
+    if (!finalize_transaction(txindex, dest_copy, (char*)fee_doge, total_copy, NULL)) {
+        clear_transaction(txindex);
+        return false;
+    }
+    sweep_apply_tx_flags(options, txindex);
+    *txindex_out = txindex;
+    return true;
+}
+
+static dogecoin_bool sweep_sign_txindex(
+    int txindex,
+    const dogecoin_paper_wallet* const* wallets,
+    size_t wallet_count,
+    char* hexbuf,
+    size_t hexbuf_cap)
+{
+    working_transaction* tx;
+    size_t vin_cnt;
+    size_t i;
+
+    if (!wallets || wallet_count == 0 || !hexbuf) {
+        return false;
+    }
+
+    tx = find_transaction(txindex);
+    if (!tx || !tx->transaction) {
+        return false;
+    }
+    vin_cnt = tx->transaction->vin->len;
+
+    if (wallet_count == 1) {
+        char wif[PRIVKEYWIFLEN];
+        char* script_pubkey;
+        if (!sweep_wallet_get_wif(wallets[0], wif, sizeof(wif))) {
+            return false;
+        }
+        script_pubkey = sweep_script_pubkey_from_wallet(wallets[0]);
+        if (!script_pubkey) {
+            return false;
+        }
+        if (!sign_transaction_ex(txindex, script_pubkey, wif, hexbuf, hexbuf_cap)) {
+            dogecoin_free(script_pubkey);
+            return false;
+        }
+        dogecoin_free(script_pubkey);
+        return true;
+    }
+
+    if (wallet_count != vin_cnt) {
+        return false;
+    }
+
+    for (i = 0; i < vin_cnt; i++) {
+        char wif[PRIVKEYWIFLEN];
+        char* script_pubkey;
+        if (!sweep_wallet_get_wif(wallets[i], wif, sizeof(wif))) {
+            return false;
+        }
+        script_pubkey = sweep_script_pubkey_from_wallet(wallets[i]);
+        if (!script_pubkey) {
+            return false;
+        }
+        if (!sign_indexed_raw_transaction_ex(
+                txindex, (int)i, script_pubkey, 1, wif, hexbuf, hexbuf_cap)) {
+            dogecoin_free(script_pubkey);
+            return false;
+        }
+        dogecoin_free(script_pubkey);
+    }
+    return true;
+}
+
+static dogecoin_bool sweep_fill_result_from_hex(
+    dogecoin_sweep_result* result,
+    const dogecoin_sweep_options* options,
+    const char* hexbuf,
+    int hexlen,
+    uint64_t out_koinu,
+    uint64_t fee_koinu)
+{
+    dogecoin_tx* stx;
+    uint8_t* bindata;
+    size_t binlen;
+    uint256_t txhash;
+    char txidhex[65];
+
+    stx = dogecoin_tx_new();
+    if (!stx) {
+        return false;
+    }
+    bindata = dogecoin_malloc((size_t)hexlen / 2 + 1);
+    if (!bindata) {
+        dogecoin_tx_free(stx);
+        return false;
+    }
+    binlen = 0;
+    utils_hex_to_bin(hexbuf, bindata, (size_t)hexlen, &binlen);
+    if (!dogecoin_tx_deserialize(bindata, binlen, stx, NULL)) {
+        dogecoin_free(bindata);
+        dogecoin_tx_free(stx);
+        return false;
+    }
+    dogecoin_free(bindata);
+    dogecoin_tx_hash(stx, txhash);
+    dogecoin_tx_free(stx);
+
+    utils_bin_to_hex((unsigned char*)txhash, sizeof(txhash), txidhex);
+    utils_reverse_hex(txidhex, 64);
+    txidhex[64] = '\0';
+
+    result->transaction_hex = dogecoin_calloc(1, (size_t)hexlen + 1);
+    result->transaction_id = dogecoin_calloc(1, strlen(txidhex) + 1);
+    result->destination_address = dogecoin_calloc(1, strlen(options->destination_address) + 1);
+    if (!result->transaction_hex || !result->transaction_id || !result->destination_address) {
+        if (result->transaction_hex) {
+            dogecoin_free(result->transaction_hex);
+        }
+        if (result->transaction_id) {
+            dogecoin_free(result->transaction_id);
+        }
+        if (result->destination_address) {
+            dogecoin_free(result->destination_address);
+        }
+        result->transaction_hex = NULL;
+        result->transaction_id = NULL;
+        result->destination_address = NULL;
+        return false;
+    }
+    memcpy(result->transaction_hex, hexbuf, (size_t)hexlen + 1);
+    strcpy(result->transaction_id, txidhex);
+    strcpy(result->destination_address, options->destination_address);
+    result->amount_swept = out_koinu;
+    result->fee_paid = fee_koinu;
+    result->success = true;
+    return true;
+}
+
+static dogecoin_sweep_result* sweep_wallets_impl(
+    const dogecoin_paper_wallet* const* wallets,
+    size_t wallet_count,
+    const dogecoin_sweep_options* options)
+{
+    dogecoin_sweep_result* result = dogecoin_sweep_result_new();
+    char fee_doge[64];
+    char out_doge[64];
+    uint64_t fee_koinu = 0;
+    uint64_t out_koinu = 0;
+    int txindex = 0;
+    char* hexbuf = NULL;
+    int hexlen;
+    size_t i;
+
+    if (!result) {
+        return NULL;
+    }
+    if (!wallets || wallet_count == 0 || !options) {
+        sweep_result_fail(result, "Invalid wallet or options");
+        return result;
+    }
+    for (i = 0; i < wallet_count; i++) {
+        if (!dogecoin_paper_wallet_is_valid(wallets[i])) {
+            sweep_result_fail(result, "Invalid paper wallet");
+            return result;
+        }
+    }
+    if (!options->destination_address) {
+        sweep_result_fail(result, "No destination address specified");
+        return result;
+    }
+    if (!sweep_options_utxo_ok(options)) {
+        sweep_result_fail(result,
+            "No UTXO specified: use dogecoin_sweep_options_set_utxo or add_utxo");
+        return result;
+    }
+    if (wallet_count > 1 && options->utxo_count != wallet_count) {
+        sweep_result_fail(result, "Multi-wallet sweep requires one UTXO per wallet");
+        return result;
+    }
+    if (!sweep_compute_amounts(options, &fee_koinu, &out_koinu, fee_doge, out_doge)) {
+        sweep_result_fail(result, "Fee exceeds input value or amount conversion failed");
+        return result;
+    }
+    if (!sweep_build_unsigned_tx(options, fee_doge, out_doge, &txindex)) {
+        sweep_result_fail(result, "Building unsigned sweep transaction failed");
+        return result;
+    }
+    hexbuf = sweep_tx_hex_alloc();
+    if (!hexbuf) {
+        clear_transaction(txindex);
+        sweep_result_fail(result, "out of memory");
+        return result;
+    }
+    if (!sweep_sign_txindex(txindex, wallets, wallet_count, hexbuf, SWEEP_TX_HEX_BUF_SIZE)) {
+        clear_transaction(txindex);
+        dogecoin_free(hexbuf);
+        sweep_result_fail(result, "Signing sweep transaction failed");
+        return result;
+    }
+    hexlen = (int)strlen(hexbuf);
+    if (hexlen <= 0) {
+        clear_transaction(txindex);
+        dogecoin_free(hexbuf);
+        sweep_result_fail(result, "Signed transaction hex is empty");
+        return result;
+    }
+    if (!sweep_fill_result_from_hex(result, options, hexbuf, hexlen, out_koinu, fee_koinu)) {
+        clear_transaction(txindex);
+        dogecoin_free(hexbuf);
+        sweep_result_fail(result, "out of memory");
+        return result;
+    }
+    dogecoin_free(hexbuf);
+    clear_transaction(txindex);
+    return result;
+}
+
+/* Initialize a paper wallet structure */
+dogecoin_paper_wallet* dogecoin_paper_wallet_new(void) {
+    dogecoin_paper_wallet* wallet = dogecoin_calloc(1, sizeof(dogecoin_paper_wallet));
+    if (!wallet) return NULL;
+    
+    wallet->private_key_wif = NULL;
+    wallet->private_key_hex = NULL;
+    wallet->encrypted_private_key = NULL;
+    wallet->passphrase = NULL;
+    wallet->address = NULL;
+    wallet->compressed = false;
+    wallet->is_encrypted = false;
+    wallet->chain_params = NULL;
+    
+    return wallet;
+}
+
+/* Free a paper wallet structure */
+void dogecoin_paper_wallet_free(dogecoin_paper_wallet* wallet) {
+    if (!wallet) return;
+
+    sweep_secure_free(wallet->private_key_wif);
+    sweep_secure_free(wallet->private_key_hex);
+    sweep_secure_free(wallet->encrypted_private_key);
+    sweep_secure_free(wallet->passphrase);
+    sweep_secure_free(wallet->address);
+
+    dogecoin_free(wallet);
+}
+
+/* Initialize a sweep result structure */
+dogecoin_sweep_result* dogecoin_sweep_result_new(void) {
+    dogecoin_sweep_result* result = dogecoin_calloc(1, sizeof(dogecoin_sweep_result));
+    if (!result) return NULL;
+    
+    result->success = false;
+    result->error_message = NULL;
+    result->transaction_hex = NULL;
+    result->transaction_id = NULL;
+    result->amount_swept = 0;
+    result->fee_paid = 0;
+    result->destination_address = NULL;
+    
+    return result;
+}
+
+/* Free a sweep result structure */
+void dogecoin_sweep_result_free(dogecoin_sweep_result* result) {
+    if (!result) return;
+    
+    if (result->error_message) {
+        dogecoin_free(result->error_message);
+    }
+    if (result->transaction_hex) {
+        dogecoin_free(result->transaction_hex);
+    }
+    if (result->transaction_id) {
+        dogecoin_free(result->transaction_id);
+    }
+    if (result->destination_address) {
+        dogecoin_free(result->destination_address);
+    }
+    
+    dogecoin_free(result);
+}
+
+/* Initialize sweep options with defaults */
+dogecoin_sweep_options* dogecoin_sweep_options_new(const dogecoin_chainparams* chain_params) {
+    dogecoin_sweep_options* options = dogecoin_calloc(1, sizeof(dogecoin_sweep_options));
+    if (!options) return NULL;
+    
+    options->destination_address = NULL;
+    options->fee_per_byte = DOGECOIN_SWEEP_DEFAULT_FEE_PER_BYTE;
+    options->min_fee = DOGECOIN_SWEEP_DEFAULT_MIN_FEE;
+    options->max_fee = DOGECOIN_SWEEP_DEFAULT_MAX_FEE;
+    options->use_rbf = false;
+    options->locktime = 0;
+    options->chain_params = chain_params;
+    options->utxos = NULL;
+    options->utxo_count = 0;
+    options->utxo_txid = NULL;
+    options->utxo_vout = -1;
+    options->utxo_total_doge = NULL;
+    
+    return options;
+}
+
+/* Free sweep options */
+void dogecoin_sweep_options_free(dogecoin_sweep_options* options) {
+    if (!options) return;
+    
+    if (options->destination_address) {
+        dogecoin_free(options->destination_address);
+    }
+    sweep_options_clear_utxos(options);
+    if (options->utxo_txid) {
+        dogecoin_free(options->utxo_txid);
+    }
+    if (options->utxo_total_doge) {
+        dogecoin_free(options->utxo_total_doge);
+    }
+    
+    dogecoin_free(options);
+}
+
+/* Set paper wallet from WIF private key */
+dogecoin_bool dogecoin_paper_wallet_set_wif(
+    dogecoin_paper_wallet* wallet,
+    const char* wif_private_key,
+    const dogecoin_chainparams* chain_params
+) {
+    if (!wallet || !wif_private_key || !chain_params) return false;
+    
+    uint8_t private_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+    dogecoin_bool compressed = true;
+    if (!dogecoin_bip38_wif_to_private_key(wif_private_key, chain_params, private_key, &compressed)) {
+        return false;
+    }
+
+    dogecoin_pubkey pubkey;
+    if (!sweep_pubkey_from_privkey(private_key, compressed, &pubkey)) {
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        return false;
+    }
+
+    char address[P2PKHLEN];
+    if (!dogecoin_pubkey_getaddr_p2pkh(&pubkey, chain_params, address)) {
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        return false;
+    }
+    dogecoin_mem_zero(private_key, sizeof(private_key));
+    
+    /* Set wallet properties */
+    wallet->private_key_wif = dogecoin_calloc(1, strlen(wif_private_key) + 1);
+    if (!wallet->private_key_wif) return false;
+    strcpy(wallet->private_key_wif, wif_private_key);
+    
+    wallet->address = dogecoin_calloc(1, strlen(address) + 1);
+    if (!wallet->address) {
+        dogecoin_free(wallet->private_key_wif);
+        return false;
+    }
+    strcpy(wallet->address, address);
+    
+    wallet->compressed = compressed;
+    wallet->is_encrypted = false;
+    wallet->chain_params = chain_params;
+    
+    return true;
+}
+
+/* Set paper wallet from hex private key */
+dogecoin_bool dogecoin_paper_wallet_set_hex(
+    dogecoin_paper_wallet* wallet,
+    const char* hex_private_key,
+    const dogecoin_chainparams* chain_params
+) {
+    if (!wallet || !hex_private_key || !chain_params) return false;
+    
+    /* Convert hex to bytes */
+    uint8_t private_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+    size_t private_key_len;
+    utils_hex_to_bin(hex_private_key, private_key, strlen(hex_private_key), &private_key_len);
+    if (private_key_len != DOGECOIN_ECKEY_PKEY_LENGTH) {
+        return false;
+    }
+    
+    /* Create key from private key */
+    dogecoin_key key;
+    memcpy(key.privkey, private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
+    
+    /* Get address from private key */
+    dogecoin_pubkey pubkey;
+    dogecoin_pubkey_from_key(&key, &pubkey);
+    
+    char address[P2PKHLEN];
+    if (!dogecoin_pubkey_getaddr_p2pkh(&pubkey, chain_params, address)) {
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        dogecoin_privkey_cleanse(&key);
+        return false;
+    }
+
+    dogecoin_mem_zero(private_key, sizeof(private_key));
+    dogecoin_privkey_cleanse(&key);
+
+    /* Set wallet properties */
+    wallet->private_key_hex = dogecoin_calloc(1, strlen(hex_private_key) + 1);
+    if (!wallet->private_key_hex) return false;
+    strcpy(wallet->private_key_hex, hex_private_key);
+    
+    wallet->address = dogecoin_calloc(1, strlen(address) + 1);
+    if (!wallet->address) {
+        dogecoin_free(wallet->private_key_hex);
+        return false;
+    }
+    strcpy(wallet->address, address);
+    
+    wallet->compressed = true; /* Assume compressed for now */
+    wallet->is_encrypted = false;
+    wallet->chain_params = chain_params;
+    
+    return true;
+}
+
+/* Set paper wallet from BIP38 encrypted private key */
+dogecoin_bool dogecoin_paper_wallet_set_encrypted(
+    dogecoin_paper_wallet* wallet,
+    const char* encrypted_private_key,
+    const char* passphrase,
+    const dogecoin_chainparams* chain_params
+) {
+    if (!wallet || !encrypted_private_key || !passphrase || !chain_params) return false;
+    
+    /* Decrypt private key */
+    uint8_t private_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+    dogecoin_bool compressed;
+    if (!dogecoin_bip38_decrypt(encrypted_private_key, passphrase, private_key, &compressed)) {
+        return false;
+    }
+
+    dogecoin_pubkey pubkey;
+    if (!sweep_pubkey_from_privkey(private_key, compressed, &pubkey)) {
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        return false;
+    }
+
+    char address[P2PKHLEN];
+    if (!dogecoin_pubkey_getaddr_p2pkh(&pubkey, chain_params, address)) {
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        return false;
+    }
+
+    if (!dogecoin_bip38_verify_address_hash(encrypted_private_key, address)) {
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        return false;
+    }
+
+    /* Set wallet properties */
+    wallet->encrypted_private_key = dogecoin_calloc(1, strlen(encrypted_private_key) + 1);
+    if (!wallet->encrypted_private_key) {
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        return false;
+    }
+    strcpy(wallet->encrypted_private_key, encrypted_private_key);
+
+    wallet->passphrase = dogecoin_calloc(1, strlen(passphrase) + 1);
+    if (!wallet->passphrase) {
+        sweep_secure_free(wallet->encrypted_private_key);
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        return false;
+    }
+    strcpy(wallet->passphrase, passphrase);
+
+    wallet->address = dogecoin_calloc(1, strlen(address) + 1);
+    if (!wallet->address) {
+        sweep_secure_free(wallet->encrypted_private_key);
+        sweep_secure_free(wallet->passphrase);
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        return false;
+    }
+    strcpy(wallet->address, address);
+    
+    wallet->compressed = compressed;
+    wallet->is_encrypted = true;
+    wallet->chain_params = chain_params;
+
+    dogecoin_mem_zero(private_key, sizeof(private_key));
+    return true;
+}
+
+/* Get the address from a paper wallet */
+dogecoin_bool dogecoin_paper_wallet_get_address(
+    const dogecoin_paper_wallet* wallet,
+    char* address_out,
+    size_t address_size
+) {
+    if (!wallet || !address_out || !wallet->address) return false;
+    
+    if (strlen(wallet->address) >= address_size) return false;
+    
+    strcpy(address_out, wallet->address);
+    return true;
+}
+
+/* Get the private key from a paper wallet */
+dogecoin_bool dogecoin_paper_wallet_get_private_key(
+    const dogecoin_paper_wallet* wallet,
+    uint8_t* private_key_out
+) {
+    if (!wallet || !private_key_out) return false;
+    
+    if (wallet->private_key_hex) {
+        /* Convert hex to bytes */
+        size_t private_key_len;
+        utils_hex_to_bin(wallet->private_key_hex, private_key_out, strlen(wallet->private_key_hex), &private_key_len);
+        return (private_key_len == DOGECOIN_ECKEY_PKEY_LENGTH);
+    } else if (wallet->encrypted_private_key && wallet->passphrase) {
+        /* Decrypt private key */
+        dogecoin_bool compressed;
+        return dogecoin_bip38_decrypt(wallet->encrypted_private_key, wallet->passphrase, private_key_out, &compressed);
+    } else if (wallet->private_key_wif) {
+        /* Decode WIF to get private key */
+        dogecoin_key key;
+        if (!dogecoin_privkey_decode_wif(wallet->private_key_wif, wallet->chain_params, &key)) {
+            return false;
+        }
+        memcpy(private_key_out, key.privkey, DOGECOIN_ECKEY_PKEY_LENGTH);
+        dogecoin_privkey_cleanse(&key);
+        return true;
+    }
+
+    return false;
+}
+
+/* Get the WIF private key from a paper wallet */
+dogecoin_bool dogecoin_paper_wallet_get_wif(
+    const dogecoin_paper_wallet* wallet,
+    char* wif_out,
+    size_t wif_size
+) {
+    if (!wallet || !wif_out) return false;
+    
+    if (wallet->private_key_wif) {
+        if (strlen(wallet->private_key_wif) >= wif_size) return false;
+        strcpy(wif_out, wallet->private_key_wif);
+        return true;
+    }
+    
+    /* Convert from other formats */
+    uint8_t private_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+    if (!dogecoin_paper_wallet_get_private_key(wallet, private_key)) {
+        return false;
+    }
+    
+    size_t wif_len = wif_size;
+    if (!dogecoin_bip38_private_key_to_wif(
+            private_key,
+            wallet->chain_params,
+            wallet->compressed,
+            wif_out,
+            &wif_len)) {
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        return false;
+    }
+    dogecoin_mem_zero(private_key, sizeof(private_key));
+    return true;
+}
+
+/* Check if a paper wallet is valid */
+dogecoin_bool dogecoin_paper_wallet_is_valid(const dogecoin_paper_wallet* wallet) {
+    if (!wallet) return false;
+    
+    /* Check if we have at least one private key format */
+    if (!wallet->private_key_wif && !wallet->private_key_hex && !wallet->encrypted_private_key) {
+        return false;
+    }
+    
+    /* Check if we have an address */
+    if (!wallet->address) return false;
+    
+    /* Try to get private key to verify it's valid */
+    uint8_t private_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+    if (!dogecoin_paper_wallet_get_private_key(wallet, private_key)) {
+        return false;
+    }
+
+    dogecoin_mem_zero(private_key, sizeof(private_key));
+    return true;
+}
+
+/* Sweep a paper wallet to a destination address */
+dogecoin_sweep_result* dogecoin_sweep_paper_wallet(
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options
+) {
+  const dogecoin_paper_wallet* wallets[1];
+  if (!wallet) {
+    dogecoin_sweep_result* result = dogecoin_sweep_result_new();
+    if (result) {
+      sweep_result_fail(result, "Invalid wallet or options");
+    }
+    return result;
+  }
+  wallets[0] = wallet;
+  return sweep_wallets_impl(wallets, 1, options);
+}
+
+dogecoin_sweep_result* dogecoin_sweep_multiple_paper_wallets(
+    const dogecoin_paper_wallet* wallets,
+    size_t wallet_count,
+    const dogecoin_sweep_options* options
+) {
+    const dogecoin_paper_wallet** wptrs;
+    dogecoin_sweep_result* result;
+    size_t i;
+
+    if (!wallets || !options) {
+        result = dogecoin_sweep_result_new();
+        if (result) {
+            sweep_result_fail(result, "Invalid wallets or options");
+        }
+        return result;
+    }
+    if (wallet_count == 0) {
+        result = dogecoin_sweep_result_new();
+        if (result) {
+            sweep_result_fail(result, "No paper wallets specified");
+        }
+        return result;
+    }
+    if (wallet_count == 1) {
+        return dogecoin_sweep_paper_wallet(&wallets[0], options);
+    }
+
+    wptrs = (const dogecoin_paper_wallet**)dogecoin_calloc(wallet_count, sizeof(dogecoin_paper_wallet*));
+    if (!wptrs) {
+        result = dogecoin_sweep_result_new();
+        if (result) {
+            sweep_result_fail(result, "out of memory");
+        }
+        return result;
+    }
+    for (i = 0; i < wallet_count; i++) {
+        wptrs[i] = &wallets[i];
+    }
+    result = sweep_wallets_impl(wptrs, wallet_count, options);
+    dogecoin_free(wptrs);
+    return result;
+}
+
+uint64_t dogecoin_sweep_estimate_fee(
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options
+) {
+    (void)wallet;
+    if (!options) return 0;
+    size_t est_vsize = sweep_estimate_vsize(options->utxo_count ? options->utxo_count : 1);
+    uint64_t fee_koinu = options->fee_per_byte * est_vsize;
+    if (fee_koinu < options->min_fee) fee_koinu = options->min_fee;
+    if (fee_koinu > options->max_fee) fee_koinu = options->max_fee;
+    return fee_koinu;
+}
+
+dogecoin_bool dogecoin_sweep_get_balance(
+    const char* address,
+    const dogecoin_chainparams* chain_params,
+    uint64_t* balance_out
+) {
+    if (!address || !balance_out) {
+        return false;
+    }
+#ifdef WITH_WALLET
+    (void)chain_params;
+    *balance_out = dogecoin_get_balance((char*)address);
+    return true;
+#else
+    (void)chain_params;
+    *balance_out = 0;
+    return false;
+#endif
+}
+
+dogecoin_transaction* dogecoin_sweep_create_transaction(
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options
+) {
+    (void)wallet;
+    if (!options || !options->destination_address || !sweep_options_utxo_ok(options)) return NULL;
+
+    char fee_doge[64];
+    char out_doge[64];
+    uint64_t fee_koinu = 0;
+    uint64_t out_koinu = 0;
+    if (!sweep_compute_amounts(options, &fee_koinu, &out_koinu, fee_doge, out_doge)) return NULL;
+
+    int txindex = 0;
+    if (!sweep_build_unsigned_tx(options, fee_doge, out_doge, &txindex)) return NULL;
+
+    char* hexbuf = sweep_tx_hex_alloc();
+    if (!hexbuf) {
+        clear_transaction(txindex);
+        return NULL;
+    }
+    int hexlen = get_raw_transaction_ex(txindex, hexbuf, SWEEP_TX_HEX_BUF_SIZE);
+    if (hexlen <= 0) {
+        clear_transaction(txindex);
+        dogecoin_free(hexbuf);
+        return NULL;
+    }
+
+    dogecoin_tx* tx = dogecoin_tx_new();
+    if (!tx) {
+        clear_transaction(txindex);
+        dogecoin_free(hexbuf);
+        return NULL;
+    }
+    uint8_t* bindata = dogecoin_malloc((size_t)hexlen / 2 + 1);
+    if (!bindata) {
+        dogecoin_tx_free(tx);
+        clear_transaction(txindex);
+        dogecoin_free(hexbuf);
+        return NULL;
+    }
+    size_t binlen = 0;
+    utils_hex_to_bin(hexbuf, bindata, (size_t)hexlen, &binlen);
+    dogecoin_free(hexbuf);
+    if (!dogecoin_tx_deserialize(bindata, binlen, tx, NULL)) {
+        dogecoin_free(bindata);
+        dogecoin_tx_free(tx);
+        clear_transaction(txindex);
+        return NULL;
+    }
+    dogecoin_free(bindata);
+    clear_transaction(txindex);
+    return tx;
+}
+
+dogecoin_bool dogecoin_sweep_sign_transaction(
+    dogecoin_transaction* transaction,
+    const dogecoin_paper_wallet* wallet
+) {
+    if (!transaction || !wallet || !dogecoin_paper_wallet_is_valid(wallet)) return false;
+
+    remove_all();
+
+    cstring* ser = cstr_new_sz(1024);
+    if (!ser) return false;
+    dogecoin_tx_serialize(ser, transaction);
+    char* hex = dogecoin_malloc(ser->len * 2 + 1);
+    if (!hex) {
+        cstr_free(ser, true);
+        return false;
+    }
+    utils_bin_to_hex((unsigned char*)ser->str, ser->len, hex);
+    cstr_free(ser, true);
+
+    int txidx = store_raw_transaction(hex);
+    dogecoin_free(hex);
+    if (txidx <= 0) return false;
+
+    char* signedbuf = sweep_tx_hex_alloc();
+    if (!signedbuf) {
+        clear_transaction(txidx);
+        return false;
+    }
+    {
+        const dogecoin_paper_wallet* wallets[1];
+        wallets[0] = wallet;
+        if (!sweep_sign_txindex(txidx, wallets, 1, signedbuf, SWEEP_TX_HEX_BUF_SIZE)) {
+            clear_transaction(txidx);
+            dogecoin_free(signedbuf);
+            return false;
+        }
+    }
+    uint8_t* bindata = dogecoin_malloc(strlen(signedbuf) / 2 + 1);
+    if (!bindata) {
+        clear_transaction(txidx);
+        dogecoin_free(signedbuf);
+        return false;
+    }
+    size_t binlen = 0;
+    utils_hex_to_bin(signedbuf, bindata, strlen(signedbuf), &binlen);
+    dogecoin_free(signedbuf);
+    dogecoin_tx* signed_tx = dogecoin_tx_new();
+    if (!signed_tx) {
+        dogecoin_free(bindata);
+        clear_transaction(txidx);
+        return false;
+    }
+    if (!dogecoin_tx_deserialize(bindata, binlen, signed_tx, NULL)) {
+        dogecoin_free(bindata);
+        dogecoin_tx_free(signed_tx);
+        clear_transaction(txidx);
+        return false;
+    }
+    dogecoin_free(bindata);
+    dogecoin_tx_copy(transaction, signed_tx);
+    dogecoin_tx_free(signed_tx);
+    clear_transaction(txidx);
+    return true;
+}
+
+dogecoin_bool dogecoin_sweep_broadcast_transaction(
+    const dogecoin_transaction* transaction,
+    const dogecoin_chainparams* chain_params,
+    char* transaction_id_out,
+    size_t transaction_id_size
+) {
+    if (!transaction || !chain_params) {
+        return false;
+    }
+#ifdef WITH_NET
+    dogecoin_bool ok = broadcast_tx(chain_params, (dogecoin_tx*)transaction, NULL, 10, 15, false);
+    if (ok && transaction_id_out && transaction_id_size >= 65) {
+        uint256_t txhash;
+        dogecoin_tx_hash((dogecoin_tx*)transaction, txhash);
+        utils_bin_to_hex((unsigned char*)txhash, sizeof(txhash), transaction_id_out);
+        utils_reverse_hex(transaction_id_out, 64);
+        transaction_id_out[64] = '\0';
+    }
+    return ok;
+#else
+    (void)transaction_id_out;
+    (void)transaction_id_size;
+    return false;
+#endif
+}
+
+dogecoin_bool dogecoin_sweep_validate_transaction(
+    const dogecoin_transaction* transaction,
+    const dogecoin_paper_wallet* wallet,
+    const dogecoin_sweep_options* options
+) {
+    size_t i;
+    dogecoin_bool dest_found;
+    int is_mainnet;
+    uint64_t outsum;
+    uint64_t fee_koinu;
+    uint64_t out_koinu;
+    char fee_doge[64];
+    char out_doge[64];
+
+    if (!transaction || !wallet || !options || !options->destination_address) {
+        return false;
+    }
+    if (!dogecoin_paper_wallet_is_valid(wallet)) {
+        return false;
+    }
+
+    for (i = 0; i < transaction->vin->len; i++) {
+        dogecoin_tx_in* vin = vector_idx(transaction->vin, i);
+        if (!vin->script_sig || vin->script_sig->len == 0) {
+            return false;
+        }
+    }
+
+    if (sweep_options_utxo_ok(options) && transaction->vin->len != options->utxo_count) {
+        return false;
+    }
+
+    is_mainnet = (options->destination_address[0] == 'D');
+    dest_found = false;
+    for (i = 0; i < transaction->vout->len; i++) {
+        dogecoin_tx_out* o = vector_idx(transaction->vout, i);
+        char addr[P2PKHLEN];
+        dogecoin_mem_zero(addr, sizeof(addr));
+        if (dogecoin_tx_out_pubkey_hash_to_p2pkh_address(o, addr, is_mainnet) &&
+            strcmp(addr, options->destination_address) == 0) {
+            dest_found = true;
+            break;
+        }
+    }
+    if (!dest_found) {
+        return false;
+    }
+
+    if (sweep_options_utxo_ok(options)) {
+        if (!sweep_compute_amounts(options, &fee_koinu, &out_koinu, fee_doge, out_doge)) {
+            return false;
+        }
+        outsum = 0;
+        for (i = 0; i < transaction->vout->len; i++) {
+            dogecoin_tx_out* o = vector_idx(transaction->vout, i);
+            outsum += (uint64_t)o->value;
+        }
+        if (outsum != out_koinu) {
+            return false;
+        }
+    }
+
+    if (options->use_rbf) {
+        for (i = 0; i < transaction->vin->len; i++) {
+            dogecoin_tx_in* vin = vector_idx(transaction->vin, i);
+            if (vin->sequence != 0xfffffffd) {
+                return false;
+            }
+        }
+    }
+
+    if (options->locktime && transaction->locktime != options->locktime) {
+        return false;
+    }
+
+    return true;
+}
+
+dogecoin_bool dogecoin_sweep_get_stats(
+    const dogecoin_transaction* transaction,
+    const dogecoin_sweep_options* options,
+    uint64_t* input_count_out,
+    uint64_t* output_count_out,
+    uint64_t* total_input_value_out,
+    uint64_t* total_output_value_out,
+    uint64_t* fee_out
+) {
+    uint64_t insum = 0;
+    uint64_t outsum = 0;
+    size_t i;
+
+    if (!transaction) {
+        return false;
+    }
+    if (options && sweep_options_utxo_ok(options)) {
+        insum = sweep_options_total_koinu(options);
+    }
+    for (i = 0; i < transaction->vout->len; i++) {
+        dogecoin_tx_out* o = vector_idx(transaction->vout, i);
+        outsum += (uint64_t)o->value;
+    }
+    if (input_count_out) {
+        *input_count_out = transaction->vin->len;
+    }
+    if (output_count_out) {
+        *output_count_out = transaction->vout->len;
+    }
+    if (total_input_value_out) {
+        *total_input_value_out = insum;
+    }
+    if (total_output_value_out) {
+        *total_output_value_out = outsum;
+    }
+    if (fee_out) {
+        *fee_out = (insum > 0 && outsum <= insum) ? insum - outsum : 0;
+    }
+    return true;
+}
+
+/* Setter functions */
+dogecoin_bool dogecoin_sweep_options_set_destination(
+    dogecoin_sweep_options* options,
+    const char* destination_address
+) {
+    if (!options || !destination_address) return false;
+    
+    if (options->destination_address) {
+        dogecoin_free(options->destination_address);
+    }
+    
+    options->destination_address = dogecoin_calloc(1, strlen(destination_address) + 1);
+    if (!options->destination_address) return false;
+    
+    strcpy(options->destination_address, destination_address);
+    return true;
+}
+
+dogecoin_bool dogecoin_sweep_options_set_fee(
+    dogecoin_sweep_options* options,
+    uint64_t fee_per_byte,
+    uint64_t min_fee,
+    uint64_t max_fee
+) {
+    if (!options) return false;
+    
+    options->fee_per_byte = fee_per_byte;
+    options->min_fee = min_fee;
+    options->max_fee = max_fee;
+    
+    return true;
+}
+
+void dogecoin_sweep_options_set_rbf(
+    dogecoin_sweep_options* options,
+    dogecoin_bool use_rbf
+) {
+    if (options) {
+        options->use_rbf = use_rbf;
+    }
+}
+
+void dogecoin_sweep_options_set_locktime(
+    dogecoin_sweep_options* options,
+    uint32_t locktime
+) {
+    if (options) {
+        options->locktime = locktime;
+    }
+}
+
+static dogecoin_bool sweep_options_append_utxo(
+    dogecoin_sweep_options* options,
+    const char* txid_hex,
+    int vout,
+    const char* amount_doge)
+{
+    dogecoin_sweep_utxo* grown;
+    dogecoin_sweep_utxo* entry;
+
+    if (!options || !txid_hex || !amount_doge || vout < 0) {
+        return false;
+    }
+
+    grown = (dogecoin_sweep_utxo*)dogecoin_realloc(
+        options->utxos, (options->utxo_count + 1) * sizeof(dogecoin_sweep_utxo));
+    if (!grown) {
+        return false;
+    }
+    options->utxos = grown;
+    entry = &options->utxos[options->utxo_count];
+    memset(entry, 0, sizeof(*entry));
+    entry->txid = dogecoin_calloc(1, strlen(txid_hex) + 1);
+    entry->amount_doge = dogecoin_calloc(1, strlen(amount_doge) + 1);
+    if (!entry->txid || !entry->amount_doge) {
+        if (entry->txid) {
+            dogecoin_free(entry->txid);
+        }
+        if (entry->amount_doge) {
+            dogecoin_free(entry->amount_doge);
+        }
+        return false;
+    }
+    strcpy(entry->txid, txid_hex);
+    strcpy(entry->amount_doge, amount_doge);
+    entry->vout = vout;
+    options->utxo_count++;
+    sweep_options_sync_legacy(options);
+    return true;
+}
+
+dogecoin_bool dogecoin_sweep_options_set_utxo(
+    dogecoin_sweep_options* options,
+    const char* txid_hex,
+    int vout,
+    const char* total_input_doge)
+{
+    if (!options || !txid_hex || !total_input_doge || vout < 0) {
+        return false;
+    }
+    sweep_options_clear_utxos(options);
+    return sweep_options_append_utxo(options, txid_hex, vout, total_input_doge);
+}
+
+dogecoin_bool dogecoin_sweep_options_add_utxo(
+    dogecoin_sweep_options* options,
+    const char* txid_hex,
+    int vout,
+    const char* amount_doge)
+{
+    return sweep_options_append_utxo(options, txid_hex, vout, amount_doge);
+}
+
+size_t dogecoin_sweep_options_utxo_count(const dogecoin_sweep_options* options)
+{
+    if (!options) {
+        return 0;
+    }
+    return options->utxo_count;
+}
+
+uint64_t dogecoin_sweep_fee_per_kb_to_per_byte(uint64_t fee_per_kb)
+{
+    return fee_per_kb / 1000;
+}
+
+/* Getter functions */
+const char* dogecoin_sweep_result_get_error(const dogecoin_sweep_result* result) {
+    return result ? result->error_message : NULL;
+}
+
+const char* dogecoin_sweep_result_get_transaction_hex(const dogecoin_sweep_result* result) {
+    return result ? result->transaction_hex : NULL;
+}
+
+const char* dogecoin_sweep_result_get_transaction_id(const dogecoin_sweep_result* result) {
+    return result ? result->transaction_id : NULL;
+}
+
+uint64_t dogecoin_sweep_result_get_amount_swept(const dogecoin_sweep_result* result) {
+    return result ? result->amount_swept : 0;
+}
+
+uint64_t dogecoin_sweep_result_get_fee_paid(const dogecoin_sweep_result* result) {
+    return result ? result->fee_paid : 0;
+}
+
+const char* dogecoin_sweep_result_get_destination_address(const dogecoin_sweep_result* result) {
+    return result ? result->destination_address : NULL;
+}

--- a/src/sweep.c
+++ b/src/sweep.c
@@ -71,6 +71,21 @@ static void sweep_secure_free(char* s)
     dogecoin_free(s);
 }
 
+static void sweep_paper_wallet_clear_sensitive(dogecoin_paper_wallet* wallet)
+{
+    if (!wallet) {
+        return;
+    }
+    sweep_secure_free(wallet->private_key_wif);
+    wallet->private_key_wif = NULL;
+    sweep_secure_free(wallet->private_key_hex);
+    wallet->private_key_hex = NULL;
+    sweep_secure_free(wallet->encrypted_private_key);
+    wallet->encrypted_private_key = NULL;
+    sweep_secure_free(wallet->passphrase);
+    wallet->passphrase = NULL;
+}
+
 static void sweep_result_fail(dogecoin_sweep_result* r, const char* msg)
 {
     if (!r || !msg) return;
@@ -519,10 +534,7 @@ dogecoin_paper_wallet* dogecoin_paper_wallet_new(void) {
 void dogecoin_paper_wallet_free(dogecoin_paper_wallet* wallet) {
     if (!wallet) return;
 
-    sweep_secure_free(wallet->private_key_wif);
-    sweep_secure_free(wallet->private_key_hex);
-    sweep_secure_free(wallet->encrypted_private_key);
-    sweep_secure_free(wallet->passphrase);
+    sweep_paper_wallet_clear_sensitive(wallet);
     sweep_secure_free(wallet->address);
 
     dogecoin_free(wallet);
@@ -610,6 +622,8 @@ dogecoin_bool dogecoin_paper_wallet_set_wif(
     const dogecoin_chainparams* chain_params
 ) {
     if (!wallet || !wif_private_key || !chain_params) return false;
+
+    sweep_paper_wallet_clear_sensitive(wallet);
     
     uint8_t private_key[DOGECOIN_ECKEY_PKEY_LENGTH];
     dogecoin_bool compressed = true;
@@ -637,7 +651,8 @@ dogecoin_bool dogecoin_paper_wallet_set_wif(
     
     wallet->address = dogecoin_calloc(1, strlen(address) + 1);
     if (!wallet->address) {
-        dogecoin_free(wallet->private_key_wif);
+        sweep_secure_free(wallet->private_key_wif);
+        wallet->private_key_wif = NULL;
         return false;
     }
     strcpy(wallet->address, address);
@@ -656,6 +671,8 @@ dogecoin_bool dogecoin_paper_wallet_set_hex(
     const dogecoin_chainparams* chain_params
 ) {
     if (!wallet || !hex_private_key || !chain_params) return false;
+
+    sweep_paper_wallet_clear_sensitive(wallet);
     
     /* Convert hex to bytes */
     uint8_t private_key[DOGECOIN_ECKEY_PKEY_LENGTH];
@@ -690,7 +707,8 @@ dogecoin_bool dogecoin_paper_wallet_set_hex(
     
     wallet->address = dogecoin_calloc(1, strlen(address) + 1);
     if (!wallet->address) {
-        dogecoin_free(wallet->private_key_hex);
+        sweep_secure_free(wallet->private_key_hex);
+        wallet->private_key_hex = NULL;
         return false;
     }
     strcpy(wallet->address, address);
@@ -710,11 +728,18 @@ dogecoin_bool dogecoin_paper_wallet_set_encrypted(
     const dogecoin_chainparams* chain_params
 ) {
     if (!wallet || !encrypted_private_key || !passphrase || !chain_params) return false;
+
+    sweep_paper_wallet_clear_sensitive(wallet);
     
-    /* Decrypt private key */
+    /* Decrypt private key (Dogecoin-mainnet BIP38 semantics). */
     uint8_t private_key[DOGECOIN_ECKEY_PKEY_LENGTH];
     dogecoin_bool compressed;
-    if (!dogecoin_bip38_decrypt(encrypted_private_key, passphrase, private_key, &compressed)) {
+    if (!dogecoin_bip38_decrypt_ex(
+            encrypted_private_key,
+            passphrase,
+            BIP38_ADDRESS_MATCH_MAINNET,
+            private_key,
+            &compressed)) {
         return false;
     }
 
@@ -1375,3 +1400,4 @@ uint64_t dogecoin_sweep_result_get_fee_paid(const dogecoin_sweep_result* result)
 const char* dogecoin_sweep_result_get_destination_address(const dogecoin_sweep_result* result) {
     return result ? result->destination_address : NULL;
 }
+

--- a/src/sweep.c
+++ b/src/sweep.c
@@ -669,6 +669,7 @@ dogecoin_bool dogecoin_paper_wallet_set_wif(
 dogecoin_bool dogecoin_paper_wallet_set_hex(
     dogecoin_paper_wallet* wallet,
     const char* hex_private_key,
+    dogecoin_bool compressed,
     const dogecoin_chainparams* chain_params
 ) {
     if (!wallet || !hex_private_key || !chain_params) return false;
@@ -683,23 +684,19 @@ dogecoin_bool dogecoin_paper_wallet_set_hex(
         return false;
     }
     
-    /* Create key from private key */
-    dogecoin_key key;
-    memcpy(key.privkey, private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    
-    /* Get address from private key */
     dogecoin_pubkey pubkey;
-    dogecoin_pubkey_from_key(&key, &pubkey);
+    if (!sweep_pubkey_from_privkey(private_key, compressed, &pubkey)) {
+        dogecoin_mem_zero(private_key, sizeof(private_key));
+        return false;
+    }
     
     char address[P2PKHLEN];
     if (!dogecoin_pubkey_getaddr_p2pkh(&pubkey, chain_params, address)) {
         dogecoin_mem_zero(private_key, sizeof(private_key));
-        dogecoin_privkey_cleanse(&key);
         return false;
     }
 
     dogecoin_mem_zero(private_key, sizeof(private_key));
-    dogecoin_privkey_cleanse(&key);
 
     /* Set wallet properties */
     wallet->private_key_hex = dogecoin_calloc(1, strlen(hex_private_key) + 1);
@@ -714,7 +711,7 @@ dogecoin_bool dogecoin_paper_wallet_set_hex(
     }
     strcpy(wallet->address, address);
     
-    wallet->compressed = true; /* Assume compressed for now */
+    wallet->compressed = compressed;
     wallet->is_encrypted = false;
     wallet->chain_params = chain_params;
     
@@ -827,6 +824,9 @@ dogecoin_bool dogecoin_paper_wallet_get_private_key(
     } else if (wallet->private_key_wif) {
         /* Decode WIF to get private key */
         dogecoin_key key;
+        if (!wallet->chain_params) {
+            return false;
+        }
         if (!dogecoin_privkey_decode_wif(wallet->private_key_wif, wallet->chain_params, &key)) {
             return false;
         }
@@ -883,6 +883,10 @@ dogecoin_bool dogecoin_paper_wallet_is_valid(const dogecoin_paper_wallet* wallet
     
     /* Check if we have an address */
     if (!wallet->address) return false;
+
+    if (wallet->private_key_wif && !wallet->chain_params) {
+        return false;
+    }
     
     /* Try to get private key to verify it's valid */
     uint8_t private_key[DOGECOIN_ECKEY_PKEY_LENGTH];
@@ -1276,6 +1280,7 @@ dogecoin_bool dogecoin_sweep_options_set_fee(
     uint64_t max_fee
 ) {
     if (!options) return false;
+    if (min_fee > max_fee) return false;
     
     options->fee_per_byte = fee_per_byte;
     options->min_fee = min_fee;

--- a/src/sweep.c
+++ b/src/sweep.c
@@ -192,7 +192,9 @@ static dogecoin_bool sweep_compute_amounts(
     uint64_t* fee_koinu_out,
     uint64_t* out_koinu_out,
     char* fee_doge,
-    char* out_doge)
+    size_t fee_doge_size,
+    char* out_doge,
+    size_t out_doge_size)
 {
     uint64_t total_koinu = sweep_options_total_koinu(options);
     size_t est_vsize = sweep_estimate_vsize(options->utxo_count);
@@ -207,10 +209,10 @@ static dogecoin_bool sweep_compute_amounts(
         return false;
     }
     uint64_t out_koinu = total_koinu - fee_koinu;
-    if (!koinu_to_coins_str(fee_koinu, fee_doge)) {
+    if (!koinu_to_coins_str(fee_koinu, fee_doge, fee_doge_size)) {
         return false;
     }
-    if (!koinu_to_coins_str(out_koinu, out_doge)) {
+    if (!koinu_to_coins_str(out_koinu, out_doge, out_doge_size)) {
         return false;
     }
     *fee_koinu_out = fee_koinu;
@@ -281,7 +283,7 @@ static dogecoin_bool sweep_build_unsigned_tx(
 
     strncpy(dest_copy, options->destination_address, sizeof(dest_copy) - 1);
     dest_copy[sizeof(dest_copy) - 1] = '\0';
-    if (!koinu_to_coins_str(sweep_options_total_koinu(options), total_copy)) {
+    if (!koinu_to_coins_str(sweep_options_total_koinu(options), total_copy, sizeof(total_copy))) {
         return false;
     }
 
@@ -477,7 +479,7 @@ static dogecoin_sweep_result* sweep_wallets_impl(
         sweep_result_fail(result, "Multi-wallet sweep requires one UTXO per wallet");
         return result;
     }
-    if (!sweep_compute_amounts(options, &fee_koinu, &out_koinu, fee_doge, out_doge)) {
+    if (!sweep_compute_amounts(options, &fee_koinu, &out_koinu, fee_doge, sizeof(fee_doge), out_doge, sizeof(out_doge))) {
         sweep_result_fail(result, "Fee exceeds input value or amount conversion failed");
         return result;
     }
@@ -1001,7 +1003,7 @@ dogecoin_transaction* dogecoin_sweep_create_transaction(
     char out_doge[64];
     uint64_t fee_koinu = 0;
     uint64_t out_koinu = 0;
-    if (!sweep_compute_amounts(options, &fee_koinu, &out_koinu, fee_doge, out_doge)) return NULL;
+    if (!sweep_compute_amounts(options, &fee_koinu, &out_koinu, fee_doge, sizeof(fee_doge), out_doge, sizeof(out_doge))) return NULL;
 
     int txindex = 0;
     if (!sweep_build_unsigned_tx(options, fee_doge, out_doge, &txindex)) return NULL;
@@ -1185,7 +1187,7 @@ dogecoin_bool dogecoin_sweep_validate_transaction(
     }
 
     if (sweep_options_utxo_ok(options)) {
-        if (!sweep_compute_amounts(options, &fee_koinu, &out_koinu, fee_doge, out_doge)) {
+        if (!sweep_compute_amounts(options, &fee_koinu, &out_koinu, fee_doge, sizeof(fee_doge), out_doge, sizeof(out_doge))) {
             return false;
         }
         outsum = 0;

--- a/src/sweep.c
+++ b/src/sweep.c
@@ -84,6 +84,8 @@ static void sweep_paper_wallet_clear_sensitive(dogecoin_paper_wallet* wallet)
     wallet->encrypted_private_key = NULL;
     sweep_secure_free(wallet->passphrase);
     wallet->passphrase = NULL;
+    sweep_secure_free(wallet->address);
+    wallet->address = NULL;
 }
 
 static void sweep_result_fail(dogecoin_sweep_result* r, const char* msg)
@@ -535,7 +537,6 @@ void dogecoin_paper_wallet_free(dogecoin_paper_wallet* wallet) {
     if (!wallet) return;
 
     sweep_paper_wallet_clear_sensitive(wallet);
-    sweep_secure_free(wallet->address);
 
     dogecoin_free(wallet);
 }

--- a/src/tx.c
+++ b/src/tx.c
@@ -1256,7 +1256,7 @@ enum dogecoin_tx_sign_result dogecoin_tx_sign_input(dogecoin_tx* tx_in_out, cons
         memcpy_safe(sigcompact_out, sig, siglen);
     }
 
-    // form normalized DER signature & hashtype
+    // form normalized DER signature & hashtype (normalized DER is 69-72 bytes on secp256k1)
     unsigned char sigder_plus_hashtype[74 + 1];
     size_t sigderlen = sizeof(sigder_plus_hashtype) - 1; // capacity hint, reserving 1 byte for hashtype
     /* A low-S normalized secp256k1 DER signature is at most 72 bytes:

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -576,8 +576,8 @@ void print_utxos(dogecoin_wallet* wallet) {
     vector_free(addrs, true);
 
     if (HASH_COUNT(utxos) > 0) {
-        char wallet_total[21];
-        dogecoin_mem_zero(wallet_total, 21);
+        char wallet_total[KOINU_STRINGLEN];
+        dogecoin_mem_zero(wallet_total, sizeof(wallet_total));
         uint64_t wallet_total_u64 = 0;
         dogecoin_utxo* utxo;
         dogecoin_utxo* tmp;
@@ -596,9 +596,9 @@ void print_utxos(dogecoin_wallet* wallet) {
                 wallet_total_u64 += coins_to_koinu_str(utxo->amount);
             }
         }
-        koinu_to_coins_str(wallet_total_u64, wallet_total, 21);
+        koinu_to_coins_str(wallet_total_u64, wallet_total, sizeof(wallet_total));
         printf("Spent Balance: %s\n", wallet_total);
-        dogecoin_mem_zero(wallet_total, 21);
+        dogecoin_mem_zero(wallet_total, sizeof(wallet_total));
         wallet_total_u64 = 0;
         HASH_ITER(hh, utxos, utxo, tmp) {
             if (!is_spent(utxo)) {
@@ -615,7 +615,7 @@ void print_utxos(dogecoin_wallet* wallet) {
                 wallet_total_u64 += coins_to_koinu_str(utxo->amount);
             }
         }
-        koinu_to_coins_str(wallet_total_u64, wallet_total, 21);
+        koinu_to_coins_str(wallet_total_u64, wallet_total, sizeof(wallet_total));
         printf("Unspent Balance: %s\n", wallet_total);
     }
 }
@@ -2002,8 +2002,8 @@ char* dogecoin_get_utxo_amount(char* address, unsigned int index) {
             i++;
         }
     }
-    char* amount = (char*)dogecoin_calloc(1, 21);
-    memcpy_safe(amount, utxo->amount, 21);
+    char* amount = (char*)dogecoin_calloc(1, KOINU_STRINGLEN);
+    memcpy_safe(amount, utxo->amount, KOINU_STRINGLEN);
     dogecoin_wallet_free(wallet);
     return amount;
 }
@@ -2027,8 +2027,8 @@ uint64_t dogecoin_get_balance(char* address) {
 
 char* dogecoin_get_balance_str(char* address) {
     if (!address) return false;
-    char* wallet_total = dogecoin_char_vla(21);
+    char* wallet_total = dogecoin_char_vla(KOINU_STRINGLEN);
     uint64_t wallet_total_u64 = dogecoin_get_balance(address);
-    koinu_to_coins_str(wallet_total_u64, wallet_total, 21);
+    koinu_to_coins_str(wallet_total_u64, wallet_total, KOINU_STRINGLEN);
     return wallet_total;
 }

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -596,7 +596,7 @@ void print_utxos(dogecoin_wallet* wallet) {
                 wallet_total_u64 += coins_to_koinu_str(utxo->amount);
             }
         }
-        koinu_to_coins_str(wallet_total_u64, wallet_total);
+        koinu_to_coins_str(wallet_total_u64, wallet_total, 21);
         printf("Spent Balance: %s\n", wallet_total);
         dogecoin_mem_zero(wallet_total, 21);
         wallet_total_u64 = 0;
@@ -615,7 +615,7 @@ void print_utxos(dogecoin_wallet* wallet) {
                 wallet_total_u64 += coins_to_koinu_str(utxo->amount);
             }
         }
-        koinu_to_coins_str(wallet_total_u64, wallet_total);
+        koinu_to_coins_str(wallet_total_u64, wallet_total, 21);
         printf("Unspent Balance: %s\n", wallet_total);
     }
 }
@@ -755,7 +755,7 @@ void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
                         // set utxo p2pkh address:
                         memcpy_safe(utxo->address, p2pkh_from_script_pubkey, P2PKHLEN);
                         // set amount of utxo:
-                        koinu_to_coins_str(tx_out->value, utxo->amount);
+                        koinu_to_coins_str(tx_out->value, utxo->amount, KOINU_STRINGLEN);
                         // set the height of the utxo:
                         utxo->height = wtx->height;
                         // finally add utxo to rbtree:
@@ -2029,6 +2029,6 @@ char* dogecoin_get_balance_str(char* address) {
     if (!address) return false;
     char* wallet_total = dogecoin_char_vla(21);
     uint64_t wallet_total_u64 = dogecoin_get_balance(address);
-    koinu_to_coins_str(wallet_total_u64, wallet_total);
+    koinu_to_coins_str(wallet_total_u64, wallet_total, 21);
     return wallet_total;
 }

--- a/test/koinu_tests.c
+++ b/test/koinu_tests.c
@@ -84,11 +84,11 @@ void test_koinu() {
     int i = 0;
     for (; i < 21; i++) {
         actual_answer = coins_to_koinu_str(coin_amounts[i]);
-        char* tmp[21];
-        dogecoin_mem_zero(tmp, 21);
-        koinu_to_coins_str(actual_answer, (char*)tmp);
+        char tmp[KOINU_COINS_STR_MAX_LEN];
+        dogecoin_mem_zero(tmp, sizeof(tmp));
+        koinu_to_coins_str(actual_answer, tmp, sizeof(tmp));
         debug_print("T%d\n\tcoin_amt: %s\n\texpected: %"PRIu64"\n\tactual:   %"PRIu64"\n\n", i, coin_amounts[i], exp_answers[i], actual_answer);
-        u_assert_str_eq((char*)tmp, exp_coin_amounts[i]);
+        u_assert_str_eq(tmp, exp_coin_amounts[i]);
         u_assert_uint32_eq(actual_answer, exp_answers[i]);
         debug_print("T%d\n\tcoin_amt: %s\n\texpected: %"PRIu64"\n\tactual:   %"PRIu64"\n\n", i, coin_amounts[i], exp_answers[i], actual_answer);
         diff = (exp_answers[i] - actual_answer);
@@ -167,10 +167,10 @@ void test_koinu() {
     for (i = 0; i < 42; i++) {
         debug_print("\n-----------------------------------\nT%d build: %s\n------------------------------------\n", i, get_build());
         actual_answer2 = coins_to_koinu_str(coin_amounts_str[i]);
-        char* coins1[21];
-        dogecoin_mem_zero(coins1, 21);
-        if (!koinu_to_coins_str(actual_answer2, (char*)coins1)) exit(EXIT_FAILURE);
-        u_assert_str_eq((char*)coins1, coin_amounts_expected[i]);
+        char coins1[KOINU_COINS_STR_MAX_LEN];
+        dogecoin_mem_zero(coins1, sizeof(coins1));
+        if (!koinu_to_coins_str(actual_answer2, coins1, sizeof(coins1))) exit(EXIT_FAILURE);
+        u_assert_str_eq(coins1, coin_amounts_expected[i]);
         diff = exp_answers2[i] - actual_answer2;
         u_assert_uint32_eq(actual_answer2, exp_answers2[i]);
         u_assert_int_eq((int)diff, 0);
@@ -296,10 +296,10 @@ void test_koinu() {
     for (i = 0; i < 35; i++) {
         debug_print("\n-----------------------------------\nT%d build: %s\n------------------------------------\n", i, get_build());
         actual_answer3 = coins_to_koinu_str(varlen_coin_amounts_str[i]);
-        char* coins2[21];
-        dogecoin_mem_zero(coins2, 21);
-        koinu_to_coins_str(actual_answer3, (char*)coins2);
-        u_assert_str_eq((char*)coins2, varlen_exp_coin_amounts_str[i]);
+        char coins2[KOINU_COINS_STR_MAX_LEN];
+        dogecoin_mem_zero(coins2, sizeof(coins2));
+        koinu_to_coins_str(actual_answer3, coins2, sizeof(coins2));
+        u_assert_str_eq(coins2, varlen_exp_coin_amounts_str[i]);
         diff = exp_answers3[i] - actual_answer3;
         u_assert_uint32_eq(actual_answer3, exp_answers3[i]);
         u_assert_int_eq((int)diff, 0);
@@ -315,13 +315,23 @@ void test_koinu() {
     for (i = 0; i < 3; i++) {
         debug_print("\n-----------------------------------\nT%d build: %s\n------------------------------------\n", i, get_build());
         actual_answer4 = coins_to_koinu_str(maxout_coin_amounts_str[i]);
-        char* coins3[21];
-        dogecoin_mem_zero(coins3, 21);
-        koinu_to_coins_str(actual_answer4, (char*)coins3);
-        u_assert_str_eq((char*)coins3, maxout_exp_coin_amounts_str[i]);
+        char coins3[KOINU_COINS_STR_MAX_LEN];
+        dogecoin_mem_zero(coins3, sizeof(coins3));
+        koinu_to_coins_str(actual_answer4, coins3, sizeof(coins3));
+        u_assert_str_eq(coins3, maxout_exp_coin_amounts_str[i]);
         diff = exp_answers4[i] - actual_answer4;
         u_assert_uint32_eq(actual_answer4, exp_answers4[i]);
         u_assert_int_eq((int)diff, 0);
         debug_print("\n\n\tcoin_amt: %s\n\texpected: %"PRIu64"\n\tactual:   %"PRIu64"\n\n", maxout_coin_amounts_str[i], exp_answers4[i], actual_answer4);
         }
+
+    {
+        char small_buf[10];
+        char ok_buf[KOINU_COINS_STR_MAX_LEN];
+        dogecoin_mem_zero(small_buf, sizeof(small_buf));
+        u_assert_int_eq(koinu_to_coins_str(1000ULL, small_buf, sizeof(small_buf)), 0);
+        dogecoin_mem_zero(ok_buf, sizeof(ok_buf));
+        u_assert_int_eq(koinu_to_coins_str(1000ULL, ok_buf, sizeof(ok_buf)), 1);
+        u_assert_str_eq(ok_buf, "0.00001000");
+    }
     }

--- a/test/sweep_tests.c
+++ b/test/sweep_tests.c
@@ -587,6 +587,84 @@ static void test_paper_wallet_private_key_extraction(void)
     printf("  Paper wallet private key extraction tests passed\n");
 }
 
+/* Re-set on one wallet object must not leak the prior address buffer. */
+static void test_paper_wallet_reuse(void)
+{
+    printf("Testing paper wallet set_* reuse...\n");
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    dogecoin_paper_wallet* wallet = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet);
+
+    dogecoin_key wkey;
+    dogecoin_privkey_init(&wkey);
+    u_assert_true(dogecoin_privkey_gen(&wkey));
+    char test_wif[PRIVKEYWIFLEN];
+    size_t wif_sz = sizeof(test_wif);
+    dogecoin_privkey_encode_wif(&wkey, chain, test_wif, &wif_sz);
+    dogecoin_privkey_cleanse(&wkey);
+
+    u_assert_true(dogecoin_paper_wallet_set_wif(wallet, test_wif, chain));
+    char addr1[P2PKHLEN];
+    u_assert_true(dogecoin_paper_wallet_get_address(wallet, addr1, sizeof(addr1)));
+
+    const char* test_hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    u_assert_true(dogecoin_paper_wallet_set_hex(wallet, test_hex, chain));
+    char addr2[P2PKHLEN];
+    u_assert_true(dogecoin_paper_wallet_get_address(wallet, addr2, sizeof(addr2)));
+    u_assert_true(strcmp(addr1, addr2) != 0);
+
+    uint8_t priv[DOGECOIN_ECKEY_PKEY_LENGTH];
+    u_assert_true(dogecoin_paper_wallet_get_private_key(wallet, priv));
+    char hex_out[65];
+    utils_bin_to_hex(priv, DOGECOIN_ECKEY_PKEY_LENGTH, hex_out);
+    u_assert_str_eq(test_hex, hex_out);
+    dogecoin_mem_zero(priv, sizeof(priv));
+
+    dogecoin_paper_wallet_free(wallet);
+    printf("  Paper wallet reuse tests passed\n");
+}
+
+static void test_bip38_confirm_interop_testnet(void)
+{
+    printf("Testing BIP38 INTEROP confirm (testnet address hash)...\n");
+
+    const char* passphrase = "interop_testnet_confirm";
+    char encrypted[BIP38_ENCRYPTED_KEY_LENGTH + 1];
+    size_t enc_sz = sizeof(encrypted);
+    char confirmation[BIP38_CONFIRMATION_CODE_MAXLEN];
+    size_t confirm_sz = sizeof(confirmation);
+    uint8_t gen_priv[DOGECOIN_ECKEY_PKEY_LENGTH];
+
+    u_assert_true(dogecoin_bip38_encrypt_ec_multiplied(
+        passphrase,
+        true,
+        false,
+        0,
+        0,
+        "nConfirmInteropHint",
+        gen_priv,
+        encrypted,
+        &enc_sz,
+        confirmation,
+        &confirm_sz));
+
+    char confirmed_address[P2PKHLEN];
+    u_assert_true(dogecoin_bip38_confirm_passphrase_ex(
+        passphrase,
+        confirmation,
+        BIP38_ADDRESS_MATCH_INTEROP,
+        confirmed_address,
+        sizeof(confirmed_address),
+        NULL,
+        NULL,
+        NULL));
+    u_assert_true(confirmed_address[0] == 'n' || confirmed_address[0] == 'm');
+
+    dogecoin_mem_zero(gen_priv, sizeof(gen_priv));
+    printf("  BIP38 INTEROP confirm testnet tests passed\n");
+}
+
 /* Test BIP38 validation */
 static void test_bip38_validation(void)
 {
@@ -610,6 +688,12 @@ static void test_bip38_validation(void)
         payload[2] = 0xFF;
         u_assert_true(dogecoin_base58_encode_check(payload, 39, bad, sizeof(bad)) != 0);
         u_assert_int_eq((int)dogecoin_bip38_is_valid(bad), 0);
+        {
+            uint8_t hash_out[4];
+            uint8_t flag_out = 0;
+            u_assert_int_eq((int)dogecoin_bip38_get_address_hash(bad, hash_out), 0);
+            u_assert_int_eq((int)dogecoin_bip38_get_flag_byte(bad, &flag_out), 0);
+        }
     }
 
     printf("  BIP38 validation tests passed\n");
@@ -935,6 +1019,7 @@ void test_sweep(void)
     test_sweep_options();
     test_sweep_result();
     test_paper_wallet_private_key_extraction();
+    test_paper_wallet_reuse();
     test_bip38_validation();
     test_bip38_negative_cases();
     test_bip38_reference_vectors();
@@ -942,6 +1027,7 @@ void test_sweep(void)
     test_bip38_ec_intermediate_encrypt_roundtrip();
     test_bip38_ec_lot_sequence_vectors();
     test_bip38_ec_lot_sequence_greek_vector();
+    test_bip38_confirm_interop_testnet();
     test_bip38_nfc_passphrase_vector();
     test_sweep_functionality();
     test_bip38_generate_and_sweep();

--- a/test/sweep_tests.c
+++ b/test/sweep_tests.c
@@ -1,0 +1,951 @@
+/*
+ * Copyright (c) 2024 The Dogecoin Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include <dogecoin/sweep.h>
+#include <dogecoin/bip38.h>
+#include <dogecoin/base58.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/key.h>
+#include <dogecoin/address.h>
+#include <dogecoin/utils.h>
+#include <dogecoin/mem.h>
+#include <dogecoin/constants.h>
+#include <dogecoin/ecc.h>
+#include <dogecoin/transaction.h>
+
+#include <test/utest.h>
+
+static void sweep_test_cleanup_transactions(void)
+{
+    remove_all();
+}
+
+typedef struct bip38_test_vector_ {
+    const char* passphrase;
+    const char* encrypted;
+    const char* wif;
+    const char* hex;
+    dogecoin_bool compressed;
+} bip38_test_vector;
+
+/* BIP-0038 non-EC vectors (algorithm check; private key bytes are valid on Dogecoin). */
+static const bip38_test_vector BIP38_NON_EC_VECTORS[] = {
+    {
+        "TestingOneTwoThree",
+        "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg",
+        "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
+        "CBF4B9F70470856BB4F40F80B87EDB90865997FFEE6DF315AB166D713AF433A5",
+        false
+    },
+    {
+        "Satoshi",
+        "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTePPX1dWByq",
+        "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5",
+        "09C2686880095B1A4C249EE3AC4EEA8A014F11E6F986D0B5025AC1F39AFBD9AE",
+        false
+    },
+    {
+        "TestingOneTwoThree",
+        "6PYNKZ1EAgYgmQfmNVamxyXVWHzK5s6DGhwP4J5o44cvXdoY7sRzhtpUeo",
+        "L44B5gGEpqEDRS9vVPz7QT35jcBG2r3CZwSwQ4fCewXAhAhqGVpP",
+        "CBF4B9F70470856BB4F40F80B87EDB90865997FFEE6DF315AB166D713AF433A5",
+        true
+    },
+    {
+        "Satoshi",
+        "6PYLtMnXvfG3oJde97zRyLYFZCYizPU5T3LwgdYJz1fRhh16bU7u6PPmY7",
+        "KwYgW8gcxj1JWJXhPSu4Fqwzfhp5Yfi42mdYmMa4XqK7NJxXUSK7",
+        "09C2686880095B1A4C249EE3AC4EEA8A014F11E6F986D0B5025AC1F39AFBD9AE",
+        true
+    }
+};
+
+/* BIP-0038 EC-multiplied vectors (algorithm check; privkey bytes are chain-agnostic). */
+static const bip38_test_vector BIP38_EC_VECTORS[] = {
+    {
+        "TestingOneTwoThree",
+        "6PfQu77ygVyJLZjfvMLyhLMQbYnu5uguoJJ4kMCLqWwPEdfpwANVS76gTX",
+        NULL,
+        "A43A940577F4E97F5C4D39EB14FF083A98187C64EA7C99EF7CE460833959A519",
+        false
+    },
+    {
+        "Satoshi",
+        "6PfLGnQs6VZnrNpmVKfjotbnQuaJK4KZoPFrAjx1JMJUa1Ft8gnf5WxfKd",
+        NULL,
+        "C2C8036DF268F498099350718C4A3EF3984D2BE84618C2650F5171DCC5EB660A",
+        false
+    }
+};
+
+/* Test official BIP38 vectors (non-EC multiplied). */
+static void test_bip38_reference_vectors(void)
+{
+    printf("Testing BIP38 reference vectors (non-EC multiplied)...\n");
+
+    size_t i;
+    for (i = 0; i < sizeof(BIP38_NON_EC_VECTORS) / sizeof(BIP38_NON_EC_VECTORS[0]); i++) {
+        const bip38_test_vector* v = &BIP38_NON_EC_VECTORS[i];
+        uint8_t expected_priv[DOGECOIN_ECKEY_PKEY_LENGTH];
+        size_t hexlen = strlen(v->hex);
+        size_t outl = sizeof(expected_priv);
+        utils_hex_to_bin(v->hex, expected_priv, hexlen, &outl);
+        u_assert_uint64_eq((uint64_t)outl, (uint64_t)DOGECOIN_ECKEY_PKEY_LENGTH);
+
+        u_assert_true(dogecoin_bip38_is_valid(v->encrypted));
+
+        uint8_t decrypted_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+        dogecoin_bool compressed = false;
+        dogecoin_bool ok = dogecoin_bip38_decrypt_ex(
+            v->encrypted, v->passphrase, BIP38_ADDRESS_MATCH_INTEROP, decrypted_key, &compressed);
+        u_assert_true(ok);
+        u_assert_int_eq((int)compressed, (int)v->compressed);
+        u_assert_mem_eq(decrypted_key, expected_priv, DOGECOIN_ECKEY_PKEY_LENGTH);
+    }
+
+    printf("  BIP38 reference vector tests passed\n");
+}
+
+static void test_bip38_ec_reference_vectors(void)
+{
+    printf("Testing BIP38 reference vectors (EC multiplied)...\n");
+
+    size_t i;
+    for (i = 0; i < sizeof(BIP38_EC_VECTORS) / sizeof(BIP38_EC_VECTORS[0]); i++) {
+        const bip38_test_vector* v = &BIP38_EC_VECTORS[i];
+        uint8_t expected_priv[DOGECOIN_ECKEY_PKEY_LENGTH];
+        size_t hexlen = strlen(v->hex);
+        size_t outl = sizeof(expected_priv);
+        utils_hex_to_bin(v->hex, expected_priv, hexlen, &outl);
+        u_assert_uint64_eq((uint64_t)outl, (uint64_t)DOGECOIN_ECKEY_PKEY_LENGTH);
+
+        u_assert_true(dogecoin_bip38_is_valid(v->encrypted));
+        u_assert_true(dogecoin_bip38_is_ec_multiplied(v->encrypted));
+
+        uint8_t decrypted_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+        dogecoin_bool compressed = false;
+        u_assert_true(dogecoin_bip38_decrypt_ex(
+            v->encrypted, v->passphrase, BIP38_ADDRESS_MATCH_INTEROP, decrypted_key, &compressed));
+        u_assert_int_eq((int)compressed, (int)v->compressed);
+        u_assert_mem_eq(decrypted_key, expected_priv, DOGECOIN_ECKEY_PKEY_LENGTH);
+    }
+
+    printf("  BIP38 EC reference vector tests passed\n");
+}
+
+static void test_bip38_ec_intermediate_encrypt_roundtrip(void)
+{
+    printf("Testing BIP38 EC intermediate + encrypt roundtrip...\n");
+
+    const char* passphrase = "TestingOneTwoThree";
+    const char* expected_intermediate =
+        "passphrasepxFy57B9v8HtUsszJYKReoNDV6VHjUSGt8EVJmux9n1J3Ltf1gRxyDGXqnf9qm";
+    uint8_t decoded[128];
+    uint8_t ownerentropy[8];
+    char intermediate[BIP38_INTERMEDIATE_CODE_MAXLEN];
+    char encrypted[BIP38_ENCRYPTED_KEY_LENGTH + 1];
+    size_t intermediate_sz;
+    size_t encrypted_sz;
+    size_t declen;
+
+    declen = dogecoin_base58_decode_check(expected_intermediate, decoded, sizeof(decoded));
+    u_assert_uint64_eq((uint64_t)declen, (uint64_t)(BIP38_INTERMEDIATE_PAYLOAD_LEN + 4));
+    memcpy(ownerentropy, decoded + 8, 8);
+
+    intermediate_sz = sizeof(intermediate);
+    u_assert_true(dogecoin_bip38_generate_intermediate_code(
+        passphrase, false, 0, 0, ownerentropy, intermediate, &intermediate_sz));
+    u_assert_str_eq(expected_intermediate, intermediate);
+    u_assert_true(dogecoin_bip38_is_intermediate_code(intermediate));
+
+    encrypted_sz = sizeof(encrypted);
+    u_assert_true(dogecoin_bip38_encrypt_from_intermediate(
+        intermediate, false, NULL, NULL, NULL, encrypted, &encrypted_sz, NULL, NULL));
+    u_assert_true(dogecoin_bip38_is_ec_multiplied(encrypted));
+
+    uint8_t priv[DOGECOIN_ECKEY_PKEY_LENGTH];
+    dogecoin_bool compressed = true;
+    u_assert_true(dogecoin_bip38_decrypt_ex(encrypted, passphrase, BIP38_ADDRESS_MATCH_INTEROP, priv, &compressed));
+    u_assert_int_eq((int)compressed, 0);
+    u_assert_true(dogecoin_ecc_verify_privatekey(priv));
+    dogecoin_mem_zero(priv, sizeof(priv));
+
+    printf("  BIP38 EC intermediate + encrypt roundtrip tests passed\n");
+}
+
+static void test_bip38_ec_lot_sequence_vectors(void)
+{
+    printf("Testing BIP38 EC lot/sequence vectors...\n");
+
+    const char* passphrase = "MOLON LABE";
+    const char* encrypted =
+        "6PgNBNNzDkKdhkT6uJntUXwwzQV8Rr2tZcbkDcuC9DZRsS6AtHts4Ypo1j";
+    const char* confirmation =
+        "cfrm38V8aXBn7JWA1ESmFMUn6erxeBGZGAxJPY4e36S9QWkzZKtaVqLNMgnifETYw7BPwWC9aPD";
+    const char* expected_hex =
+        "44EA95AFBF138356A05EA32110DFD627232D0F2991AD221187BE356F19FA8190";
+    const char* expected_address = "1Jscj8ALrYu2y9TD8NrpvDBugPedmbj4Yh";
+
+    uint8_t expected_priv[DOGECOIN_ECKEY_PKEY_LENGTH];
+    size_t hexlen = strlen(expected_hex);
+    size_t outl = sizeof(expected_priv);
+    utils_hex_to_bin(expected_hex, expected_priv, hexlen, &outl);
+
+    u_assert_true(dogecoin_bip38_is_valid(encrypted));
+    u_assert_true(dogecoin_bip38_is_ec_multiplied(encrypted));
+    u_assert_true(dogecoin_bip38_has_lot_sequence(encrypted));
+
+    uint8_t decrypted_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+    dogecoin_bool compressed = true;
+    uint32_t lot = 0;
+    uint32_t sequence = 0;
+    u_assert_true(dogecoin_bip38_decrypt_with_lot_sequence_ex(
+        encrypted, passphrase, BIP38_ADDRESS_MATCH_INTEROP,
+        decrypted_key, &compressed, &lot, &sequence));
+    u_assert_int_eq((int)compressed, 0);
+    u_assert_uint32_eq(lot, 263183U);
+    u_assert_uint32_eq(sequence, 1U);
+    u_assert_mem_eq(decrypted_key, expected_priv, DOGECOIN_ECKEY_PKEY_LENGTH);
+
+    char confirmed_address[P2PKHLEN];
+    dogecoin_bool confirm_compressed = true;
+    uint32_t confirm_lot = 0;
+    uint32_t confirm_seq = 0;
+    u_assert_true(dogecoin_bip38_confirm_passphrase_ex(
+        passphrase,
+        confirmation,
+        BIP38_ADDRESS_MATCH_INTEROP,
+        confirmed_address,
+        sizeof(confirmed_address),
+        &confirm_compressed,
+        &confirm_lot,
+        &confirm_seq));
+    u_assert_str_eq(expected_address, confirmed_address);
+    u_assert_int_eq((int)confirm_compressed, 0);
+    u_assert_uint32_eq(confirm_lot, 263183U);
+    u_assert_uint32_eq(confirm_seq, 1U);
+
+    char enc2[BIP38_ENCRYPTED_KEY_LENGTH + 1];
+    size_t enc2_sz = sizeof(enc2);
+    uint8_t gen_priv[DOGECOIN_ECKEY_PKEY_LENGTH];
+    u_assert_true(dogecoin_bip38_encrypt_ec_multiplied(
+        passphrase,
+        false,
+        true,
+        263183U,
+        1U,
+        expected_address,
+        gen_priv,
+        enc2,
+        &enc2_sz,
+        NULL,
+        NULL));
+    u_assert_true(dogecoin_bip38_decrypt_with_lot_sequence_ex(
+        enc2, passphrase, BIP38_ADDRESS_MATCH_INTEROP,
+        decrypted_key, &compressed, &lot, &sequence));
+
+    dogecoin_mem_zero(decrypted_key, sizeof(decrypted_key));
+    printf("  BIP38 EC lot/sequence vector tests passed\n");
+}
+
+static void test_bip38_ec_lot_sequence_greek_vector(void)
+{
+    printf("Testing BIP38 EC lot/sequence (Greek passphrase vector)...\n");
+
+    /* BIP-0038 test vector: Greek uppercase ΜΟΛΩΝ ΛΑΒΕ (UTF-8). */
+    const char* passphrase = "\xCE\x9C\xCE\x9F\xCE\x9B\xCE\xA9\xCE\x9D \xCE\x9B\xCE\x91\xCE\x92\xCE\x95";
+    const char* encrypted =
+        "6PgGWtx25kUg8QWvwuJAgorN6k9FbE25rv5dMRwu5SKMnfpfVe5mar2ngH";
+    const char* confirmation =
+        "cfrm38V8G4qq2ywYEFfWLD5Cc6msj9UwsG2Mj4Z6QdGJAFQpdatZLavkgRd1i4iBMdRngDqDs51";
+    const char* expected_hex =
+        "CA2759AA4ADB0F96C414F36ABEB8DB59342985BE9FA50FAAC228C8E7D90E3006";
+
+    uint8_t expected_priv[DOGECOIN_ECKEY_PKEY_LENGTH];
+    size_t hexlen = strlen(expected_hex);
+    size_t outl = sizeof(expected_priv);
+    utils_hex_to_bin(expected_hex, expected_priv, hexlen, &outl);
+
+    uint8_t decrypted_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+    dogecoin_bool compressed = true;
+    uint32_t lot = 0;
+    uint32_t sequence = 0;
+    u_assert_true(dogecoin_bip38_decrypt_with_lot_sequence_ex(
+        encrypted, passphrase, BIP38_ADDRESS_MATCH_INTEROP,
+        decrypted_key, &compressed, &lot, &sequence));
+    u_assert_int_eq((int)compressed, 0);
+    u_assert_uint32_eq(lot, 806938U);
+    u_assert_uint32_eq(sequence, 1U);
+    u_assert_mem_eq(decrypted_key, expected_priv, DOGECOIN_ECKEY_PKEY_LENGTH);
+
+    char confirmed_address[P2PKHLEN];
+    u_assert_true(dogecoin_bip38_confirm_passphrase_ex(
+        passphrase, confirmation, BIP38_ADDRESS_MATCH_INTEROP,
+        confirmed_address, sizeof(confirmed_address), NULL, &lot, &sequence));
+    u_assert_uint32_eq(lot, 806938U);
+    u_assert_uint32_eq(sequence, 1U);
+    u_assert_true(dogecoin_bip38_is_confirmation_code(confirmation));
+
+    dogecoin_mem_zero(decrypted_key, sizeof(decrypted_key));
+    printf("  BIP38 EC Greek lot/sequence vector tests passed\n");
+}
+
+static void test_bip38_nfc_passphrase_vector(void)
+{
+    printf("Testing BIP38 NFC passphrase vector...\n");
+
+    /* Decomposed UTF-8 input (includes embedded NUL); scrypt uses NFC per BIP-0038. */
+    static const uint8_t decomposed_passphrase[] = {
+        0xCF, 0x92, 0xCC, 0x81, 0x00, 0xF0, 0x90, 0x90, 0x80, 0xF0, 0x9F, 0x92, 0xA9
+    };
+    const char* encrypted = "6PRW5o9FLp4gJDDVqJQKJFTpMvdsSGJxMYHtHaQBF3ooa8mwD69bapcDQn";
+    const char* expected_address = "16ktGzmfrurhbhi6JGqsMWf7TyqK9HNAeF";
+
+    uint8_t decrypted_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+    dogecoin_bool compressed = true;
+    u_assert_true(dogecoin_bip38_decrypt_passphrase_ex(
+        encrypted,
+        decomposed_passphrase,
+        sizeof(decomposed_passphrase),
+        BIP38_ADDRESS_MATCH_INTEROP,
+        decrypted_key,
+        &compressed));
+    u_assert_int_eq((int)compressed, 0);
+    u_assert_true(dogecoin_bip38_verify_address_hash(encrypted, expected_address));
+
+    /* Roundtrip: encrypt_passphrase + decrypt_passphrase with same byte sequence. */
+    dogecoin_key nfc_key;
+    dogecoin_privkey_init(&nfc_key);
+    u_assert_true(dogecoin_privkey_gen(&nfc_key));
+    char nfc_addr[P2PKHLEN];
+    dogecoin_pubkey nfc_pub;
+    dogecoin_pubkey_init(&nfc_pub);
+    dogecoin_pubkey_from_key(&nfc_key, &nfc_pub);
+    u_assert_true(dogecoin_pubkey_getaddr_p2pkh(&nfc_pub, &dogecoin_chainparams_main, nfc_addr));
+
+    char enc_rt[BIP38_ENCRYPTED_KEY_LENGTH + 1];
+    size_t enc_rt_sz = sizeof(enc_rt);
+    u_assert_true(dogecoin_bip38_encrypt_passphrase(
+        nfc_key.privkey,
+        decomposed_passphrase,
+        sizeof(decomposed_passphrase),
+        nfc_addr,
+        true,
+        enc_rt,
+        &enc_rt_sz));
+    u_assert_true(dogecoin_bip38_decrypt_passphrase(
+        enc_rt, decomposed_passphrase, sizeof(decomposed_passphrase), decrypted_key, &compressed));
+    u_assert_true(compressed);
+    u_assert_mem_eq(nfc_key.privkey, decrypted_key, DOGECOIN_ECKEY_PKEY_LENGTH);
+
+    dogecoin_privkey_cleanse(&nfc_key);
+    dogecoin_pubkey_cleanse(&nfc_pub);
+    dogecoin_mem_zero(decrypted_key, sizeof(decrypted_key));
+    printf("  BIP38 NFC passphrase vector tests passed\n");
+}
+
+/* Test paper wallet creation and validation */
+static void test_paper_wallet_creation(void)
+{
+    printf("Testing paper wallet creation...\n");
+
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    dogecoin_paper_wallet* wallet1 = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet1);
+
+    dogecoin_key gen_wif_key;
+    dogecoin_privkey_init(&gen_wif_key);
+    u_assert_true(dogecoin_privkey_gen(&gen_wif_key));
+    char test_wif[PRIVKEYWIFLEN];
+    size_t wif_sz = sizeof(test_wif);
+    dogecoin_privkey_encode_wif(&gen_wif_key, chain, test_wif, &wif_sz);
+    dogecoin_privkey_cleanse(&gen_wif_key);
+
+    dogecoin_bool result = dogecoin_paper_wallet_set_wif(wallet1, test_wif, chain);
+    u_assert_true(result);
+
+    char address[P2PKHLEN];
+    result = dogecoin_paper_wallet_get_address(wallet1, address, sizeof(address));
+    u_assert_true(result);
+    printf("  WIF Address: %s\n", address);
+
+    u_assert_true(dogecoin_paper_wallet_is_valid(wallet1));
+
+    dogecoin_paper_wallet_free(wallet1);
+
+    dogecoin_paper_wallet* wallet2 = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet2);
+
+    const char* test_hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    result = dogecoin_paper_wallet_set_hex(wallet2, test_hex, chain);
+    u_assert_true(result);
+
+    result = dogecoin_paper_wallet_get_address(wallet2, address, sizeof(address));
+    u_assert_true(result);
+    printf("  Hex Address: %s\n", address);
+
+    u_assert_true(dogecoin_paper_wallet_is_valid(wallet2));
+
+    dogecoin_paper_wallet_free(wallet2);
+
+    sweep_test_cleanup_transactions();
+    printf("  Paper wallet creation tests passed\n");
+}
+
+/* Test BIP38 encryption/decryption */
+static void test_bip38_encryption(void)
+{
+    printf("Testing BIP38 encryption/decryption...\n");
+
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    dogecoin_key key;
+    dogecoin_privkey_gen(&key);
+
+    dogecoin_pubkey pubkey;
+    dogecoin_pubkey_from_key(&key, &pubkey);
+
+    char address[P2PKHLEN];
+    dogecoin_pubkey_getaddr_p2pkh(&pubkey, chain, address);
+    printf("  Test address: %s\n", address);
+
+    char encrypted_key[BIP38_ENCRYPTED_KEY_LENGTH + 1];
+    size_t encrypted_size = sizeof(encrypted_key);
+    const char* passphrase = "test_passphrase_123";
+
+    dogecoin_bool result = dogecoin_bip38_encrypt(
+        key.privkey,
+        passphrase,
+        address,
+        true,
+        encrypted_key,
+        &encrypted_size
+    );
+    u_assert_true(result);
+    printf("  Encrypted key: %s\n", encrypted_key);
+
+    result = dogecoin_bip38_is_valid(encrypted_key);
+    u_assert_true(result);
+
+    uint8_t decrypted_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+    dogecoin_bool compressed;
+    result = dogecoin_bip38_decrypt(encrypted_key, passphrase, decrypted_key, &compressed);
+    u_assert_true(result);
+    u_assert_true(compressed);
+
+    u_assert_mem_eq(key.privkey, decrypted_key, DOGECOIN_ECKEY_PKEY_LENGTH);
+
+    dogecoin_paper_wallet* wallet = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet);
+
+    result = dogecoin_paper_wallet_set_encrypted(wallet, encrypted_key, passphrase, chain);
+    u_assert_true(result);
+
+    char wallet_address[P2PKHLEN];
+    result = dogecoin_paper_wallet_get_address(wallet, wallet_address, sizeof(wallet_address));
+    u_assert_true(result);
+    u_assert_str_eq(address, wallet_address);
+
+    u_assert_true(dogecoin_paper_wallet_is_valid(wallet));
+
+    dogecoin_paper_wallet_free(wallet);
+
+    printf("  BIP38 encryption/decryption tests passed\n");
+}
+
+/* Test sweep options */
+static void test_sweep_options(void)
+{
+    printf("Testing sweep options...\n");
+
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    dogecoin_sweep_options* options = dogecoin_sweep_options_new(chain);
+    u_assert_not_null(options);
+
+    const char* dest_address = "D7Y55vD8nNtW7VnT9Xr6Qc4vB8hN3jK2mP";
+    dogecoin_bool result = dogecoin_sweep_options_set_destination(options, dest_address);
+    u_assert_true(result);
+    u_assert_str_eq(options->destination_address, dest_address);
+
+    result = dogecoin_sweep_options_set_fee(options, 2000, 1000, 5000);
+    u_assert_true(result);
+    u_assert_uint64_eq(options->fee_per_byte, 2000ULL);
+    u_assert_uint64_eq(options->min_fee, 1000ULL);
+    u_assert_uint64_eq(options->max_fee, 5000ULL);
+
+    dogecoin_sweep_options_set_rbf(options, true);
+    u_assert_true(options->use_rbf);
+
+    dogecoin_sweep_options_set_locktime(options, 1234567890);
+    u_assert_uint32_eq(options->locktime, 1234567890U);
+
+    dogecoin_sweep_options_free(options);
+
+    printf("  Sweep options tests passed\n");
+}
+
+/* Test sweep result */
+static void test_sweep_result(void)
+{
+    printf("Testing sweep result...\n");
+
+    dogecoin_sweep_result* result = dogecoin_sweep_result_new();
+    u_assert_not_null(result);
+
+    u_assert_int_eq((int)result->success, 0);
+    u_assert_is_null(result->error_message);
+    u_assert_is_null(result->transaction_hex);
+    u_assert_is_null(result->transaction_id);
+    u_assert_uint64_eq(result->amount_swept, 0ULL);
+    u_assert_uint64_eq(result->fee_paid, 0ULL);
+    u_assert_is_null(result->destination_address);
+
+    u_assert_is_null(dogecoin_sweep_result_get_error(result));
+    u_assert_is_null(dogecoin_sweep_result_get_transaction_hex(result));
+    u_assert_is_null(dogecoin_sweep_result_get_transaction_id(result));
+    u_assert_uint64_eq(dogecoin_sweep_result_get_amount_swept(result), 0ULL);
+    u_assert_uint64_eq(dogecoin_sweep_result_get_fee_paid(result), 0ULL);
+    u_assert_is_null(dogecoin_sweep_result_get_destination_address(result));
+
+    dogecoin_sweep_result_free(result);
+
+    printf("  Sweep result tests passed\n");
+}
+
+/* Test paper wallet private key extraction */
+static void test_paper_wallet_private_key_extraction(void)
+{
+    printf("Testing paper wallet private key extraction...\n");
+
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    dogecoin_paper_wallet* wallet1 = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet1);
+
+    dogecoin_key wkey;
+    dogecoin_privkey_init(&wkey);
+    u_assert_true(dogecoin_privkey_gen(&wkey));
+    char test_wif[PRIVKEYWIFLEN];
+    size_t wif_sz = sizeof(test_wif);
+    dogecoin_privkey_encode_wif(&wkey, chain, test_wif, &wif_sz);
+    dogecoin_privkey_cleanse(&wkey);
+
+    dogecoin_bool result = dogecoin_paper_wallet_set_wif(wallet1, test_wif, chain);
+    u_assert_true(result);
+
+    char extracted_wif[PRIVKEYWIFLEN];
+    result = dogecoin_paper_wallet_get_wif(wallet1, extracted_wif, sizeof(extracted_wif));
+    u_assert_true(result);
+    u_assert_str_eq(test_wif, extracted_wif);
+
+    uint8_t private_key[DOGECOIN_ECKEY_PKEY_LENGTH];
+    result = dogecoin_paper_wallet_get_private_key(wallet1, private_key);
+    u_assert_true(result);
+
+    dogecoin_paper_wallet_free(wallet1);
+
+    dogecoin_paper_wallet* wallet2 = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet2);
+
+    const char* test_hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    result = dogecoin_paper_wallet_set_hex(wallet2, test_hex, chain);
+    u_assert_true(result);
+
+    result = dogecoin_paper_wallet_get_private_key(wallet2, private_key);
+    u_assert_true(result);
+
+    char hex_out[65];
+    utils_bin_to_hex(private_key, DOGECOIN_ECKEY_PKEY_LENGTH, hex_out);
+    u_assert_str_eq(test_hex, hex_out);
+
+    dogecoin_paper_wallet_free(wallet2);
+
+    printf("  Paper wallet private key extraction tests passed\n");
+}
+
+/* Test BIP38 validation */
+static void test_bip38_validation(void)
+{
+    printf("Testing BIP38 validation...\n");
+
+    u_assert_int_eq((int)dogecoin_bip38_is_valid(NULL), 0);
+    u_assert_int_eq((int)dogecoin_bip38_is_valid(""), 0);
+    u_assert_int_eq((int)dogecoin_bip38_is_valid("invalid"), 0);
+    u_assert_int_eq((int)dogecoin_bip38_is_valid("1234567890123456789012345678901234567890123456789012345678901234567890"), 0);
+
+    u_assert_true(dogecoin_bip38_is_valid(
+        "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg"));
+
+    {
+        const char* valid = "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg";
+        /* decode_check requires data[] length >= strlen(base58); payload is 39 bytes + 4 checksum. */
+        uint8_t payload[128];
+        char bad[BIP38_ENCRYPTED_KEY_LENGTH + 1];
+        size_t declen = dogecoin_base58_decode_check(valid, payload, sizeof(payload));
+        u_assert_uint64_eq((uint64_t)declen, 39u + 4u);
+        payload[2] = 0xFF;
+        u_assert_true(dogecoin_base58_encode_check(payload, 39, bad, sizeof(bad)) != 0);
+        u_assert_int_eq((int)dogecoin_bip38_is_valid(bad), 0);
+    }
+
+    printf("  BIP38 validation tests passed\n");
+}
+
+static void test_bip38_negative_cases(void)
+{
+    printf("Testing BIP38 negative cases...\n");
+
+    /* Non-EC and EC keys reject a wrong passphrase via address-hash check. */
+    const char* non_ec_encrypted = BIP38_NON_EC_VECTORS[0].encrypted;
+    const char* ec_encrypted = BIP38_EC_VECTORS[0].encrypted;
+    uint8_t priv[DOGECOIN_ECKEY_PKEY_LENGTH];
+    dogecoin_bool compressed = false;
+
+    u_assert_int_eq(
+        (int)dogecoin_bip38_decrypt_ex(
+            non_ec_encrypted, "wrong passphrase", BIP38_ADDRESS_MATCH_INTEROP, priv, &compressed),
+        0);
+    u_assert_int_eq(
+        (int)dogecoin_bip38_decrypt_ex(
+            ec_encrypted, "wrong passphrase", BIP38_ADDRESS_MATCH_INTEROP, priv, &compressed),
+        0);
+
+    {
+        char addr[P2PKHLEN];
+        memset(addr, 0, sizeof(addr));
+        u_assert_int_eq(
+            (int)dogecoin_bip38_confirm_passphrase_ex(
+                "wrong passphrase",
+                "cfrm38V8aXBn7JWA1ESmFMUn6erxeBGZGAxJPY4e36S9QWkzZKtaVqLNMgnifETYw7BPwWC9aPD",
+                BIP38_ADDRESS_MATCH_INTEROP,
+                addr,
+                sizeof(addr),
+                NULL,
+                NULL,
+                NULL),
+            0);
+    }
+
+    {
+        uint32_t lot = 0;
+        uint32_t sequence = 0;
+        dogecoin_bip38_generate_lot_sequence(&lot, &sequence);
+        u_assert_true(lot >= 1 && lot <= 1048575U);
+        u_assert_true(sequence <= 4095U);
+    }
+
+    printf("  BIP38 negative tests passed\n");
+}
+
+/* Test sweep functionality (basic WIF + UTXO setup; signing is covered by transaction tests). */
+static void test_sweep_functionality(void)
+{
+    printf("Testing sweep functionality...\n");
+    sweep_test_cleanup_transactions();
+
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    dogecoin_paper_wallet* wallet = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet);
+
+    dogecoin_key sw_key;
+    dogecoin_privkey_init(&sw_key);
+    u_assert_true(dogecoin_privkey_gen(&sw_key));
+    char test_wif[PRIVKEYWIFLEN];
+    size_t wif_sz = sizeof(test_wif);
+    dogecoin_privkey_encode_wif(&sw_key, chain, test_wif, &wif_sz);
+    dogecoin_privkey_cleanse(&sw_key);
+
+    dogecoin_bool result = dogecoin_paper_wallet_set_wif(wallet, test_wif, chain);
+    u_assert_true(result);
+
+    dogecoin_sweep_options* options = dogecoin_sweep_options_new(chain);
+    u_assert_not_null(options);
+
+    const char* dest_address = "DHprgyNMcy3Ct9zVbJCrezYywxTBDWPL3v";
+    result = dogecoin_sweep_options_set_destination(options, dest_address);
+    u_assert_true(result);
+
+    result = dogecoin_sweep_options_set_utxo(
+        options,
+        "b4455e7b7b7acb51fb6feba7a2702c42a5100f61f61abafa31851ed6ae076074",
+        1,
+        "12.0");
+    u_assert_true(result);
+
+    /* Exercise the actual sweep pipeline: build -> sign -> validate. */
+    dogecoin_transaction* tx = dogecoin_sweep_create_transaction(wallet, options);
+    u_assert_not_null(tx);
+
+    u_assert_true(dogecoin_sweep_sign_transaction(tx, wallet));
+    u_assert_true(dogecoin_sweep_validate_transaction(tx, wallet, options));
+
+    uint64_t in_count = 0;
+    uint64_t out_count = 0;
+    uint64_t in_value = 0;
+    uint64_t out_value = 0;
+    uint64_t fee_value = 0;
+    u_assert_true(dogecoin_sweep_get_stats(
+        tx, options, &in_count, &out_count, &in_value, &out_value, &fee_value));
+    u_assert_uint64_eq(in_count, 1ULL);
+    u_assert_uint64_eq(out_count, 1ULL);
+    u_assert_uint64_eq(in_value, 1200000000ULL);
+    u_assert_true(fee_value > 0);
+    u_assert_uint64_eq(in_value, out_value + fee_value);
+    dogecoin_tx_free(tx);
+
+    sweep_test_cleanup_transactions();
+
+    dogecoin_sweep_result* sweep = dogecoin_sweep_paper_wallet(wallet, options);
+    u_assert_not_null(sweep);
+    u_assert_true(sweep->success);
+    u_assert_not_null(sweep->transaction_hex);
+    u_assert_not_null(sweep->transaction_id);
+    u_assert_true(strlen(sweep->transaction_hex) > 0);
+    u_assert_true(strlen(sweep->transaction_id) == 64);
+    dogecoin_sweep_result_free(sweep);
+
+    dogecoin_sweep_options_free(options);
+    dogecoin_paper_wallet_free(wallet);
+
+    sweep_test_cleanup_transactions();
+    printf("  Sweep functionality tests passed\n");
+}
+
+static void test_bip38_generate_and_sweep(void)
+{
+    printf("Testing BIP38 generate + sweep transaction build...\n");
+    sweep_test_cleanup_transactions();
+
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    dogecoin_key key;
+    dogecoin_privkey_init(&key);
+    dogecoin_privkey_gen(&key);
+
+    dogecoin_pubkey pubkey;
+    dogecoin_pubkey_init(&pubkey);
+    dogecoin_pubkey_from_key(&key, &pubkey);
+
+    char source_address[P2PKHLEN];
+    u_assert_true(dogecoin_pubkey_getaddr_p2pkh(&pubkey, chain, source_address));
+
+    const char* passphrase = "libdogecoin_bip38_sweep_gen_test";
+    char encrypted[BIP38_ENCRYPTED_KEY_LENGTH + 1];
+    size_t enc_sz = sizeof(encrypted);
+    u_assert_true(dogecoin_bip38_encrypt(key.privkey, passphrase, source_address, true,
+                                         encrypted, &enc_sz));
+    u_assert_true(dogecoin_bip38_is_valid(encrypted));
+
+    uint8_t roundtrip[DOGECOIN_ECKEY_PKEY_LENGTH];
+    dogecoin_bool compressed = false;
+    u_assert_true(dogecoin_bip38_decrypt(encrypted, passphrase, roundtrip, &compressed));
+    u_assert_true(compressed);
+    u_assert_mem_eq(key.privkey, roundtrip, DOGECOIN_ECKEY_PKEY_LENGTH);
+
+    dogecoin_paper_wallet* wallet = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet);
+    u_assert_true(dogecoin_paper_wallet_set_encrypted(wallet, encrypted, passphrase, chain));
+    u_assert_true(dogecoin_paper_wallet_is_valid(wallet));
+
+    dogecoin_sweep_options* options = dogecoin_sweep_options_new(chain);
+    u_assert_not_null(options);
+    u_assert_true(dogecoin_sweep_options_set_destination(options, "DHprgyNMcy3Ct9zVbJCrezYywxTBDWPL3v"));
+    u_assert_true(dogecoin_sweep_options_set_utxo(
+        options,
+        "b4455e7b7b7acb51fb6feba7a2702c42a5100f61f61abafa31851ed6ae076074",
+        1,
+        "12.0"));
+
+    char wif_check[PRIVKEYWIFLEN];
+    u_assert_true(dogecoin_paper_wallet_get_wif(wallet, wif_check, sizeof(wif_check)));
+
+    dogecoin_transaction* tx = dogecoin_sweep_create_transaction(wallet, options);
+    u_assert_not_null(tx);
+    u_assert_true(dogecoin_sweep_sign_transaction(tx, wallet));
+    u_assert_true(dogecoin_sweep_validate_transaction(tx, wallet, options));
+    dogecoin_tx_free(tx);
+    sweep_test_cleanup_transactions();
+
+    dogecoin_sweep_result* sweep = dogecoin_sweep_paper_wallet(wallet, options);
+    u_assert_not_null(sweep);
+    u_assert_true(sweep->success);
+    u_assert_not_null(sweep->transaction_hex);
+    u_assert_not_null(sweep->transaction_id);
+    u_assert_true(strlen(sweep->transaction_hex) > 0);
+    dogecoin_sweep_result_free(sweep);
+
+    dogecoin_sweep_options_free(options);
+    dogecoin_paper_wallet_free(wallet);
+    dogecoin_privkey_cleanse(&key);
+    dogecoin_pubkey_cleanse(&pubkey);
+
+    sweep_test_cleanup_transactions();
+    printf("  BIP38 generate + sweep tests passed (BIP38 + wallet + options)\n");
+}
+
+static void test_multi_utxo_sweep(void)
+{
+    printf("Testing multi-UTXO sweep (same key)...\n");
+    sweep_test_cleanup_transactions();
+
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    dogecoin_paper_wallet* wallet = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet);
+
+    dogecoin_key key;
+    dogecoin_privkey_init(&key);
+    u_assert_true(dogecoin_privkey_gen(&key));
+    char test_wif[PRIVKEYWIFLEN];
+    size_t wif_sz = sizeof(test_wif);
+    dogecoin_privkey_encode_wif(&key, chain, test_wif, &wif_sz);
+    dogecoin_privkey_cleanse(&key);
+
+    u_assert_true(dogecoin_paper_wallet_set_wif(wallet, test_wif, chain));
+
+    dogecoin_sweep_options* options = dogecoin_sweep_options_new(chain);
+    u_assert_not_null(options);
+    u_assert_true(dogecoin_sweep_options_set_destination(options, "DHprgyNMcy3Ct9zVbJCrezYywxTBDWPL3v"));
+    u_assert_uint64_eq(dogecoin_sweep_fee_per_kb_to_per_byte(1000000ULL), 1000ULL);
+    u_assert_true(dogecoin_sweep_options_set_fee(
+        options, dogecoin_sweep_fee_per_kb_to_per_byte(1000000ULL), 1000, 5000000));
+    u_assert_true(dogecoin_sweep_options_add_utxo(
+        options,
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        0,
+        "50.0"));
+    u_assert_true(dogecoin_sweep_options_add_utxo(
+        options,
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        1,
+        "50.0"));
+    u_assert_uint64_eq(dogecoin_sweep_options_utxo_count(options), 2ULL);
+
+    dogecoin_sweep_result* sweep = dogecoin_sweep_paper_wallet(wallet, options);
+    u_assert_not_null(sweep);
+    u_assert_true(sweep->success);
+    u_assert_not_null(sweep->transaction_hex);
+    u_assert_true(strlen(sweep->transaction_hex) > 0);
+    dogecoin_sweep_result_free(sweep);
+
+    dogecoin_sweep_options_free(options);
+    dogecoin_paper_wallet_free(wallet);
+
+    sweep_test_cleanup_transactions();
+    printf("  Multi-UTXO sweep tests passed\n");
+}
+
+/* Test error handling */
+static void test_rbf_locktime_sweep(void)
+{
+    printf("Testing RBF + locktime sweep...\n");
+    sweep_test_cleanup_transactions();
+
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    dogecoin_paper_wallet* wallet = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet);
+
+    dogecoin_key key;
+    dogecoin_privkey_init(&key);
+    u_assert_true(dogecoin_privkey_gen(&key));
+    char test_wif[PRIVKEYWIFLEN];
+    size_t wif_sz = sizeof(test_wif);
+    dogecoin_privkey_encode_wif(&key, chain, test_wif, &wif_sz);
+    dogecoin_privkey_cleanse(&key);
+
+    u_assert_true(dogecoin_paper_wallet_set_wif(wallet, test_wif, chain));
+
+    dogecoin_sweep_options* options = dogecoin_sweep_options_new(chain);
+    u_assert_not_null(options);
+    u_assert_true(dogecoin_sweep_options_set_destination(options, "DHprgyNMcy3Ct9zVbJCrezYywxTBDWPL3v"));
+    u_assert_true(dogecoin_sweep_options_set_fee(options, 1000, 1000, 5000000));
+    u_assert_true(dogecoin_sweep_options_set_utxo(
+        options,
+        "b4455e7b7b7acb51fb6feba7a2702c42a5100f61f61abafa31851ed6ae076074",
+        1,
+        "12.0"));
+    dogecoin_sweep_options_set_rbf(options, true);
+    dogecoin_sweep_options_set_locktime(options, 500000U);
+
+    dogecoin_transaction* tx = dogecoin_sweep_create_transaction(wallet, options);
+    u_assert_not_null(tx);
+    u_assert_uint32_eq(tx->locktime, 500000U);
+    u_assert_true(dogecoin_sweep_sign_transaction(tx, wallet));
+    u_assert_true(dogecoin_sweep_validate_transaction(tx, wallet, options));
+    dogecoin_tx_free(tx);
+
+    dogecoin_sweep_options_free(options);
+    dogecoin_paper_wallet_free(wallet);
+    sweep_test_cleanup_transactions();
+    printf("  RBF + locktime sweep tests passed\n");
+}
+
+static void test_sweep_error_handling(void)
+{
+    printf("Testing error handling...\n");
+
+    const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
+
+    u_assert_int_eq((int)dogecoin_paper_wallet_set_wif(NULL, "test", chain), 0);
+    u_assert_int_eq((int)dogecoin_paper_wallet_set_wif(dogecoin_paper_wallet_new(), NULL, chain), 0);
+    u_assert_int_eq((int)dogecoin_paper_wallet_set_wif(dogecoin_paper_wallet_new(), "test", NULL), 0);
+
+    dogecoin_paper_wallet* wallet = dogecoin_paper_wallet_new();
+    u_assert_not_null(wallet);
+
+    u_assert_int_eq((int)dogecoin_paper_wallet_set_wif(wallet, "invalid_wif", chain), 0);
+    u_assert_int_eq((int)dogecoin_paper_wallet_is_valid(wallet), 0);
+
+    dogecoin_paper_wallet_free(wallet);
+
+    printf("  Error handling tests passed\n");
+}
+
+void test_sweep(void)
+{
+    sweep_test_cleanup_transactions();
+    test_paper_wallet_creation();
+    test_bip38_encryption();
+    test_sweep_options();
+    test_sweep_result();
+    test_paper_wallet_private_key_extraction();
+    test_bip38_validation();
+    test_bip38_negative_cases();
+    test_bip38_reference_vectors();
+    test_bip38_ec_reference_vectors();
+    test_bip38_ec_intermediate_encrypt_roundtrip();
+    test_bip38_ec_lot_sequence_vectors();
+    test_bip38_ec_lot_sequence_greek_vector();
+    test_bip38_nfc_passphrase_vector();
+    test_sweep_functionality();
+    test_bip38_generate_and_sweep();
+    test_multi_utxo_sweep();
+    test_rbf_locktime_sweep();
+    test_sweep_error_handling();
+}

--- a/test/sweep_tests.c
+++ b/test/sweep_tests.c
@@ -182,7 +182,7 @@ static void test_bip38_ec_intermediate_encrypt_roundtrip(void)
 
     encrypted_sz = sizeof(encrypted);
     u_assert_true(dogecoin_bip38_encrypt_from_intermediate(
-        intermediate, false, NULL, NULL, NULL, encrypted, &encrypted_sz, NULL, NULL));
+        intermediate, false, NULL, NULL, encrypted, &encrypted_sz, NULL, NULL));
     u_assert_true(dogecoin_bip38_is_ec_multiplied(encrypted));
 
     uint8_t priv[DOGECOIN_ECKEY_PKEY_LENGTH];
@@ -400,8 +400,19 @@ static void test_paper_wallet_creation(void)
     u_assert_not_null(wallet2);
 
     const char* test_hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    result = dogecoin_paper_wallet_set_hex(wallet2, test_hex, chain);
+    result = dogecoin_paper_wallet_set_hex(wallet2, test_hex, true, chain);
     u_assert_true(result);
+
+    char compressed_addr[P2PKHLEN];
+    result = dogecoin_paper_wallet_get_address(wallet2, compressed_addr, sizeof(compressed_addr));
+    u_assert_true(result);
+
+    dogecoin_paper_wallet* wallet3 = dogecoin_paper_wallet_new();
+    u_assert_true(dogecoin_paper_wallet_set_hex(wallet3, test_hex, false, chain));
+    char uncompressed_addr[P2PKHLEN];
+    u_assert_true(dogecoin_paper_wallet_get_address(wallet3, uncompressed_addr, sizeof(uncompressed_addr)));
+    u_assert_str_not_eq(compressed_addr, uncompressed_addr);
+    dogecoin_paper_wallet_free(wallet3);
 
     result = dogecoin_paper_wallet_get_address(wallet2, address, sizeof(address));
     u_assert_true(result);
@@ -497,6 +508,8 @@ static void test_sweep_options(void)
     u_assert_uint64_eq(options->min_fee, 1000ULL);
     u_assert_uint64_eq(options->max_fee, 5000ULL);
 
+    u_assert_int_eq((int)dogecoin_sweep_options_set_fee(options, 1000, 5000, 1000), 0);
+
     dogecoin_sweep_options_set_rbf(options, true);
     u_assert_true(options->use_rbf);
 
@@ -572,7 +585,7 @@ static void test_paper_wallet_private_key_extraction(void)
     u_assert_not_null(wallet2);
 
     const char* test_hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    result = dogecoin_paper_wallet_set_hex(wallet2, test_hex, chain);
+    result = dogecoin_paper_wallet_set_hex(wallet2, test_hex, true, chain);
     u_assert_true(result);
 
     result = dogecoin_paper_wallet_get_private_key(wallet2, private_key);
@@ -609,7 +622,7 @@ static void test_paper_wallet_reuse(void)
     u_assert_true(dogecoin_paper_wallet_get_address(wallet, addr1, sizeof(addr1)));
 
     const char* test_hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    u_assert_true(dogecoin_paper_wallet_set_hex(wallet, test_hex, chain));
+    u_assert_true(dogecoin_paper_wallet_set_hex(wallet, test_hex, true, chain));
     char addr2[P2PKHLEN];
     u_assert_true(dogecoin_paper_wallet_get_address(wallet, addr2, sizeof(addr2)));
     u_assert_true(strcmp(addr1, addr2) != 0);
@@ -1005,6 +1018,19 @@ static void test_sweep_error_handling(void)
 
     u_assert_int_eq((int)dogecoin_paper_wallet_set_wif(wallet, "invalid_wif", chain), 0);
     u_assert_int_eq((int)dogecoin_paper_wallet_is_valid(wallet), 0);
+
+    {
+        const char* wif_stub = "6Kxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+        const char* addr_stub = "D7Y55vD8nNtW7VnT9Xr6Qc4vB8hN3jK2mP";
+        wallet->private_key_wif = dogecoin_calloc(1, strlen(wif_stub) + 1);
+        wallet->address = dogecoin_calloc(1, strlen(addr_stub) + 1);
+        u_assert_not_null(wallet->private_key_wif);
+        u_assert_not_null(wallet->address);
+        strcpy(wallet->private_key_wif, wif_stub);
+        strcpy(wallet->address, addr_stub);
+        wallet->chain_params = NULL;
+        u_assert_int_eq((int)dogecoin_paper_wallet_is_valid(wallet), 0);
+    }
 
     dogecoin_paper_wallet_free(wallet);
 

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -108,10 +108,10 @@ void test_transaction()
     //     {
     //       "value": 5885.98644000,
             dogecoin_tx_out* tx_out = vector_idx(tx_worth_2->vout, 0);
-            char* dogecoin[21];
-            dogecoin_mem_zero(dogecoin, 21);
-            koinu_to_coins_str(tx_out->value, (char*)dogecoin);
-            u_assert_str_eq((char*)dogecoin, "5885.98644000");
+            char dogecoin[21];
+            dogecoin_mem_zero(dogecoin, sizeof(dogecoin));
+            koinu_to_coins_str(tx_out->value, dogecoin);
+            u_assert_str_eq(dogecoin, "5885.98644000");
     //       "n": 0,
     //       "scriptPubKey": {
     //         "asm": "OP_DUP OP_HASH160 a4a942c99c94522a025b2b8cfd2edd149fb49954 OP_EQUALVERIFY OP_CHECKSIG",
@@ -298,7 +298,7 @@ void test_transaction()
     char* raw_hexadecimal_transaction  = finalize_transaction(working_transaction_index, external_p2pkh_address, ".00226", "12.0", internal_p2pkh_address);
 
     u_assert_int_eq(sign_transaction(working_transaction_index, utxo_scriptpubkey, private_key_wif), 1);
-    u_assert_str_eq(raw_hexadecimal_transaction, expected_signed_raw_hexadecimal_transaction);
+    u_assert_str_eq(get_raw_transaction(working_transaction_index), expected_signed_raw_hexadecimal_transaction);
 
     // ----------------------------------------------------------------
     // test building transaction with single input and signing with sign_transaction:
@@ -318,12 +318,12 @@ void test_transaction()
     raw_hexadecimal_transaction  = finalize_transaction(working_transaction_index, external_p2pkh_address, ".00113", "10.0", internal_p2pkh_address);
 
     u_assert_int_eq(sign_transaction(working_transaction_index, utxo_scriptpubkey, private_key_wif), 1);
-    u_assert_str_eq(raw_hexadecimal_transaction, expected_single_utxo_signed_transaction);
+    u_assert_str_eq(get_raw_transaction(working_transaction_index), expected_single_utxo_signed_transaction);
 
     // ----------------------------------------------------------------
     // test store_raw_transaction:
 
-    int working_transaction_index2 = store_raw_transaction(raw_hexadecimal_transaction);
+    int working_transaction_index2 = store_raw_transaction(get_raw_transaction(working_transaction_index));
     u_assert_int_eq(working_transaction_index, working_transaction_index2 - 1);
     u_assert_str_eq(get_raw_transaction(working_transaction_index), get_raw_transaction(working_transaction_index2));
 
@@ -499,115 +499,6 @@ void test_transaction()
     u_assert_true(isMainnetFromB58Prefix("D6vSSr6ftnicfpSNARqezdehAL5Abe2LQw"));
 
     // ----------------------------------------------------------------
-    // test a large transaction that caused problems in finalize_transaction
-
-    working_transaction_index = start_transaction();
-
-    // add inputs
-    u_assert_int_eq(add_utxo(working_transaction_index, "00df9507524acbf5ccc1c00d152216c984192f1fc6edad81406b4371a7d91038", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "5d08f2928cefd155e377fe40a521cf66317bcde0a24c0d9094090306196dbbf8", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "9b9f872cbebff7d2242cbbde8d0fe7ca108be55bdde4a7e6905001f51bce2fc6", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "c9ef9105f0af21bef3df7affb68a8ccbf140b57bb3d880feafa98ff4a5ce7681", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "9e31e81fcb20f493affd2e3d4ec6cc7438021253b6e8869407479ed1b999ead3", 2), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "78314092f843b6b78347c87c7d43c1591586d56bfe6de800a10ed6ac600d330d", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "78cf3fc573cdd7b2226717ec697d5f9e813479194ba18aaf5ae715aa8a8d4427", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "a1cba23b31985476f25514b6593efd0fd0c625ceab071e90c3815521af385d4d", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "62fea417be4c37db98c220fe96f4753518d0422e6c6727d66162648c9c169bbd", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "d395def4e5590af657be7abc71549492e5d4f3679a60c758c20bf44c7daa5a51", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "55ea0e1b6612ae80e1b3f197dcf109e17d04bd9cd9853d4e826eac5cdd71b43a", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "9c58ce226db9e0595d49e1c1673d93a01f40afe92f6d588bc74b4a17decfe253", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "53a0bd6ea2d02d40323b6e1ea11357367a0d4632b2f8404632330e8c89c3ded6", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "d25dfc12e402124e7fe69488c9b330c6034ec7913d540b70c0539282d5000732", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "649b00be10ab02d6e884bb32946b682b03d2ed24d8c73a21a902d2c9f6731176", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "698f5b6e17a0c98266142276cfaf26776681275c9f7496a551ecfdb5dfad1960", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "15ffbba4111326cd0648c93c1b611d96a629e712e1ad849c9336bf3d99ec2767", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "27c6bd41f6146f5bfb690598e3c845603d9ada3b8ff468e8a4b4a9664b29c569", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "9ebd232f9e707ed0022a5367a519570f6df22b8e50eebc0a6874a5e4ab0ef3f2", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "d0af485f0930a91806916ee1ff815e0edf97aa4f9fda8bc6704e83dcfe00a0b4", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "da3b58e9113265ce41206181ccd7f76d1c333f702138c242e1255f6f04c4bd30", 4), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "7e026ee12f2f738242676d039222c887f6866818828567ec4a9a39ebf0e6e9a0", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "8d9c6d9be6bac379cbb05fa2fcaa37a364e3e2bd3186d5ca45f699656a0f3fbe", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "fbc24b8568e222e732e8a3573848b56a508880f4c27c67135ce9a5b814732e58", 8), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "66421a7d021930ac6ca4aa0b237736a7367a0ac5a86b62a7d1edc7a624786d2f", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "bbd247c762ecf4da6d010278afe1416efbc966af7a0d84a398d18fdd81defeb4", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "c648456de8b63927111afec155757962ee13dc569b1b441e2cd49766f27a0a11", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "f5cc0ffc8f39e6f654bf0de0c9e9d163fc49b0b57f3fc654d989bbfd99b34e09", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "d63e2e43e12fbb7d9478670e31ee66b3a4952d20e970b93cc1e3a534b7146b5d", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "a8cabbf23f3262679728c4de3774be1ee81b730fd4736b4b9c652841729b0fce", 4), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "7952236e62d381ea8f929e002d3195c202832be7017d9de69de262b03f5a97c5", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "8413920ef9835a24d2bb12c0e2d4354b432c863ad9a9a08ff5dd2762524e8f88", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "cd3dfdbd6eb1ea4dcaa1523ac50511ed8ed085595669fa9bfebe5706c95b9560", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "717010ccb3c7e2ca8114609c5a580901a1bfcaf63d56932f0f4417eacf6d6cdc", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "662368f336ecbb37758b886f431720219c3134ab00a9a4a3a3e400d8375923ba", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "5ab35e2e591de678b10df0d5ea5b64fde69351a35e0acc3597579c1966b091cc", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "7c3e156ac8abd2ba40a6123c5ca0cd06619a7bfcd19b58623a71dfde204c2eab", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "cd30ca40690d047446538a9da5336ac59b210739f99d0b3cd197f0a06cc709ea", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "ea05d48e2166cebc99b07769ee593396554f6e7fa8e82edef653d35b8e1c63c8", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "a4ac7e4a0320aae3545e73edc40871c8a103f27e93090553fd81b3d836c0f7d1", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "34e0f4b1762e258abaefe6a56d7060d6070e7ac8d229256e3890772b988c318d", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "872a896cae8669f0578f48ae5a8876923c957f35df3a5a96a4e3372498670105", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "e53023539c1be3112baba7a5ae55d5feebdd93f7131170d09346c09a46f45fc4", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "91e640201d2762b8ddd6dac653a87267c52ef2341809fa4f7b5340323a115aee", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "9a390760c8f4ed07eaf8ac75ccededd6d17784951c41579bec1a13492b300a6d", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "b2218023c6c9e6c41e017dfe63975acf95dd739a3a3ead13e58e6e9ab6bad28e", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "f9fb2f91935120241c59efb8c1d0d0f2994753520defbbde3e4c623c1d8f75d3", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "183c428655c9988cdf54613265ccbf8e0e082ae4534ce5f352e5fa9500974993", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "53484bf1dba5cd4d14512129af2c8088a2700e2d2c73431f121cb5971170b5db", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "b7674978eda56ee91f5003ae6ffbcda169cb016913c99562b32bc6ef91753998", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "21db9e7e6e2b72a972ad4a7e511ca7d3bce5f6bc043dbb05b8c03f8b4a97df37", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "c338e6dd38b40fe144c25a5c6d14c44f40611d3569e874beda608dc01ae658dd", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "b9638873605d5f4a8a1e5eea4a87ece8e6525c51816ca70d8dd8f650f359c19b", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "20875c96439f6248ed393da0b67cc62ef4bd463a0c42ced465e3c51caceee060", 0), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "5be3badc9048ffc367fc8ca485a5523b0741f8748229ad560f31f6a1f1f9705e", 1), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "ed14fd5e700619b7a64413a61cbccba4861dfe30688a7cdedb322f7e562a37ef", 1), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "4ddfffea5375a08774981c0e5fec8ffab4cc4912c0d1dc5470efb35b1f0c1be6", 1), 1);
-    u_assert_int_eq(add_utxo(working_transaction_index, "ab2a5bad51b793715304ffa208ca9127d20a1f1fe7892c58cdbb6c8f2b6fc5e2", 0), 1);
-
-    // add outputs
-    u_assert_int_eq(add_output(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "97687.14577424"), 1);
-
-    // finalize the transaction and verify its not null or empty
-    raw_hexadecimal_transaction = finalize_transaction(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "0.08679272", "97687.23256696", "DMVMYSajAj7qQ7L6D81KiGxTMx8mrB9cgc");
-    u_assert_not_null(raw_hexadecimal_transaction);
-    u_assert_str_not_eq(raw_hexadecimal_transaction, "");
-
-    // test finalize_transaction_ex on the large transaction
-    char txhex_large[TXHEXMAXLEN + 1];
-    u_assert_true(finalize_transaction_ex(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "0.08679272", "97687.23256696", "DMVMYSajAj7qQ7L6D81KiGxTMx8mrB9cgc", txhex_large, sizeof(txhex_large)) > 0);
-    u_assert_str_not_eq(txhex_large, "");
-
-    // get_raw_transaction_ex must produce identical hex
-    char buf2[TXHEXMAXLEN + 1];
-    int len2 = get_raw_transaction_ex(working_transaction_index, buf2, sizeof(buf2));
-    u_assert_true(len2 > 0);
-    u_assert_str_eq(buf2, txhex_large);
-
-    // test sign_raw_transaction_ex on input 0 of the large transaction
-    size_t need2 = 0;
-    u_assert_int_eq(sign_raw_transaction_ex(0, txhex_large, NULL, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
-
-    char* out2 = malloc(need2);
-    u_assert_not_null(out2);
-    u_assert_int_eq(sign_raw_transaction_ex(0, txhex_large, out2, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
-    u_assert_true(strlen(out2) > 0);
-    dogecoin_free(out2);
-
-    // sign just vin-0 and store it
-    char buf3[TXHEXMAXLEN + 1];
-    u_assert_true(sign_indexed_raw_transaction_ex(working_transaction_index, 0, utxo_scriptpubkey, 1, private_key_wif, buf3, sizeof(buf3)));
-    u_assert_str_eq(buf3, get_raw_transaction(working_transaction_index));
-
-    // sign all remaining inputs in one shot
-    char buf4[TXHEXMAXLEN + 1];
-    u_assert_true(sign_transaction_ex(working_transaction_index, utxo_scriptpubkey, private_key_wif, buf4, sizeof(buf4)));
-    u_assert_str_eq(buf4, get_raw_transaction(working_transaction_index));
-
-    // convenience wrapper that does the same with just the priv-key
-    char buf5[TXHEXMAXLEN + 1];
-    u_assert_true(sign_transaction_w_privkey_ex(working_transaction_index, private_key_wif, buf5, sizeof(buf5)));
-    u_assert_str_eq(buf5, get_raw_transaction(working_transaction_index));
-
-    // ----------------------------------------------------------------
     // optional Falcon-512 OP_RETURN commit test (only when built with liboqs)
 #ifdef USE_LIBOQS
     uint8_t *pk = NULL, *sk = NULL, *sig = NULL;
@@ -628,7 +519,7 @@ void test_transaction()
     uint8_t commit32[32];
     u_assert_true(dogecoin_falcon512_commit_bytes(pk, pk_len, sig, sig_len, commit32));
 
-    // push commit into OP_RETURN and then extract it back
+    // build a tx and add OP_RETURN commit
     dogecoin_tx* txc = dogecoin_tx_new();
     u_assert_true(dogecoin_tx_add_falcon512_commit(txc, commit32));
 
@@ -760,4 +651,126 @@ void test_transaction()
     cstr_free(carrier_spk, true);
     cstr_free(carrier_redeem, true);
 #endif
+}
+
+/*
+ * Large multi-input transaction (regression for finalize/sign on ~50 vin).
+ * Run as its own test so armhf/QEMU does not retain test_transaction() stack.
+ */
+void test_transaction_large(void)
+{
+    const char* private_key_wif = "ci5prbqz7jXyFPVWKkHhPq4a9N8Dag3TpeRfuqqC2Nfr7gSqx1fy";
+    const char* utxo_scriptpubkey = "76a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac";
+    const char* raw_hexadecimal_transaction;
+    int working_transaction_index;
+
+    working_transaction_index = start_transaction();
+
+    // add inputs
+    u_assert_int_eq(add_utxo(working_transaction_index, "00df9507524acbf5ccc1c00d152216c984192f1fc6edad81406b4371a7d91038", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "5d08f2928cefd155e377fe40a521cf66317bcde0a24c0d9094090306196dbbf8", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9b9f872cbebff7d2242cbbde8d0fe7ca108be55bdde4a7e6905001f51bce2fc6", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "c9ef9105f0af21bef3df7affb68a8ccbf140b57bb3d880feafa98ff4a5ce7681", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9e31e81fcb20f493affd2e3d4ec6cc7438021253b6e8869407479ed1b999ead3", 2), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "78314092f843b6b78347c87c7d43c1591586d56bfe6de800a10ed6ac600d330d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "78cf3fc573cdd7b2226717ec697d5f9e813479194ba18aaf5ae715aa8a8d4427", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "a1cba23b31985476f25514b6593efd0fd0c625ceab071e90c3815521af385d4d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "62fea417be4c37db98c220fe96f4753518d0422e6c6727d66162648c9c169bbd", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d395def4e5590af657be7abc71549492e5d4f3679a60c758c20bf44c7daa5a51", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "55ea0e1b6612ae80e1b3f197dcf109e17d04bd9cd9853d4e826eac5cdd71b43a", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9c58ce226db9e0595d49e1c1673d93a01f40afe92f6d588bc74b4a17decfe253", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "53a0bd6ea2d02d40323b6e1ea11357367a0d4632b2f8404632330e8c89c3ded6", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d25dfc12e402124e7fe69488c9b330c6034ec7913d540b70c0539282d5000732", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "649b00be10ab02d6e884bb32946b682b03d2ed24d8c73a21a902d2c9f6731176", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "698f5b6e17a0c98266142276cfaf26776681275c9f7496a551ecfdb5dfad1960", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "15ffbba4111326cd0648c93c1b611d96a629e712e1ad849c9336bf3d99ec2767", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "27c6bd41f6146f5bfb690598e3c845603d9ada3b8ff468e8a4b4a9664b29c569", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9ebd232f9e707ed0022a5367a519570f6df22b8e50eebc0a6874a5e4ab0ef3f2", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d0af485f0930a91806916ee1ff815e0edf97aa4f9fda8bc6704e83dcfe00a0b4", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "da3b58e9113265ce41206181ccd7f76d1c333f702138c242e1255f6f04c4bd30", 4), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "7e026ee12f2f738242676d039222c887f6866818828567ec4a9a39ebf0e6e9a0", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "8d9c6d9be6bac379cbb05fa2fcaa37a364e3e2bd3186d5ca45f699656a0f3fbe", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "fbc24b8568e222e732e8a3573848b56a508880f4c27c67135ce9a5b814732e58", 8), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "66421a7d021930ac6ca4aa0b237736a7367a0ac5a86b62a7d1edc7a624786d2f", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "bbd247c762ecf4da6d010278afe1416efbc966af7a0d84a398d18fdd81defeb4", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "c648456de8b63927111afec155757962ee13dc569b1b441e2cd49766f27a0a11", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "f5cc0ffc8f39e6f654bf0de0c9e9d163fc49b0b57f3fc654d989bbfd99b34e09", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "d63e2e43e12fbb7d9478670e31ee66b3a4952d20e970b93cc1e3a534b7146b5d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "a8cabbf23f3262679728c4de3774be1ee81b730fd4736b4b9c652841729b0fce", 4), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "7952236e62d381ea8f929e002d3195c202832be7017d9de69de262b03f5a97c5", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "8413920ef9835a24d2bb12c0e2d4354b432c863ad9a9a08ff5dd2762524e8f88", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "cd3dfdbd6eb1ea4dcaa1523ac50511ed8ed085595669fa9bfebe5706c95b9560", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "717010ccb3c7e2ca8114609c5a580901a1bfcaf63d56932f0f4417eacf6d6cdc", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "662368f336ecbb37758b886f431720219c3134ab00a9a4a3a3e400d8375923ba", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "5ab35e2e591de678b10df0d5ea5b64fde69351a35e0acc3597579c1966b091cc", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "7c3e156ac8abd2ba40a6123c5ca0cd06619a7bfcd19b58623a71dfde204c2eab", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "cd30ca40690d047446538a9da5336ac59b210739f99d0b3cd197f0a06cc709ea", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "ea05d48e2166cebc99b07769ee593396554f6e7fa8e82edef653d35b8e1c63c8", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "a4ac7e4a0320aae3545e73edc40871c8a103f27e93090553fd81b3d836c0f7d1", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "34e0f4b1762e258abaefe6a56d7060d6070e7ac8d229256e3890772b988c318d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "872a896cae8669f0578f48ae5a8876923c957f35df3a5a96a4e3372498670105", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "e53023539c1be3112baba7a5ae55d5feebdd93f7131170d09346c09a46f45fc4", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "91e640201d2762b8ddd6dac653a87267c52ef2341809fa4f7b5340323a115aee", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "9a390760c8f4ed07eaf8ac75ccededd6d17784951c41579bec1a13492b300a6d", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "b2218023c6c9e6c41e017dfe63975acf95dd739a3a3ead13e58e6e9ab6bad28e", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "f9fb2f91935120241c59efb8c1d0d0f2994753520defbbde3e4c623c1d8f75d3", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "183c428655c9988cdf54613265ccbf8e0e082ae4534ce5f352e5fa9500974993", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "53484bf1dba5cd4d14512129af2c8088a2700e2d2c73431f121cb5971170b5db", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "b7674978eda56ee91f5003ae6ffbcda169cb016913c99562b32bc6ef91753998", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "21db9e7e6e2b72a972ad4a7e511ca7d3bce5f6bc043dbb05b8c03f8b4a97df37", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "c338e6dd38b40fe144c25a5c6d14c44f40611d3569e874beda608dc01ae658dd", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "b9638873605d5f4a8a1e5eea4a87ece8e6525c51816ca70d8dd8f650f359c19b", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "20875c96439f6248ed393da0b67cc62ef4bd463a0c42ced465e3c51caceee060", 0), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "5be3badc9048ffc367fc8ca485a5523b0741f8748229ad560f31f6a1f1f9705e", 1), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "ed14fd5e700619b7a64413a61cbccba4861dfe30688a7cdedb322f7e562a37ef", 1), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "4ddfffea5375a08774981c0e5fec8ffab4cc4912c0d1dc5470efb35b1f0c1be6", 1), 1);
+    u_assert_int_eq(add_utxo(working_transaction_index, "ab2a5bad51b793715304ffa208ca9127d20a1f1fe7892c58cdbb6c8f2b6fc5e2", 0), 1);
+
+    // add outputs
+    u_assert_int_eq(add_output(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "97687.14577424"), 1);
+
+    // finalize the transaction and verify its not null or empty
+    raw_hexadecimal_transaction = finalize_transaction(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "0.08679272", "97687.23256696", "DMVMYSajAj7qQ7L6D81KiGxTMx8mrB9cgc");
+    u_assert_not_null(raw_hexadecimal_transaction);
+    u_assert_str_not_eq(raw_hexadecimal_transaction, "");
+
+    /* Large-tx signing buffers must be heap-allocated (armhf/QEMU stack is ~8 MiB). */
+    char* txhex_large = (char*)calloc(1, TXHEXMAXLEN + 1);
+    char* tx_work_buf = (char*)calloc(1, TXHEXMAXLEN + 1);
+    u_assert_not_null(txhex_large);
+    u_assert_not_null(tx_work_buf);
+
+    // test finalize_transaction_ex on the large transaction
+    u_assert_true(finalize_transaction_ex(working_transaction_index, "DGKhMhaagCrpQuzuKQoZsGYnCsw8f2DuBq", "0.08679272", "97687.23256696", "DMVMYSajAj7qQ7L6D81KiGxTMx8mrB9cgc", txhex_large, TXHEXMAXLEN + 1) > 0);
+    u_assert_str_not_eq(txhex_large, "");
+
+    // get_raw_transaction_ex must produce identical hex
+    int len2 = get_raw_transaction_ex(working_transaction_index, tx_work_buf, TXHEXMAXLEN + 1);
+    u_assert_true(len2 > 0);
+    u_assert_str_eq(tx_work_buf, txhex_large);
+
+    // test sign_raw_transaction_ex on input 0 of the large transaction
+    size_t need2 = 0;
+    u_assert_int_eq(sign_raw_transaction_ex(0, txhex_large, NULL, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
+
+    char* out2 = malloc(need2);
+    u_assert_not_null(out2);
+    u_assert_int_eq(sign_raw_transaction_ex(0, txhex_large, out2, &need2, utxo_scriptpubkey, 1, private_key_wif), 1);
+    u_assert_true(strlen(out2) > 0);
+    free(out2);
+
+    // sign just vin-0 and store it
+    u_assert_true(sign_indexed_raw_transaction_ex(working_transaction_index, 0, utxo_scriptpubkey, 1, private_key_wif, tx_work_buf, TXHEXMAXLEN + 1));
+    u_assert_str_eq(tx_work_buf, get_raw_transaction(working_transaction_index));
+
+    // sign all remaining inputs in one shot
+    u_assert_true(sign_transaction_ex(working_transaction_index, utxo_scriptpubkey, private_key_wif, tx_work_buf, TXHEXMAXLEN + 1));
+    u_assert_str_eq(tx_work_buf, get_raw_transaction(working_transaction_index));
+
+    // convenience wrapper that does the same with just the priv-key
+    u_assert_true(sign_transaction_w_privkey_ex(working_transaction_index, private_key_wif, tx_work_buf, TXHEXMAXLEN + 1));
+    u_assert_str_eq(tx_work_buf, get_raw_transaction(working_transaction_index));
+
+    free(txhex_large);
+    free(tx_work_buf);
 }

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -110,7 +110,7 @@ void test_transaction()
             dogecoin_tx_out* tx_out = vector_idx(tx_worth_2->vout, 0);
             char dogecoin[21];
             dogecoin_mem_zero(dogecoin, sizeof(dogecoin));
-            koinu_to_coins_str(tx_out->value, dogecoin);
+            koinu_to_coins_str(tx_out->value, dogecoin, sizeof(dogecoin));
             u_assert_str_eq(dogecoin, "5885.98644000");
     //       "n": 0,
     //       "scriptPubKey": {
@@ -128,7 +128,7 @@ void test_transaction()
     //       "value": 2.00000000,
     //       "n": 1,
             tx_out = vector_idx(tx_worth_2->vout, 1);
-            koinu_to_coins_str(tx_out->value, (char*)dogecoin);
+            koinu_to_coins_str(tx_out->value, (char*)dogecoin, sizeof(dogecoin));
             u_assert_str_eq((char*)dogecoin, "2.00000000");
     //       "scriptPubKey": {
     //         "asm": "OP_DUP OP_HASH160 d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c OP_EQUALVERIFY OP_CHECKSIG",
@@ -206,7 +206,7 @@ void test_transaction()
     //       "value": 227889.99548000,
     //       "n": 0,
             dogecoin_tx_out* tx_out_10 = vector_idx(tx_worth_10->vout, 0);
-            koinu_to_coins_str(tx_out_10->value, (char*)dogecoin);
+            koinu_to_coins_str(tx_out_10->value, (char*)dogecoin, sizeof(dogecoin));
             u_assert_str_eq((char*)dogecoin, "227889.99548000");
     //       "scriptPubKey": {
     //         "asm": "OP_DUP OP_HASH160 1476c35e582eb198e1a28c455005a70c68695868 OP_EQUALVERIFY OP_CHECKSIG",
@@ -223,7 +223,7 @@ void test_transaction()
     //       "value": 10.00000000,
     //       "n": 1,
             tx_out_10 = vector_idx(tx_worth_10->vout, 1);
-            koinu_to_coins_str(tx_out_10->value, (char*)dogecoin);
+            koinu_to_coins_str(tx_out_10->value, (char*)dogecoin, sizeof(dogecoin));
             u_assert_str_eq((char*)dogecoin, "10.00000000");
     //       "scriptPubKey": {
     //         "asm": "OP_DUP OP_HASH160 d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c OP_EQUALVERIFY OP_CHECKSIG",

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -60,6 +60,7 @@ extern void test_random();
 extern void test_rmd160();
 extern void test_scrypt();
 extern void test_serialize();
+extern void test_sweep();
 extern void test_sha1();
 extern void test_sha1_hmac();
 extern void test_sha_256();
@@ -71,6 +72,7 @@ extern void test_signmsg_ext();
 extern void test_tpm();
 extern void test_psbt();
 extern void test_transaction();
+extern void test_transaction_large(void);
 extern void test_validation();
 extern void test_tx_serialization();
 extern void test_tx_sighash();
@@ -171,6 +173,7 @@ int main()
     u_run_test(test_rmd160);
     u_run_test(test_scrypt);
     u_run_test(test_serialize);
+    u_run_test(test_sweep);
     u_run_test(test_sha1);
     u_run_test(test_sha1_hmac);
     u_run_test(test_sha_256);
@@ -184,6 +187,7 @@ int main()
 #endif
     u_run_test(test_psbt);
     u_run_test(test_transaction);
+    u_run_test(test_transaction_large);
     u_run_test(test_validation);
     u_run_test(test_tx_serialization);
     u_run_test(test_invalid_tx_deser);


### PR DESCRIPTION
> **Stacked on #277** (`qlpqlp:BIP38-Support`). GitHub can't base a cross-fork
> PR on that branch, so the Files Changed tab shows the whole BIP38 stack.
> The reviewable delta is the tip commit only: `src/cli/such.c`, +20/−11.
> If #277 merges first this rebases to a clean single-commit PR; if this
> merges first, #277 resolves automatically.

Follow-up to eb59cf3 (KOINU_STRINGLEN bump). The bump enlarged the element
count but the two CLI amount buffers are declared `char*[N]` — arrays of
pointers, not char buffers — so bumping N grew the pointer array (176 bytes
on 64-bit) rather than fixing the type. This corrects the type and hardens
the one unsafe copy on the same path.

### coin_amount / subtotal are the wrong type

```c
char* coin_amount[KOINU_STRINGLEN];              // array of 22 pointers
dogecoin_mem_zero(coin_amount, KOINU_STRINGLEN); // clears 22 of ~176 bytes
koinu_to_coins_str(tx_out->value, (char*)coin_amount, KOINU_STRINGLEN);
```

Every use casts to `(char*)` and treats the pointer array as a byte buffer.
It works only because the oversized allocation absorbs the writes. It's also
a trap: "fixing" the declaration to `char[N]` without auditing would shrink
176 → 22 and could overflow.

### Unterminated copy on the edit path

```c
memcpy_safe(coin_amount, (char*)getl("new amount"), KOINU_STRINGLEN);
```

Copies a fixed `KOINU_STRINGLEN` bytes from `getl()`'s static buffer with no
length check and no guaranteed NUL terminator, then hands the result to
`coins_to_koinu_str()`, which parses it as a C string.

### Changes

- Declare both as `char[KOINU_STRINGLEN]` (real 22-byte buffers).
- Drop the `(char*)` casts (`char[]` decays to `char*`).
- Size `dogecoin_mem_zero` / `koinu_to_coins_str` via `sizeof(buf)`.
- Replace the fixed-size `memcpy` with a length-checked copy that **rejects**
  over-length input (prints the existing invalid-amount message and leaves
  the output untouched) rather than truncating — silent truncation could
  turn an over-long string into a *different valid amount* on a
  tx-building path.

The `constants.h` include and the `KOINU_STRINGLEN` value (22) are already in
place from eb59cf3, so this is `src/cli/such.c` only (+20/−11).

### Testing

Builds clean on top of eb59cf3 (`./autogen.sh && ./configure --disable-net &&
make -j4`, exit 0, `such` binary links, no warnings on the changed TU).
`make check` passes, including the koinu undersized-buffer test added in
3413546. Display/edit-path CLI code; no logic change to amount formatting
or parsing.