### PR TITLE
ci: phase 0 static analysis — CodeQL security-extended, cppcheck, clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,6 +17,12 @@
 #       flags every memcpy/memset; CERT's own guidance treats this as
 #       advisory. Memory-safety coverage comes from ASan/fuzzing instead.
 
+#   uthash.h suppressed via line filter in the workflow invocation:
+#       vendored third-party (Troy Hanson's uthash); generates ~127
+#       macro-parentheses findings per TU that are upstream's to fix.
+#       (clang-tidy 18's HeaderFilterRegex has no negative match; the
+#       workflow passes --line-filter to drop uthash.h instead.)
+
 Checks: >
   -*,
   cert-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,32 @@
+# clang-tidy baseline for libdogecoin
+#
+# Check families follow the audit plan: cert-*, bugprone-*, clang-analyzer-*.
+# Individually disabled checks below each carry a rationale; add new
+# exclusions with the same discipline rather than suppressing inline.
+#
+#   -bugprone-easily-swappable-parameters:
+#       structurally noisy for a C API passing (buf, len) pairs; the hazard
+#       it flags is better covered by hand audit of the FFI boundary.
+#   -bugprone-narrowing-conversions:
+#       high-volume on serialization code; revisit per-module during depth
+#       audits rather than globally.
+#   -cert-err34-c:
+#       atoi/strtol conversion checks; legitimate findings but batched as
+#       hardening, not gating, until the parser paths are hand-audited.
+#   -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling:
+#       flags every memcpy/memset; CERT's own guidance treats this as
+#       advisory. Memory-safety coverage comes from ASan/fuzzing instead.
+
+Checks: >
+  -*,
+  cert-*,
+  bugprone-*,
+  clang-analyzer-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  -cert-err34-c,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '(include/dogecoin|src)/.*\.h$'
+FormatStyle: none

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -44,11 +44,15 @@ jobs:
       - name: run clang-tidy over first-party sources
         run: |
           clang-tidy --version
-          # first-party C sources only; vendored trees excluded
+          # first-party C sources only; vendored trees excluded.
+          # --line-filter drops findings inside vendored uthash.h (LLVM's
+          # HeaderFilterRegex cannot express a negative match).
           find src -maxdepth 1 -name '*.c' \
             ! -name 'utf8proc*.c' \
             | xargs -P "$(nproc)" -n 4 \
-              clang-tidy -p build --quiet 2>/dev/null \
+              clang-tidy -p build --quiet \
+                --line-filter='[{"name":"uthash.h","lines":[[9999999,9999999]]},{"name":".c"},{"name":".h"}]' \
+                2>/dev/null \
             | tee clang-tidy-report.txt || true
           echo "---"
           grep -c "warning:" clang-tidy-report.txt || echo "0 warnings"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,60 @@
