### PR TITLE
fix: eliminate function-pointer type-mismatch UB via typed trampolines

### DIFF
--- a/include/dogecoin/headersdb_file.h
+++ b/include/dogecoin/headersdb_file.h
@@ -68,17 +68,9 @@ dogecoin_bool dogecoin_headersdb_disconnect_tip(dogecoin_headers_db* db);
 dogecoin_bool dogecoin_headersdb_has_checkpoint_start(dogecoin_headers_db* db);
 void dogecoin_headersdb_set_checkpoint_start(dogecoin_headers_db* db, uint256_t hash, uint32_t height, arith_uint256 chainwork);
 
-static const dogecoin_headers_db_interface dogecoin_headers_db_interface_file = {
-    (void* (*)(const dogecoin_chainparams*, dogecoin_bool))dogecoin_headers_db_new,
-    (void (*)(void *))dogecoin_headers_db_free,
-    (dogecoin_bool (*)(void *, const char *, dogecoin_bool))dogecoin_headers_db_load,
-    (void (*)(void* , vector_t *))dogecoin_headers_db_fill_block_locator,
-    (dogecoin_blockindex *(*)(void* , struct const_buffer *, dogecoin_bool , dogecoin_bool *))dogecoin_headers_db_connect_hdr,
-    (dogecoin_blockindex* (*)(void *))dogecoin_headersdb_getchaintip,
-    (dogecoin_bool (*)(void *))dogecoin_headersdb_disconnect_tip,
-    (dogecoin_bool (*)(void *))dogecoin_headersdb_has_checkpoint_start,
-    (void (*)(void *, uint256_t, uint32_t, arith_uint256))dogecoin_headersdb_set_checkpoint_start
-};
+/* Defined in headersdb_file.c using typed trampolines (avoids the
+ * function-pointer-cast UB that -fsanitize=function flags). */
+extern const dogecoin_headers_db_interface dogecoin_headers_db_interface_file;
 
 LIBDOGECOIN_END_DECL
 

--- a/src/headersdb_file.c
+++ b/src/headersdb_file.c
@@ -578,3 +578,58 @@ void dogecoin_headersdb_set_checkpoint_start(dogecoin_headers_db* db, uint256_t 
         dogecoin_btree_tsearch(db->chainbottom, &db->tree_root, dogecoin_header_compare);
     }
 }
+
+/* ---------------------------------------------------------------------------
+ * Interface trampolines
+ *
+ * dogecoin_headers_db_interface stores its members with generic (void*)
+ * signatures. The concrete functions above take a typed (dogecoin_headers_db*)
+ * first argument. Assigning them into the interface by casting the *function
+ * pointer* is undefined behaviour (C §6.3.2.3/8): calling a function through a
+ * pointer of an incompatible type. UBSan (-fsanitize=function) flags this at
+ * every call through the interface.
+ *
+ * These trampolines carry the exact generic signature the interface declares,
+ * cast only the *data pointer* (which is well defined), and forward to the
+ * typed function. This removes the undefined behaviour without changing the
+ * interface shape or the typed functions themselves.
+ * ------------------------------------------------------------------------- */
+static void* headers_db_if_init(const dogecoin_chainparams* chainparams, dogecoin_bool inmem_only) {
+    return dogecoin_headers_db_new(chainparams, inmem_only);
+}
+static void headers_db_if_free(void* db) {
+    dogecoin_headers_db_free((dogecoin_headers_db*)db);
+}
+static dogecoin_bool headers_db_if_load(void* db, const char* filename, dogecoin_bool prompt) {
+    return dogecoin_headers_db_load((dogecoin_headers_db*)db, filename, prompt);
+}
+static void headers_db_if_fill_blocklocator_tip(void* db, vector_t* blocklocators) {
+    dogecoin_headers_db_fill_block_locator((dogecoin_headers_db*)db, blocklocators);
+}
+static dogecoin_blockindex* headers_db_if_connect_hdr(void* db, struct const_buffer* buf, dogecoin_bool load_process, dogecoin_bool* connected) {
+    return dogecoin_headers_db_connect_hdr((dogecoin_headers_db*)db, buf, load_process, connected);
+}
+static dogecoin_blockindex* headers_db_if_getchaintip(void* db) {
+    return dogecoin_headersdb_getchaintip((dogecoin_headers_db*)db);
+}
+static dogecoin_bool headers_db_if_disconnect_tip(void* db) {
+    return dogecoin_headersdb_disconnect_tip((dogecoin_headers_db*)db);
+}
+static dogecoin_bool headers_db_if_has_checkpoint_start(void* db) {
+    return dogecoin_headersdb_has_checkpoint_start((dogecoin_headers_db*)db);
+}
+static void headers_db_if_set_checkpoint_start(void* db, uint256_t hash, uint32_t height, arith_uint256 chainwork) {
+    dogecoin_headersdb_set_checkpoint_start((dogecoin_headers_db*)db, hash, height, chainwork);
+}
+
+const dogecoin_headers_db_interface dogecoin_headers_db_interface_file = {
+    headers_db_if_init,
+    headers_db_if_free,
+    headers_db_if_load,
+    headers_db_if_fill_blocklocator_tip,
+    headers_db_if_connect_hdr,
+    headers_db_if_getchaintip,
+    headers_db_if_disconnect_tip,
+    headers_db_if_has_checkpoint_start,
+    headers_db_if_set_checkpoint_start
+};

