### PR TITLE
coverage: measure fuzz harness reachability (stacked on #351)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1248,3 +1248,57 @@ jobs:
           files: |
             gitian/builds/${{ github.ref_name }}/**/*
           fail_on_unmatched_files: true
+
+  fuzz:
+    name: fuzz-libfuzzer
+    runs-on: ubuntu-22.04
+    steps:
+      - name: install packages
+        run: |
+          sudo apt-get update
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
+            autoconf automake libtool-bin build-essential curl python3 \
+            clang llvm libevent-dev
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: configure libdogecoin (clang + libFuzzer)
+        run: |
+          ./autogen.sh
+          ./configure CC=clang \
+            CFLAGS="-fsanitize=fuzzer-no-link -g -O1" \
+            --enable-fuzz
+        shell: bash
+
+      - name: build fuzz harnesses
+        run: |
+          # The vendored secp256k1 convenience library must be built before
+          # the harnesses link against libdogecoin.la.
+          make -C src/secp256k1
+          make fuzz fuzz/seed_logdb_corpus
+        shell: bash
+
+      - name: smoke-run harnesses
+        run: |
+          # Short bounded runs: surface crashes/leaks without long fuzzing.
+          # rss/malloc limits keep known unbounded-allocation paths (e.g. the
+          # getheaders locator vector) from aborting CI as raw OOM.
+          RUNS=20000
+          COMMON="-runs=$RUNS -max_len=8192 -rss_limit_mb=2048 -malloc_limit_mb=1024"
+          for t in fuzz_tx fuzz_block fuzz_wtx fuzz_logdb fuzz_protocol; do
+            if [ -x "fuzz/$t" ]; then
+              echo "::group::$t"
+              ./fuzz/$t $COMMON
+              echo "::endgroup::"
+            fi
+          done
+
+      - name: seed corpus + replay (logdb)
+        run: |
+          # Generate checksum-valid seeds and re-run logdb from them so the
+          # fuzzer exercises the post-checksum record-accepted path.
+          mkdir -p corpus_logdb
+          ./fuzz/seed_logdb_corpus corpus_logdb
+          ./fuzz/fuzz_logdb corpus_logdb -runs=20000 -max_len=8192 -rss_limit_mb=2048
+        shell: bash

--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -1,0 +1,64 @@
+# fuzz coverage reporting (advisory / artifact-only)
+#
+# Runs the existing libFuzzer harnesses under coverage instrumentation and
+# publishes an HTML report plus a per-file uncovered-priority list. This is
+# a measurement job: it never gates. Its output answers the audit plan's
+# reachability question — what attack surface the fuzzers actually exercise.
+#
+# Scheduled weekly (corpora accumulate value over time) and runnable on
+# demand. It generates short mini-corpora from scratch on each run, so the
+# absolute numbers reflect "what a brief fuzz run reaches", not a ceiling.
+# When a persistent corpus store exists, point CORPUS_ROOT at it via the
+# workflow inputs for numbers that reflect accumulated coverage.
+
+name: fuzz-coverage
+
+on:
+  workflow_dispatch:
+    inputs:
+      seed_runs:
+        description: 'inputs per target when generating a corpus'
+        required: false
+        default: '50000'
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+
+jobs:
+  coverage:
+    name: fuzz-coverage
+    runs-on: ubuntu-22.04
+    steps:
+      - name: install packages
+        run: |
+          sudo apt-get update
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
+            autoconf automake libtool-bin build-essential curl python3 \
+            clang llvm libevent-dev
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: run coverage
+        run: |
+          SEED_RUNS="${{ github.event.inputs.seed_runs || '50000' }}" \
+            contrib/coverage/fuzz_coverage.sh fuzz-corpora
+        shell: bash
+
+      - name: coverage summary to job log
+        run: |
+          echo '### fuzz coverage (first-party sources)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          tail -1 coverage-report/summary.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo 'least-covered first-party files (next-harness priority):' >> "$GITHUB_STEP_SUMMARY"
+          head -12 coverage-report/uncovered.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-coverage-report
+          path: |
+            coverage-report/html/
+            coverage-report/summary.txt
+            coverage-report/uncovered.txt

--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ package-lock.json
 # fuzzing
 fuzz/fuzz_tx
 fuzz/fuzz_block
+fuzz/fuzz_protocol
 fuzz/fuzz_psbt
 fuzz/*.bin
 crash-*

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,11 @@ package-lock.json
 
 # Generated ZK carrier circuit/proving artifacts
 /contrib/zk_carrier/circuits/build/
+
+# fuzzing
+fuzz/fuzz_tx
+fuzz/fuzz_psbt
+fuzz/*.bin
+crash-*
+oom-*
+timeout-*

--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ package-lock.json
 
 # fuzzing
 fuzz/fuzz_tx
+fuzz/fuzz_block
 fuzz/fuzz_psbt
 fuzz/*.bin
 crash-*

--- a/Makefile.am
+++ b/Makefile.am
@@ -527,6 +527,13 @@ fuzz_fuzz_logdb_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_logdb_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_logdb_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
+noinst_PROGRAMS += fuzz/fuzz_psbt
+fuzz_fuzz_psbt_SOURCES = fuzz/fuzz_psbt.c
+fuzz_fuzz_psbt_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
+fuzz_fuzz_psbt_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_psbt_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_psbt_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
 # Corpus seed generator for fuzz_logdb. NOT a libFuzzer target: it links
 # the plain (uninstrumented) library and emits checksum-valid single
 # records so the fuzzer can mutate past the per-record SHA256 gate.
@@ -542,7 +549,7 @@ fuzz-corpus: fuzz/seed_logdb_corpus
 	./fuzz/seed_logdb_corpus $(CORPUS)
 
 
-FUZZ_TARGETS = fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_wtx fuzz/fuzz_logdb
+FUZZ_TARGETS = fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_wtx fuzz/fuzz_logdb fuzz/fuzz_psbt
 if WITH_NET
 FUZZ_TARGETS += fuzz/fuzz_protocol
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -506,5 +506,19 @@ fuzz_fuzz_protocol_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_protocol_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_protocol_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
-fuzz: fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_protocol
+noinst_PROGRAMS += fuzz/fuzz_wtx
+fuzz_fuzz_wtx_SOURCES = fuzz/fuzz_wtx.c
+fuzz_fuzz_wtx_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
+fuzz_fuzz_wtx_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_wtx_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_wtx_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
+noinst_PROGRAMS += fuzz/fuzz_logdb
+fuzz_fuzz_logdb_SOURCES = fuzz/fuzz_logdb.c
+fuzz_fuzz_logdb_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/src/logdb/include
+fuzz_fuzz_logdb_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_logdb_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_logdb_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
+fuzz: fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_protocol fuzz/fuzz_wtx fuzz/fuzz_logdb
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -527,6 +527,21 @@ fuzz_fuzz_logdb_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_logdb_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_logdb_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
+# Corpus seed generator for fuzz_logdb. NOT a libFuzzer target: it links
+# the plain (uninstrumented) library and emits checksum-valid single
+# records so the fuzzer can mutate past the per-record SHA256 gate.
+noinst_PROGRAMS += fuzz/seed_logdb_corpus
+fuzz_seed_logdb_corpus_SOURCES = fuzz/seed_logdb_corpus.c
+fuzz_seed_logdb_corpus_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include -I$(top_srcdir)/src/logdb/include
+fuzz_seed_logdb_corpus_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+
+# Generate a starter corpus: make fuzz-corpus CORPUS=path (default ./corpus_logdb)
+CORPUS ?= corpus_logdb
+fuzz-corpus: fuzz/seed_logdb_corpus
+	$(MKDIR_P) $(CORPUS)
+	./fuzz/seed_logdb_corpus $(CORPUS)
+
+
 FUZZ_TARGETS = fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_wtx fuzz/fuzz_logdb
 if WITH_NET
 FUZZ_TARGETS += fuzz/fuzz_protocol

--- a/Makefile.am
+++ b/Makefile.am
@@ -493,5 +493,12 @@ fuzz_fuzz_tx_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_tx_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_tx_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
-fuzz: fuzz/fuzz_tx
+noinst_PROGRAMS += fuzz/fuzz_block
+fuzz_fuzz_block_SOURCES = fuzz/fuzz_block.c
+fuzz_fuzz_block_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
+fuzz_fuzz_block_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_block_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_block_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
+fuzz: fuzz/fuzz_tx fuzz/fuzz_block
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -499,12 +499,19 @@ fuzz_fuzz_block_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
 fuzz_fuzz_block_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_block_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_block_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
+# fuzz_protocol drives p2p message deserializers from protocol.c, which is
+# only compiled into the library under WITH_NET (and pulls in libevent).
+# Gate the harness on the same condition so `make fuzz` still builds the
+# net-independent targets when networking is disabled.
+if WITH_NET
 noinst_PROGRAMS += fuzz/fuzz_protocol
 fuzz_fuzz_protocol_SOURCES = fuzz/fuzz_protocol.c
 fuzz_fuzz_protocol_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
 fuzz_fuzz_protocol_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_protocol_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_protocol_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+endif
 
 noinst_PROGRAMS += fuzz/fuzz_wtx
 fuzz_fuzz_wtx_SOURCES = fuzz/fuzz_wtx.c
@@ -520,5 +527,10 @@ fuzz_fuzz_logdb_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_logdb_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_logdb_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
-fuzz: fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_protocol fuzz/fuzz_wtx fuzz/fuzz_logdb
+FUZZ_TARGETS = fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_wtx fuzz/fuzz_logdb
+if WITH_NET
+FUZZ_TARGETS += fuzz/fuzz_protocol
+endif
+
+fuzz: $(FUZZ_TARGETS)
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = -I build-aux/m4
 AUTOMAKE_OPTIONS = serial-tests
-.PHONY: gen
+.PHONY: gen fuzz
 .INTERMEDIATE: $(GENBIN)
 
 DIST_SUBDIRS = src/secp256k1
@@ -484,3 +484,14 @@ endif
 endif
 
 libdogecoin_la_LDFLAGS = -no-undefined -version-info $(LIB_VERSION_CURRENT):$(LIB_VERSION_REVISION):$(LIB_VERSION_AGE)
+
+if USE_FUZZ
+noinst_PROGRAMS += fuzz/fuzz_tx
+fuzz_fuzz_tx_SOURCES = fuzz/fuzz_tx.c
+fuzz_fuzz_tx_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
+fuzz_fuzz_tx_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_tx_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_tx_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+
+fuzz: fuzz/fuzz_tx
+endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -499,6 +499,12 @@ fuzz_fuzz_block_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
 fuzz_fuzz_block_LDADD = libdogecoin.la $(ASM_LIB_FILES)
 fuzz_fuzz_block_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
 fuzz_fuzz_block_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
+noinst_PROGRAMS += fuzz/fuzz_protocol
+fuzz_fuzz_protocol_SOURCES = fuzz/fuzz_protocol.c
+fuzz_fuzz_protocol_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/include
+fuzz_fuzz_protocol_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+fuzz_fuzz_protocol_CFLAGS = $(AM_CFLAGS) -fsanitize=fuzzer,address,undefined
+fuzz_fuzz_protocol_LDFLAGS = -fsanitize=fuzzer,address,undefined -static
 
-fuzz: fuzz/fuzz_tx fuzz/fuzz_block
+fuzz: fuzz/fuzz_tx fuzz/fuzz_block fuzz/fuzz_protocol
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -233,6 +233,11 @@ AC_ARG_ENABLE(tests,
   [use_tests=$enableval],
   [use_tests=yes])
 
+AC_ARG_ENABLE(fuzz,
+  AS_HELP_STRING([--enable-fuzz],[build libFuzzer harnesses, requires clang (default is no)]),
+  [use_fuzz=$enableval],
+  [use_fuzz=no])
+
 AC_MSG_CHECKING([for __builtin_expect])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[void myfunc() {__builtin_expect(0,0);}]])],
   [ AC_MSG_RESULT([yes]);AC_DEFINE(HAVE_BUILTIN_EXPECT,1,[Define this symbol if __builtin_expect is available]) ],
@@ -497,6 +502,7 @@ if test x$use_intel_avx2 = xyes || test x$use_intel_sse = xyes; then
 fi
 AC_SUBST([NASM])
 AM_CONDITIONAL([USE_TESTS], [test x"$use_tests" != x"no"])
+AM_CONDITIONAL([USE_FUZZ], [test x"$use_fuzz" = x"yes"])
 AM_CONDITIONAL([WITH_BENCH], [test "x$with_bench" = "xyes"])
 AM_CONDITIONAL([WITH_TOOLS], [test "x$with_tools" = "xyes"])
 AM_CONDITIONAL([WITH_NET], [test "x$with_net" = "xyes"])

--- a/contrib/coverage/README.md
+++ b/contrib/coverage/README.md
@@ -1,0 +1,68 @@
+# Fuzz coverage measurement
+
+`fuzz_coverage.sh` builds the libFuzzer harnesses (from the fuzzing
+harness set) under LLVM source-based coverage instrumentation, replays a
+corpus through each, and reports how much of the first-party source the
+harnesses actually reach.
+
+This exists for the audit assurance case: "we have fuzzers" is weaker
+than "here is the specific attack surface the fuzzers exercise, and here
+is what they don't reach yet." The uncovered-priority list is also the
+input for deciding where the next harness or corpus investment goes.
+
+## Usage
+
+```
+contrib/coverage/fuzz_coverage.sh [corpus_root]
+```
+
+With no corpus, each target gets a short bounded fuzz run to generate one
+in place, so the script works from a clean tree. For meaningful numbers,
+point it at an accumulated corpus:
+
+```
+contrib/coverage/fuzz_coverage.sh /path/to/persistent-corpora
+```
+
+where `persistent-corpora/` holds one subdirectory per target named after
+the target (`fuzz_tx/`, `fuzz_psbt/`, ...).
+
+Environment knobs: `SEED_RUNS` (inputs per generated corpus, default
+20000), `MAX_LEN`, `OUT_DIR` (default `coverage-report`), `LLVM_SUFFIX`
+(e.g. `-18` if your llvm tools are versioned).
+
+## Output
+
+- `coverage-report/html/index.html` — browsable line-level coverage
+- `coverage-report/summary.txt` — `llvm-cov report` over first-party `src/`
+- `coverage-report/uncovered.txt` — first-party `.c` files sorted by line
+  coverage ascending; the top entries are the largest unexercised surface
+
+## Reading the numbers honestly
+
+The absolute percentages depend entirely on corpus quality. A
+freshly-generated mini-corpus measures what a few minutes of fuzzing
+reaches, not what the harness is capable of reaching. Two things are
+robust regardless of corpus size and are what to act on:
+
+1. **Files at 0%** with a harness that nominally targets them — this
+   usually means the harness entry point bails before reaching the code,
+   not that the code is hard to reach. Worth inspecting the harness.
+2. **Relative ranking** of parser surface — if the largest untrusted-input
+   parser (currently `psbt.c`) sits far below the serialization helpers
+   feeding it, that is a corpus/harness gap to close, not noise.
+
+## Build notes
+
+- Coverage instrumentation goes on library objects via `CFLAGS`
+  (`-fprofile-instr-generate -fcoverage-mapping`) so coverage lands in
+  `src/`, not just the harness files. The profile runtime is pulled in at
+  link via configure-level `LDFLAGS`.
+- The build is `--enable-static --disable-shared`: linking the profile
+  runtime into a shared object trips a hidden-`atexit` DSO link error, and
+  static harnesses match how the fuzz CI already builds them.
+- `CXX=clang++` is set because the libtool link step drives the final link
+  through the C++ compiler, which must also understand the profile flag.
+- Vendored trees (`secp256k1`, `libevent`, `intel`, `utf8proc`, logdb's
+  red-black-tree, enclave/optee/pqc backends) are excluded from the report
+  via `-ignore-filename-regex`; the audit scope is first-party code.

--- a/contrib/coverage/fuzz_coverage.sh
+++ b/contrib/coverage/fuzz_coverage.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# fuzz_coverage.sh — measure source coverage achieved by the libFuzzer
+# harnesses, per the audit plan's reachability requirement: the assurance
+# case needs to show what attack surface the fuzzers actually exercise,
+# not just that they ran.
+#
+# Usage:
+#   contrib/coverage/fuzz_coverage.sh [corpus_root]
+#
+#   corpus_root (optional): directory containing one corpus subdirectory
+#   per target, named after the target (corpus_root/fuzz_tx, ...).
+#   Targets with no corpus subdirectory get one generated in-place via a
+#   short bounded fuzz run (SEED_RUNS inputs), so the script is usable
+#   with zero prior state. Bring a real accumulated corpus for numbers
+#   that mean anything: generated mini-corpora measure "what a few
+#   minutes of fuzzing reaches", not "what the harness can reach".
+#
+# Environment:
+#   SEED_RUNS   inputs per target when generating a corpus (default 20000)
+#   MAX_LEN     -max_len passed to libFuzzer            (default 8192)
+#   OUT_DIR     report output directory                 (default coverage-report)
+#   LLVM_SUFFIX suffix for llvm tools, e.g. "-18"       (default autodetected)
+#
+# Requires: clang with matching llvm-profdata/llvm-cov, autotools, and a
+# tree configured per the invocation below (the script reconfigures).
+#
+# Outputs (under $OUT_DIR):
+#   html/index.html      browsable line-level coverage
+#   summary.txt          llvm-cov report over first-party src/
+#   uncovered.txt        first-party files sorted by uncovered lines,
+#                        i.e. the priority list for the next harness
+
+set -euo pipefail
+
+CORPUS_ROOT="${1:-fuzz-corpora}"
+SEED_RUNS="${SEED_RUNS:-20000}"
+MAX_LEN="${MAX_LEN:-8192}"
+OUT_DIR="${OUT_DIR:-coverage-report}"
+
+# --- locate llvm tools matched to clang ---------------------------------
+if [ -n "${LLVM_SUFFIX:-}" ]; then
+    PROFDATA="llvm-profdata${LLVM_SUFFIX}"; COV="llvm-cov${LLVM_SUFFIX}"
+elif command -v llvm-profdata >/dev/null 2>&1; then
+    PROFDATA="llvm-profdata"; COV="llvm-cov"
+else
+    # try the versioned name matching clang's major version
+    CLANG_MAJ="$(clang --version | sed -n 's/.*clang version \([0-9]*\).*/\1/p' | head -1)"
+    PROFDATA="llvm-profdata-${CLANG_MAJ}"; COV="llvm-cov-${CLANG_MAJ}"
+fi
+command -v "$PROFDATA" >/dev/null || { echo "error: $PROFDATA not found" >&2; exit 1; }
+command -v "$COV"      >/dev/null || { echo "error: $COV not found" >&2; exit 1; }
+
+# --- build with coverage instrumentation --------------------------------
+# Library objects need -fprofile-instr-generate -fcoverage-mapping so the
+# coverage lands in src/, not just the harness files. The profile runtime
+# must also be present at link; per-target LDFLAGS in Makefile.am are
+# fixed, but automake always appends configure-level LDFLAGS, so it goes
+# in there.
+echo "== configuring with coverage instrumentation =="
+./autogen.sh >/dev/null
+./configure CC=clang CXX=clang++ \
+    CFLAGS="-fsanitize=fuzzer-no-link -fprofile-instr-generate -fcoverage-mapping -g -O1" \
+    LDFLAGS="-fprofile-instr-generate" \
+    --enable-static --disable-shared \
+    --enable-fuzz >/dev/null
+
+echo "== building harnesses =="
+make -C src/secp256k1 >/dev/null 2>&1 || true
+make fuzz fuzz/seed_logdb_corpus -j"$(nproc)" >/dev/null
+
+TARGETS=""
+for t in fuzz_tx fuzz_block fuzz_wtx fuzz_logdb fuzz_psbt fuzz_protocol; do
+    [ -x "fuzz/$t" ] && TARGETS="$TARGETS $t"
+done
+echo "targets:$TARGETS"
+
+# --- ensure a corpus per target, then replay under profiling ------------
+mkdir -p "$CORPUS_ROOT" "$OUT_DIR"
+rm -f "$OUT_DIR"/*.profraw "$OUT_DIR"/merged.profdata
+
+for t in $TARGETS; do
+    corpus="$CORPUS_ROOT/$t"
+    if [ ! -d "$corpus" ] || [ -z "$(ls -A "$corpus" 2>/dev/null)" ]; then
+        echo "== $t: no corpus found, generating ($SEED_RUNS runs) =="
+        mkdir -p "$corpus"
+        # logdb gets checksum-valid seeds first so post-checksum paths count
+        if [ "$t" = "fuzz_logdb" ] && [ -x fuzz/seed_logdb_corpus ]; then
+            ./fuzz/seed_logdb_corpus "$corpus"
+        fi
+        LLVM_PROFILE_FILE=/dev/null ./fuzz/$t "$corpus" \
+            -runs="$SEED_RUNS" -max_len="$MAX_LEN" \
+            -rss_limit_mb=2048 -malloc_limit_mb=1024 >/dev/null 2>&1 || {
+            echo "warning: $t exited nonzero during corpus generation (crash?); continuing with partial corpus" >&2
+        }
+    fi
+    n=$(ls "$corpus" | wc -l)
+    echo "== $t: replaying corpus ($n inputs) under profiling =="
+    # bare file arguments = execute each input once, then exit
+    LLVM_PROFILE_FILE="$OUT_DIR/$t.%p.profraw" ./fuzz/$t "$corpus"/* \
+        -rss_limit_mb=2048 >/dev/null 2>&1 || {
+        echo "warning: $t crashed during replay; profile up to crash point retained" >&2
+    }
+done
+
+# --- merge and report ----------------------------------------------------
+echo "== merging profiles =="
+"$PROFDATA" merge -sparse "$OUT_DIR"/*.profraw -o "$OUT_DIR/merged.profdata"
+
+# report against one binary with -object for the rest so shared library
+# code is attributed once
+set -- $TARGETS
+FIRST="fuzz/$1"; shift
+OBJECTS=""
+for t in "$@"; do OBJECTS="$OBJECTS -object fuzz/$t"; done
+
+# first-party scope: src/*.c at top level (vendored trees have their own
+# directories and are excluded by the regex)
+SCOPE='-ignore-filename-regex=(secp256k1|libevent|intel|logdb/|openenclave|optee|raccoon_g|zk_carrier|utf8proc|fuzz/)'
+
+echo "== generating reports =="
+"$COV" report "$FIRST" $OBJECTS \
+    -instr-profile="$OUT_DIR/merged.profdata" $SCOPE \
+    > "$OUT_DIR/summary.txt"
+
+"$COV" show "$FIRST" $OBJECTS \
+    -instr-profile="$OUT_DIR/merged.profdata" $SCOPE \
+    -format=html -output-dir="$OUT_DIR/html"
+
+# priority list: first-party .c files sorted by line coverage ascending
+# (llvm-cov columns: Filename Regions MissedRegions Cover Functions
+#  MissedFunctions Executed Lines MissedLines Cover Branches ...).
+# Missed Lines is the absolute count that most directly answers "where
+# is the biggest unexercised attack surface".
+awk 'NR>2 && $1 ~ /\.c$/ {
+        lines_cover=$(NF-3); missed_lines=$(NF-4);
+        gsub("%","",lines_cover);
+        printf "%6s%% lines  %8s missed  %s\n", lines_cover, missed_lines, $1
+     }' "$OUT_DIR/summary.txt" 2>/dev/null | sort -n > "$OUT_DIR/uncovered.txt" || true
+
+echo
+echo "== totals =="
+tail -1 "$OUT_DIR/summary.txt"
+echo
+echo "reports: $OUT_DIR/summary.txt, $OUT_DIR/uncovered.txt, $OUT_DIR/html/index.html"

--- a/fuzz/fuzz_block.c
+++ b/fuzz/fuzz_block.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * libFuzzer harness for dogecoin_block_header_deserialize.
  */
 #include <stdint.h>

--- a/fuzz/fuzz_block.c
+++ b/fuzz/fuzz_block.c
@@ -1,0 +1,21 @@
+/*
+ * libFuzzer harness for dogecoin_block_header_deserialize.
+ */
+#include <stdint.h>
+#include <stddef.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/block.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/buffer.h>
+#include <dogecoin/arith_uint256.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+    dogecoin_block_header *header = dogecoin_block_header_new();
+    struct const_buffer buf = { data, size };
+    arith_uint256 chainwork = {0};
+    dogecoin_block_header_deserialize(header, &buf, &dogecoin_chainparams_main, &chainwork);
+    dogecoin_block_header_free(header);
+    return 0;
+}