+# static analysis: clang-tidy (advisory)
+#
+# Phase 0 policy: this job never fails the build (continue-on-error). It
+# exists to generate the backlog and shake out config noise. It flips to
+# gating on new findings only after the baseline is triaged.
+#
+# Uses the CMake build solely to produce compile_commands.json; the
+# release build system remains autotools.
+
+name: clang-tidy
+
+on:
+  push:
+    branches:
+      - '*-dev-*'
+      - 'main'
+  pull_request:
+    branches:
+      - '*-dev-*'
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+      - 'doc/**'
+
+jobs:
+  clang-tidy:
+    name: clang-tidy
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: install toolchain
+        run: |
+          sudo apt-get update --yes
+          sudo apt-get install -y clang-tidy cmake build-essential libevent-dev
+
+      - name: generate compile commands
+        run: |
+          cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: run clang-tidy over first-party sources
+        run: |
+          clang-tidy --version
+          # first-party C sources only; vendored trees excluded
+          find src -maxdepth 1 -name '*.c' \
+            ! -name 'utf8proc*.c' \
+            | xargs -P "$(nproc)" -n 4 \
+              clang-tidy -p build --quiet 2>/dev/null \
+            | tee clang-tidy-report.txt || true
+          echo "---"
+          grep -c "warning:" clang-tidy-report.txt || echo "0 warnings"
+
+      - name: upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-report
+          path: clang-tidy-report.txt

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,98 @@
+# static analysis: cppcheck with CWE-tagged findings
+#
+# Gating policy (phase 0): only `error` severity fails the job. The full
+# report (all severities, CWE IDs included) is uploaded as an artifact for
+# triage. Gating widens to `warning` once the initial backlog is dispositioned
+# in contrib/analysis/cppcheck-suppressions.txt.
+#
+# Vendored/third-party code is excluded at invocation time below rather than
+# via suppressions, so the suppressions file stays a record of first-party
+# triage decisions only.
+
+name: cppcheck
+
+on:
+  push:
+    branches:
+      - '*-dev-*'
+      - 'main'
+  pull_request:
+    branches:
+      - '*-dev-*'
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
+      - 'doc/**'
+
+jobs:
+  cppcheck:
+    name: cppcheck
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: install cppcheck
+        run: |
+          sudo apt-get update --yes
+          sudo apt-get install -y cppcheck
+
+      - name: run cppcheck (full report, non-gating)
+        run: |
+          cppcheck --version
+          cppcheck \
+            --enable=warning,style,performance,portability \
+            --std=c99 \
+            -D__GNUC__ -D__linux__ \
+            --inline-suppr \
+            --suppressions-list=contrib/analysis/cppcheck-suppressions.txt \
+            --library=posix \
+            -I include \
+            -i src/secp256k1 \
+            -i src/libevent \
+            -i src/intel \
+            -i src/utf8proc.c \
+            -i src/utf8proc_data.c \
+            --xml --xml-version=2 \
+            --output-file=cppcheck-report.xml \
+            src/ 2>&1 | tail -20
+
+      - name: summarize findings by CWE
+        run: |
+          python3 - <<'EOF'
+          import xml.etree.ElementTree as ET
+          from collections import Counter
+          root = ET.parse('cppcheck-report.xml').getroot()
+          errors = root.findall('.//error')
+          by_sev = Counter(e.get('severity') for e in errors)
+          by_cwe = Counter(e.get('cwe') for e in errors if e.get('cwe'))
+          print(f"total findings: {len(errors)}")
+          print("by severity:", dict(by_sev))
+          print("by CWE:", dict(by_cwe.most_common(15)))
+          EOF
+
+      - name: upload full report
+        uses: actions/upload-artifact@v4
+        with:
+          name: cppcheck-report
+          path: cppcheck-report.xml
+
+      - name: gate on error severity
+        run: |
+          cppcheck \
+            --enable=warning \
+            --std=c99 \
+            -D__GNUC__ -D__linux__ \
+            --inline-suppr \
+            --suppressions-list=contrib/analysis/cppcheck-suppressions.txt \
+            --library=posix \
+            -I include \
+            -i src/secp256k1 \
+            -i src/libevent \
+            -i src/intel \
+            -i src/utf8proc.c \
+            -i src/utf8proc_data.c \
+            --error-exitcode=1 \
+            --quiet \
+            src/

--- a/.github/workflows/ql.yml
+++ b/.github/workflows/ql.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
-      - '*-dev-*'
+      - '*-dev*'
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
@@ -58,6 +58,7 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
+        queries: security-extended
 
     - name: build libdogecoin
       run: |

--- a/contrib/analysis/cppcheck-suppressions.txt
+++ b/contrib/analysis/cppcheck-suppressions.txt
@@ -1,0 +1,18 @@
+// cppcheck suppressions baseline for libdogecoin
+//
+// Format: <check-id>[:<path>[:<line>]]
+// Every suppression added here MUST carry a one-line rationale comment
+// directly above it (disposition: false-positive | out-of-scope | hardening-deferred).
+// See doc/audit: triage and disposition rules.
+//
+// Vendored/third-party code is excluded at invocation time (see
+// .github/workflows/cppcheck.yml), not suppressed here.
+
+// cppcheck cannot see inline assembly / compiler builtins used by ctaes and
+// the scrypt SSE2 path; unusedFunction is structurally noisy for a library
+// whose public surface is consumed externally.
+unusedFunction
+
+// Informational check with a very high false-positive rate on C99 designated
+// initializers; revisit after the Phase 1 backlog triage.
+missingIncludeSystem