--- a/src/jpeg.c
+++ b/src/jpeg.c
@@ -107,12 +107,25 @@ void jpec_buffer_write_2bytes(jpec_buffer_t* b, int val) {
 static void jpec_huff_encode_block_impl(jpec_block_t* block, jpec_huff_state_t* s);
 static void jpec_huff_write_bits(jpec_huff_state_t* s, unsigned int bits, int n);
 
+/* Trampolines: the skeleton stores generic (void*) callbacks but the concrete
+ * jpec_huff functions take typed first arguments. Casting the function pointer
+ * and calling through it is UB (C §6.3.2.3/8, flagged by -fsanitize=function).
+ * These wrappers carry the generic signature and cast only the data pointer. */
+void jpec_huff_del(jpec_huff_t* h);
+void jpec_huff_encode_block(jpec_huff_t* h, jpec_block_t* block, jpec_buffer_t* buf);
+static void jpec_huff_del_tramp(void* opq) {
+	jpec_huff_del((jpec_huff_t*)opq);
+}
+static void jpec_huff_encode_block_tramp(void* opq, jpec_block_t* block, jpec_buffer_t* buf) {
+	jpec_huff_encode_block((jpec_huff_t*)opq, block, buf);
+}
+
 void jpec_huff_skel_init(jpec_huff_skel_t* skel) {
 	assert(skel);
 	memset(skel, 0, sizeof(*skel));
 	skel->opq = jpec_huff_new();
-	skel->del = (void (*)(void*))jpec_huff_del;
-	skel->encode_block = (void (*)(void*, jpec_block_t*, jpec_buffer_t*))jpec_huff_encode_block;
+	skel->del = jpec_huff_del_tramp;
+	skel->encode_block = jpec_huff_encode_block_tramp;
 }
 
 jpec_huff_t* jpec_huff_new(void) {

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -366,6 +366,16 @@ void set_wallet_filename(dogecoin_wallet* wallet, const dogecoin_chainparams *pa
     memcpy_safe((char*)wallet->filename + path_size + delim_size + chain_size, file_suffix, file_size);
 }
 
+/* Trampolines carrying vector's generic void(*)(void*) free signature; casting
+ * the typed *_free function pointers directly would be UB (flagged by
+ * -fsanitize=function). These cast only the data pointer. */
+static void dogecoin_wallet_wtx_free_tramp(void* p) {
+    dogecoin_wallet_wtx_free((dogecoin_wtx*)p);
+}
+static void dogecoin_wallet_addr_free_tramp(void* p) {
+    dogecoin_wallet_addr_free((dogecoin_wallet_addr*)p);
+}
+
 dogecoin_wallet* dogecoin_wallet_new(const dogecoin_chainparams *params)
 {
     dogecoin_wallet* wallet = dogecoin_calloc(1, sizeof(*wallet));
@@ -376,9 +386,9 @@ dogecoin_wallet* dogecoin_wallet_new(const dogecoin_chainparams *params)
     wallet->utxos = 0;
     wallet->unspent_rbtree = 0;
     wallet->spends_rbtree = 0;
-    wallet->vec_wtxes = vector_new(10, (void (*)(void *)) dogecoin_wallet_wtx_free);
+    wallet->vec_wtxes = vector_new(10, dogecoin_wallet_wtx_free_tramp);
     wallet->wtxes_rbtree = 0;
-    wallet->waddr_vector = vector_new(10, (void (*)(void *)) dogecoin_wallet_addr_free);
+    wallet->waddr_vector = vector_new(10, dogecoin_wallet_addr_free_tramp);
     wallet->waddr_rbtree = 0;
     return wallet;
 }


### PR DESCRIPTION
UBSan (-fsanitize=function) flags six call sites where a typed function is stored into a generic void(*)(void*)-style callback field by casting the function pointer, then called through the mismatched type. That is undefined behaviour (C 6.3.2.3/8): it happens to work on every ABI libdogecoin targets, but is a real portability/correctness hazard (a CFI- or LTO-enabled build may miscompile it).

Fix by routing each through a typed trampoline whose signature genuinely matches the callback field and which casts only the *data* pointer (well defined), rather than casting the function pointer:

  - headersdb_file: the dogecoin_headers_db_interface_file instance moves from the header (nine cast members) into headersdb_file.c, populated with static trampolines. Header now declares it extern. Clears the spv.c call-through findings (headers_db new/free/load and the rest of the interface).
  - jpeg: jpec_huff_skel_init installs jpec_huff_del / _encode_block via trampolines instead of casts.
  - wallet: dogecoin_wallet_new passes wtx_free / addr_free through trampolines to vector_new. (wtx_free was the same latent UB, not yet exercised by a test; fixed alongside.)

Verified: full test suite builds and runs under UBSan with zero function-type-mismatch findings remaining (was six). No behavioural change -- the trampolines forward identically. The remaining UBSan findings (bip32/arith/ jpeg shift UB, sha2 unaligned load) are separate and addressed by #325/#326/#327.

Found by the ASan+UBSan assurance sweep of 0.1.5-dev.