--- a/fuzz/fuzz_logdb.c
+++ b/fuzz/fuzz_logdb.c
@@ -1,0 +1,49 @@
+/*
+ * libFuzzer harness for logdb_record_deser_from_file.
+ *
+ * logdb is the append-only record store backing the wallet/headers DBs.
+ * The per-record deserializer reads attacker-controlled varint key/value
+ * lengths and fread()s that many bytes, making it the natural target for
+ * the stack-overflow + unbounded-allocation hardening in PR #345.
+ *
+ * The real function reads from a FILE* (db->file). We wrap the fuzz input
+ * in an in-memory stream via fmemopen so no disk I/O is required.
+ *
+ * Build:  ./configure CC=clang CFLAGS="-fsanitize=fuzzer-no-link" --enable-fuzz && make fuzz
+ * Run:    ./fuzz/fuzz_logdb CORPUS_DIR -max_len=100000
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include <dogecoin/dogecoin.h>
+#include <logdb/logdb_core.h>
+#include <logdb/logdb_rec.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+
+    /* fmemopen requires a non-NULL, non-empty buffer. */
+    FILE *f = fmemopen((void *)data, size, "rb");
+    if (!f) return 0;
+
+    logdb_log_db *db = logdb_new();
+    if (!db) { fclose(f); return 0; }
+    db->file = f;
+
+    logdb_record *rec = logdb_record_new();
+    enum logdb_error error = LOGDB_SUCCESS;
+
+    /* Single record parse: exercises magic/hash/mode reads, both
+     * varint-length fields, and the cstr_resize + fread loops. */
+    logdb_record_deser_from_file(rec, db, &error);
+
+    logdb_record_free(rec);
+
+    /* Detach the stream before logdb_free so it doesn't fclose a
+     * second time (we own f here). */
+    db->file = NULL;
+    logdb_free(db);
+    fclose(f);
+    return 0;
+}