### PR DESCRIPTION
## Summary

First phase of a broader static-analysis and audit effort for the library.
This PR establishes the tooling baseline; triage of findings and any
resulting fixes are follow-up work, not part of this change.

Three commits, independently revertable:

1. **CodeQL: enable `security-extended`** — `ql.yml` currently runs the
   default query suite only. This adds `queries: security-extended`,
   picking up the remainder of the CWE Top 25 mapped queries (memory
   safety, integer handling, injection classes) at the cost of some
   additional triage noise. Findings land in the Security tab as before.

2. **cppcheck workflow (new)** — runs over first-party sources with
   CWE-tagged XML output uploaded as a build artifact for triage.
   - Vendored code (`secp256k1`, `libevent`, `intel`, `utf8proc*`) is
     excluded at invocation, so the suppressions file records
     first-party triage decisions only.
   - Analysis is pinned to `-D__GNUC__ -D__linux__`: without this,
     cppcheck's config exploration trips `#error` in
     `portable_endian.h` and flags the MSVC-only `DISABLE_WARNING`
     macros as unknown.
   - **Gating policy: `error` severity only for now.** The full report
     (all severities) is in the artifact. Gating widens to `warning`
     once the initial backlog is dispositioned.
   - `contrib/analysis/cppcheck-suppressions.txt` is the baseline;
     every suppression must carry a one-line rationale comment.

3. **clang-tidy workflow + `.clang-tidy` config (new)** — enables
   `cert-*`, `bugprone-*`, `clang-analyzer-*` with four exclusions,
   each documented inline in the config.
   - **This job is `continue-on-error` by design.** A green check with
     findings in the report artifact is expected behavior, not a broken
     gate — it exists to generate the triage backlog. It flips to
     gating on new findings only after the baseline is triaged.
   - Vendored `uthash.h` is dropped via `--line-filter` (~127
     macro-parentheses findings per TU that are upstream's to fix;
     clang-tidy 18's `HeaderFilterRegex` cannot express a negative
     match).
   - Uses the CMake build **only** to produce `compile_commands.json`;
     autotools remains the release build system.

## What reviewers are agreeing to

Beyond the YAML itself, this PR encodes policy: what gates (cppcheck
`error` severity), what's advisory (clang-tidy, full cppcheck report),
what's excluded as third-party, and the rule that every suppression or
check exclusion carries a written rationale. Pushback on any of those
is in scope for this review.

## Early findings from smoke testing (not addressed here)

Limited runs over `bip32.c`, `psbt.c`, `base58.c` during development
already surfaced triage candidates, filed for follow-up rather than
fixed in this PR:

- `strlens(s)` in `include/dogecoin/utils.h` has an unparenthesized
  macro argument — hardening, not exploitable as used.
- Two `clang-analyzer-core.CallAndMessage` uninitialized-value findings
  in `bip32.c` — unconfirmed, but key-derivation surface, so first in
  the triage queue.

The first full-tree artifact runs on this PR constitute the actual
initial backlog.

## Testing

- Patch series applies cleanly on current `0.1.5-dev` (`git am`,
  verified on fresh clone)
- All three workflow files YAML-validated
- cppcheck invocation smoke-tested locally (3 files): zero
  error-severity findings after platform pinning
- clang-tidy config smoke-tested locally against generated
  `compile_commands.json`; uthash filter verified (163 → 36 warnings
  on `bip32.c`, real analyzer findings retained)
- Full-tree runs happen via this PR's own workflow triggers — treat
  the first run as part of review