### PR TITLE
key/eckey/bip32: zeroize private-key material after use (CWE-226)

### DIFF
--- a/src/bip32.c
+++ b/src/bip32.c
@@ -267,6 +267,7 @@ dogecoin_bool dogecoin_hdnode_private_ckd(dogecoin_hdnode* inout, uint32_t i)
 
     dogecoin_mem_zero(data, sizeof(data));
     dogecoin_mem_zero(I, sizeof(I));
+    dogecoin_mem_zero(p, sizeof(p));
     dogecoin_mem_zero(z, sizeof(z));
     return true;
 }

--- a/src/eckey.c
+++ b/src/eckey.c
@@ -213,7 +213,12 @@ eckey* new_eckey_ts(dogecoin_eckey_context* ctx, dogecoin_bool is_testnet) {
     pkeybase58c[0] = chain->b58prefix_secret_address;
     pkeybase58c[33] = 1; /* always use compressed keys */
     memcpy_safe(&pkeybase58c[1], &key->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) { dogecoin_key_free(key); return NULL; }
+    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) {
+        dogecoin_mem_zero(pkeybase58c, sizeof(pkeybase58c));
+        dogecoin_key_free(key);
+        return NULL;
+    }
+    dogecoin_mem_zero(pkeybase58c, sizeof(pkeybase58c));
     if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) { dogecoin_key_free(key); return NULL; }
     dogecoin_mutex_lock(&ctx->lock);
     key->idx = HASH_COUNT(ctx->keys) + 1;
@@ -246,7 +251,12 @@ eckey* new_eckey_from_privkey_ts(dogecoin_eckey_context* ctx, char* private_key)
     pkeybase58c[0] = chain->b58prefix_secret_address;
     pkeybase58c[33] = 1; /* always use compressed keys */
     memcpy_safe(&pkeybase58c[1], &key->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) { dogecoin_key_free(key); return NULL; }
+    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) {
+        dogecoin_mem_zero(pkeybase58c, sizeof(pkeybase58c));
+        dogecoin_key_free(key);
+        return NULL;
+    }
+    dogecoin_mem_zero(pkeybase58c, sizeof(pkeybase58c));
     if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) { dogecoin_key_free(key); return NULL; }
     dogecoin_mutex_lock(&ctx->lock);
     key->idx = HASH_COUNT(ctx->keys) + 1;

--- a/src/key.c
+++ b/src/key.c
@@ -116,7 +116,7 @@ dogecoin_bool dogecoin_privkey_decode_wif(const char* privkey_wif, const dogecoi
         return false;
     }
     memcpy_safe(privkey->privkey, &privkey_data[1], DOGECOIN_ECKEY_PKEY_LENGTH);
-    dogecoin_mem_zero(privkey_data, sizeof(privkey_data));
+    dogecoin_mem_zero(privkey_data, privkey_len);
     dogecoin_free(privkey_data);
     return true;
 }


### PR DESCRIPTION
## Summary

Key-material-lifetime hardening (CWE-226: sensitive information left in resident memory). Three focused fixes that scrub private-key material as soon as it is no longer needed, so secrets don't linger on the stack/heap after use.

## Changes

- **`key.c` — WIF decode**: zero the *full* decoded WIF buffer after use, not `sizeof(pointer)` bytes. The previous scrub zeroed only a pointer's worth of bytes, leaving most of the decoded private key resident.
- **`eckey.c` — eckey constructors**: zero the private-key temporary in the `new_eckey` paths before returning.
- **`bip32.c` — CKD derivation**: zero the retained private-key copy used during child-key derivation.

## Why

These are the sibling fixes to the seal-path zeroization audit (submitted separately). All are the same class — secret material readable in a memory dump after the operation completes — and each is a small, self-contained scrub with no behavioural change.

## Testing

- Builds clean (`clang -O2`, `-Wall -Wextra`), full `./tests` suite passes.
- Scrubs use `dogecoin_mem_zero` (volatile, non-elidable), so they survive `-O2`.

Part of the ongoing security-audit series. Kept separate from the seal-path zeroization PR because these are one-line-each buffer scrubs, whereas the seal path is a larger control-flow change that warrants its own review.