--- a/fuzz/fuzz_logdb.c
+++ b/fuzz/fuzz_logdb.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * libFuzzer harness for logdb_record_deser_from_file.
  *
  * logdb is the append-only record store backing the wallet/headers DBs.

--- a/fuzz/fuzz_protocol.c
+++ b/fuzz/fuzz_protocol.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * libFuzzer harness for p2p message deserializers in protocol.c.
  *
  * Primary target: dogecoin_p2p_deser_msg_getheaders, which parses an

--- a/fuzz/fuzz_protocol.c
+++ b/fuzz/fuzz_protocol.c
@@ -1,0 +1,51 @@
+/*
+ * libFuzzer harness for p2p message deserializers in protocol.c.
+ *
+ * Primary target: dogecoin_p2p_deser_msg_getheaders, which parses an
+ * untrusted, unauthenticated getheaders message (a block-locator vector
+ * plus a hashstop). Also exercises the version-message deserializer.
+ *
+ * The first input byte selects which parser to drive, so one corpus can
+ * cover multiple message types.
+ *
+ * Build:  ./configure CC=clang CFLAGS="-fsanitize=fuzzer-no-link" --enable-fuzz && make fuzz
+ * Run:    ./fuzz/fuzz_protocol CORPUS_DIR -max_len=100000
+ */
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/protocol.h>
+#include <dogecoin/buffer.h>
+#include <dogecoin/vector.h>
+#include <dogecoin/cstr.h>
+
+static void free_locator(void *p) { dogecoin_free(p); }
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size < 1) return 0;
+
+    uint8_t selector = data[0];
+    struct const_buffer buf = { data + 1, size - 1 };
+
+    switch (selector & 0x01) {
+    case 0: {
+        /* getheaders: block-locator vector + hashstop */
+        vector_t *locators = vector_new(8, free_locator);
+        uint256_t hashstop;
+        memset(hashstop, 0, sizeof(hashstop));
+        dogecoin_p2p_deser_msg_getheaders(locators, hashstop, &buf);
+        vector_free(locators, true);
+        break;
+    }
+    case 1: {
+        /* version message */
+        dogecoin_p2p_version_msg msg;
+        memset(&msg, 0, sizeof(msg));
+        dogecoin_p2p_msg_version_deser(&msg, &buf);
+        break;
+    }
+    }
+    return 0;
+}

--- a/fuzz/fuzz_protocol.c
+++ b/fuzz/fuzz_protocol.c
@@ -20,6 +20,7 @@
 #include <dogecoin/buffer.h>
 #include <dogecoin/vector.h>
 #include <dogecoin/cstr.h>
+#include <dogecoin/mem.h>
 
 static void free_locator(void *p) { dogecoin_free(p); }
 

--- a/fuzz/fuzz_psbt.c
+++ b/fuzz/fuzz_psbt.c
@@ -1,0 +1,72 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
+ * libFuzzer harness for dogecoin_psbt_deserialize + serialize round-trip.
+ *
+ * Drives the BIP174 PSBT parser (src/psbt.c) on untrusted bytes. The parser
+ * walks attacker-controlled key/value maps with varint-prefixed lengths and
+ * fixed-size pubkey copies, so it is a natural target for memory-safety and
+ * unbounded-allocation defects. This harness exercises:
+ *   - deser_psbt_kv: the klen/vlen varint allocation path (PR #352, kv-OOM)
+ *   - the BIP32 derivation handlers: the klen==34 pubkey-copy guard
+ *     in both the input and output maps (PR #353, heap overflow)
+ *   - the global/input/output map state machine and free() paths
+ *
+ * On a successful parse it re-serializes the PSBT to also exercise the
+ * serializer and surface deser/ser asymmetry. dogecoin_psbt_deserialize
+ * owns the *out allocation: on success the caller frees it; on failure it
+ * sets *out = NULL and frees internally, so the harness only frees on
+ * success.
+ *
+ * The checked-in regression corpus at test/fuzz_corpus/psbt/ (including the
+ * crash-eea3d... input that reproduced the #353 overflow pre-fix) should be
+ * passed as a seed/replay directory so the harness proves those fixes hold.
+ */
+#include <stdint.h>
+#include <stddef.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/psbt.h>
+#include <dogecoin/cstr.h>
+#include <dogecoin/mem.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+
+    dogecoin_psbt *psbt = NULL;
+    if (dogecoin_psbt_deserialize(data, size, &psbt) && psbt) {
+        /* Round-trip: re-serialize the parsed PSBT. Exercises the
+         * serialization path and surfaces deser/ser asymmetry. */
+        cstring *out = dogecoin_psbt_serialize(psbt);
+        if (out) cstr_free(out, 1);
+        dogecoin_psbt_free(psbt);
+    }
+    /* On failure dogecoin_psbt_deserialize sets *out = NULL and frees its
+     * own internal allocation, so there is nothing to free here. */
+    return 0;
+}

--- a/fuzz/fuzz_tx.c
+++ b/fuzz/fuzz_tx.c
@@ -1,0 +1,22 @@
+/*
+ * libFuzzer harness for dogecoin_tx_deserialize.
+ *
+ * Build:  ./configure CC=clang CFLAGS="-fsanitize=fuzzer-no-link" --enable-fuzz && make fuzz
+ * Run:    ./fuzz/fuzz_tx CORPUS_DIR -max_len=100000
+ */
+#include <stdint.h>
+#include <stddef.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/tx.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+
+    dogecoin_tx *tx = dogecoin_tx_new();
+    size_t consumed = 0;
+    dogecoin_tx_deserialize((const unsigned char *)data, size, tx, &consumed);
+    dogecoin_tx_free(tx);
+
+    return 0;
+}

--- a/fuzz/fuzz_tx.c
+++ b/fuzz/fuzz_tx.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * libFuzzer harness for dogecoin_tx_deserialize + serialize round-trip.
  */
 #include <stdint.h>

--- a/fuzz/fuzz_tx.c
+++ b/fuzz/fuzz_tx.c
@@ -1,22 +1,25 @@
 /*
- * libFuzzer harness for dogecoin_tx_deserialize.
- *
- * Build:  ./configure CC=clang CFLAGS="-fsanitize=fuzzer-no-link" --enable-fuzz && make fuzz
- * Run:    ./fuzz/fuzz_tx CORPUS_DIR -max_len=100000
+ * libFuzzer harness for dogecoin_tx_deserialize + serialize round-trip.
  */
 #include <stdint.h>
 #include <stddef.h>
 
 #include <dogecoin/dogecoin.h>
 #include <dogecoin/tx.h>
+#include <dogecoin/cstr.h>
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     if (size == 0) return 0;
 
     dogecoin_tx *tx = dogecoin_tx_new();
     size_t consumed = 0;
-    dogecoin_tx_deserialize((const unsigned char *)data, size, tx, &consumed);
+    if (dogecoin_tx_deserialize((const unsigned char *)data, size, tx, &consumed)) {
+        /* Round-trip: re-serialize the parsed tx. Exercises the
+         * serialization path and surfaces deser/ser asymmetry. */
+        cstring *out = cstr_new_sz(1024);
+        dogecoin_tx_serialize(out, tx);
+        cstr_free(out, 1);
+    }
     dogecoin_tx_free(tx);
-
     return 0;
 }

--- a/fuzz/fuzz_wtx.c
+++ b/fuzz/fuzz_wtx.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * libFuzzer harness for dogecoin_wallet_wtx_deserialize.
  *
  * Parses an untrusted on-disk wallet transaction record:

--- a/fuzz/fuzz_wtx.c
+++ b/fuzz/fuzz_wtx.c
@@ -1,0 +1,35 @@
+/*
+ * libFuzzer harness for dogecoin_wallet_wtx_deserialize.
+ *
+ * Parses an untrusted on-disk wallet transaction record:
+ *   uint32 height | uint256 tx_hash_cache | serialized dogecoin_tx
+ *
+ * This is the read path exercised when loading a wallet file, so the
+ * input is fully attacker-controlled if a wallet .dat is tampered with.
+ * Directly targets the record-length / truncation handling hardened in
+ * PR #342 (wtx reclen DoS) and the alloc/free balance touched by #318.
+ *
+ * Build:  ./configure CC=clang CFLAGS="-fsanitize=fuzzer-no-link" --enable-fuzz && make fuzz
+ * Run:    ./fuzz/fuzz_wtx CORPUS_DIR -max_len=100000
+ */
+#include <stdint.h>
+#include <stddef.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/wallet.h>
+#include <dogecoin/buffer.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) return 0;
+
+    dogecoin_wtx *wtx = dogecoin_wallet_wtx_new();
+    struct const_buffer buf = { data, size };
+
+    /* Return value intentionally ignored: we care about memory-safety of
+     * the parse on both the success and failure paths, including
+     * truncated headers (height/hash) and embedded-tx truncation. */
+    dogecoin_wallet_wtx_deserialize(wtx, &buf);
+
+    dogecoin_wallet_wtx_free(wtx);
+    return 0;
+}

--- a/fuzz/seed_logdb_corpus.c
+++ b/fuzz/seed_logdb_corpus.c
@@ -1,4 +1,31 @@
 /*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2026 bluezr
+ Copyright (c) 2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/*
  * Corpus seed generator for fuzz_logdb.
  *
  * fuzz_logdb drives logdb_record_deser_from_file() against a fresh

--- a/fuzz/seed_logdb_corpus.c
+++ b/fuzz/seed_logdb_corpus.c
@@ -1,0 +1,149 @@
+/*
+ * Corpus seed generator for fuzz_logdb.
+ *
+ * fuzz_logdb drives logdb_record_deser_from_file() against a fresh
+ * logdb_log_db (logdb_new(): sha256_init'd hashctx, NO file header
+ * absorbed) reading exactly one record from an fmemopen'd buffer.
+ *
+ * A record ends with a SHA256 checksum over (running_ctx || record body),
+ * so random bytes essentially never pass the memcmp() gate and the fuzzer
+ * plateaus before reaching the record-accepted path. This tool emits
+ * valid single-record buffers, computed against the SAME fresh-context
+ * init the harness uses, so libFuzzer mutates outward from inputs that
+ * already clear the checksum.
+ *
+ * It writes records by hand using the library's own ser/hash primitives,
+ * mirroring logdb_write_record() exactly but over a fresh sha256 context
+ * (no header), which is what the harness sees.
+ *
+ * Build (from a configured tree):
+ *   clang -I include -I src/logdb/include seed_logdb_corpus.c \
+ *       .libs/libdogecoin.a src/secp256k1/.libs/libsecp256k1.a -o seed_logdb
+ * Run:
+ *   ./seed_logdb CORPUS_DIR
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/sha2.h>
+#include <dogecoin/cstr.h>
+#include <dogecoin/serialize.h>
+#include <logdb/logdb_core.h>
+#include <logdb/logdb_rec.h>
+
+/* Must match logdb_core.c. record_magic is the per-record start marker;
+ * hashlen is the truncated-SHA length the default db uses. */
+static const uint8_t RECORD_MAGIC[8] =
+    { 0x88, 0x61, 0xAD, 0xFC, 0x5A, 0x11, 0x22, 0xF8 };
+#define HASHLEN 16  /* kLOGDB_DEFAULT_HASH_LEN */
+
+/* Build one valid record buffer for a fresh (header-less) hash context,
+ * exactly as the harness's logdb_new() db would expect to read it.
+ *
+ * On-disk record layout consumed by logdb_record_deser_from_file (note
+ * mode is a STANDALONE byte, and the body-hashcheck appears TWICE, once
+ * before mode and once after the value, with hashlen = 16):
+ *
+ *   magic[8]
+ *   hashcheck[16]               (body-start indicator, arbitrary bytes;
+ *                                deser only feeds it to the SHA context,
+ *                                never validates it against the body)
+ *   mode[1]
+ *   varint(klen) | key
+ *   [ varint(vlen) | value ]    (WRITE only)
+ *   hashcheck[16]               (body-end indicator, same note as above)
+ *   finalcheck[16]              (sha256(running_ctx), first 16 bytes)
+ *
+ * The running ctx absorbs, in order:
+ *   magic, hashcheck, mode, varint(klen), key,
+ *   [varint(vlen), value,] hashcheck
+ * then is finalized; the first hashlen(=16) bytes are finalcheck.
+ *
+ * The two hashcheck blocks are NOT verified against the body by the
+ * reader (it only memcmp()s the final checksum), so we use a fixed
+ * indicator value for them and let the final SHA bind the whole record.
+ */
+static void put_varlen(cstring *s, uint32_t v) {
+    ser_varlen(s, v);  /* CompactSize, same encoder the reader's varint expects */
+}
+
+static cstring *build_record(uint8_t mode, const char *key, size_t klen,
+                             const char *val, size_t vlen) {
+    /* fixed body-start/-end indicator (16 bytes); value is irrelevant to
+     * validation, it only needs to be consistent between the bytes we
+     * emit and the bytes we feed the hash. */
+    uint8_t indicator[HASHLEN];
+    memset(indicator, 0xA5, sizeof(indicator));
+
+    /* encode the body field-by-field in reader order */
+    cstring *kv = cstr_new_sz(64);
+    put_varlen(kv, (uint32_t)klen);
+    if (klen) cstr_append_buf(kv, key, klen);
+    if (mode == RECORD_TYPE_WRITE) {
+        put_varlen(kv, (uint32_t)vlen);
+        if (vlen) cstr_append_buf(kv, val, vlen);
+    }
+
+    /* running context: magic | indicator | mode | kv | indicator */
+    sha256_context ctx;
+    sha256_init(&ctx);
+    sha256_write(&ctx, RECORD_MAGIC, 8);
+    sha256_write(&ctx, indicator, HASHLEN);
+    sha256_write(&ctx, &mode, 1);
+    sha256_write(&ctx, (const uint8_t *)kv->str, kv->len);
+    sha256_write(&ctx, indicator, HASHLEN);
+
+    uint8_t finalhash[SHA256_DIGEST_LENGTH];
+    sha256_context ctx_final = ctx;
+    sha256_finalize(&ctx_final, finalhash);
+
+    /* assemble bytes in reader order */
+    cstring *out = cstr_new_sz(64 + kv->len);
+    cstr_append_buf(out, RECORD_MAGIC, 8);
+    cstr_append_buf(out, indicator, HASHLEN);
+    cstr_append_buf(out, &mode, 1);
+    cstr_append_buf(out, kv->str, kv->len);
+    cstr_append_buf(out, indicator, HASHLEN);
+    cstr_append_buf(out, finalhash, HASHLEN);  /* only first HASHLEN bytes read */
+
+    cstr_free(kv, true);
+    return out;
+}
+
+static void dump(const char *dir, const char *name, cstring *buf) {
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/%s", dir, name);
+    FILE *f = fopen(path, "wb");
+    if (!f) { perror(path); return; }
+    fwrite(buf->str, 1, buf->len, f);
+    fclose(f);
+    printf("wrote %s (%zu bytes)\n", path, buf->len);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s CORPUS_DIR\n", argv[0]);
+        return 1;
+    }
+    const char *dir = argv[1];
+
+    struct { uint8_t mode; const char *k; size_t kl; const char *v; size_t vl; const char *name; } cases[] = {
+        { RECORD_TYPE_WRITE,  "k",    1,   "v",    1,   "seed_write_tiny" },
+        { RECORD_TYPE_WRITE,  "addr", 4,   "value12bytes", 12, "seed_write_small" },
+        { RECORD_TYPE_ERASE,  "k",    1,   "",     0,   "seed_erase" },
+        { RECORD_TYPE_WRITE,  "",     0,   "",     0,   "seed_write_empty" },
+        { RECORD_TYPE_WRITE,  "longkey_padding_0123456789", 26,
+                              "longval_padding_0123456789abcdef", 32, "seed_write_long" },
+    };
+
+    for (size_t i = 0; i < sizeof(cases)/sizeof(cases[0]); i++) {
+        cstring *b = build_record(cases[i].mode, cases[i].k, cases[i].kl,
+                                  cases[i].v, cases[i].vl);
+        dump(dir, cases[i].name, b);
+        cstr_free(b, true);
+    }
+    return 0;
+}


### PR DESCRIPTION
> **Stacked on #351.** This depends on the libFuzzer harnesses from that
> PR and targets its branch, not `0.1.5-dev`. Draft until #351 merges;
> the coverage job cannot run green on any base without the harnesses, so
> a red/absent CI run here is expected until then. Once #351 lands this
> retargets to `0.1.5-dev`.

## What this found

Running the tooling against the harnesses (small corpora — treat these as
a floor, not a ceiling) shows the fuzzers reach serialization and
transaction deserialization but leave the largest untrusted-input surface
almost untouched:

| file | line coverage | missed lines | note |
|---|---|---|---|
| `psbt.c` | ~7% | 918 | largest parser, barely exercised |
| `protocol.c` | ~13% | 165 | p2p message deserializers |
| `block.c` | 0% | — | **has a `fuzz_block` harness yet 0% — likely bails before block deser** |
| `base58.c`, `bip32.c`, `key.c`, crypto primitives | 0% | — | no harness drives them |

Two of these are robust regardless of corpus size and worth acting on:
`psbt.c` sitting far below the serialization helpers that feed it is a
real corpus/harness gap on our biggest parser, and `block.c` at 0%
*despite* having a harness points at the harness entry point, not at
hard-to-reach code.

This is the payoff of the change: it turns "we have fuzzers" into "here
is the attack surface they exercise, and here is what they miss" — which
is what the audit assurance case needs.

## What this adds

- `contrib/coverage/fuzz_coverage.sh` — builds the harnesses under LLVM
  source-based coverage, replays a corpus per target, and emits:
  browsable HTML, an `llvm-cov` summary over first-party `src/`, and
  `uncovered.txt` (files sorted by coverage ascending = next-harness
  priority list).
- `.github/workflows/fuzz-coverage.yml` — **advisory, never gates.**
  Weekly schedule + `workflow_dispatch`. Publishes the report as an
  artifact and writes a summary to the job log.
- `contrib/coverage/README.md` — usage, how to read the numbers honestly,
  and the build constraints below.

## Build notes (the non-obvious parts)

- Coverage flags go on library `CFLAGS`
  (`-fprofile-instr-generate -fcoverage-mapping`) so coverage lands in
  `src/`, not just the harness files.
- Build is `--enable-static --disable-shared`: linking the profile
  runtime into a shared object trips a hidden-`atexit` DSO link error, and
  static matches how the fuzz CI already builds harnesses.
- `CXX=clang++` is set because libtool drives the final link through the
  C++ compiler, which must also understand the profile flag.
- Vendored trees (`secp256k1`, `libevent`, `intel`, `utf8proc`, logdb's
  RB-tree, enclave/optee/pqc backends) are excluded from the report;
  audit scope is first-party code.

## Corpus caveat

The job generates short mini-corpora from scratch each run, so absolute
percentages reflect a brief fuzz run, not a ceiling. Pointing it at a
persistent accumulated corpus (via the script's `corpus_root` argument)
gives numbers that mean more; wiring up a corpus store is follow-up work.

## Testing

- Patch applies cleanly on the #351 base (`git am`, verified on fresh
  clone)
- `fuzz_coverage.sh` bash-syntax-checked; workflow YAML-validated;
  executable bit preserved through the patch round-trip
- Ran end-to-end locally: builds all harnesses under instrumentation,
  merges profiles, produces the report — the table above is real output
- Confirmed the one crash seen during replay is the already-documented
  `getheaders` unbounded-allocation path (`protocol.c:384`) that #351
  already caps with `-malloc_limit_mb`, not a new finding