### PR TITLE
seal: zeroize derived keys and hardware-path plaintext (CWE-226)

### DIFF
--- a/src/seal.c
+++ b/src/seal.c
@@ -1339,31 +1339,29 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw(const SEED seed, con
 
     // Generate a random IV for AES encryption
     uint8_t iv[AES_IV_SIZE];
+    uint8_t* encrypted_seed = NULL;
+    dogecoin_bool result = false;
     if (!dogecoin_random_bytes(iv, sizeof(iv), 1))
     {
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
 
     // Encrypt the seed using AES
     size_t encrypted_size = size;
     dogecoin_bool padding_used = false;
-    uint8_t* encrypted_seed = malloc(encrypted_size);
+    encrypted_seed = malloc(encrypted_size);
     if (!encrypted_seed)
     {
         fprintf(stderr, "ERROR: Memory allocation failed.\n");
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
 
     size_t encrypted_actual_size = aes256_cbc_encrypt(encryption_key, iv, seed, size, padding_used, encrypted_seed);
     if (encrypted_actual_size == 0)
     {
         fprintf(stderr, "ERROR: AES encryption failed.\n");
-        dogecoin_free(encrypted_seed);
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
 
     // Write the IV, salt, verification key hash, and encrypted seed to the file
@@ -1374,7 +1372,8 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw(const SEED seed, con
         fwrite(salt_verification, 1, SALT_SIZE, fp);
         fwrite(verification_key_hash, 1, sizeof(verification_key_hash), fp);
         fwrite(encrypted_seed, 1, encrypted_size, fp);
-        fp ? fclose(fp) : 0;
+        fclose(fp);
+        fp = NULL;
     }
     else if (encrypted_blob_out != NULL && encrypted_blob_size != NULL)
     {
@@ -1390,10 +1389,21 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw(const SEED seed, con
         *encrypted_blob_size = sizeof(iv) + SALT_SIZE + SALT_SIZE + sizeof(verification_key_hash) + encrypted_size;
     }
 
-    // Free the encrypted seed
-    dogecoin_free(encrypted_seed);
+    result = true;
 
-    return true;
+cleanup:
+    // Scrub the PBKDF2-derived key material before returning (CWE-226).
+    dogecoin_mem_zero(encryption_key, sizeof(encryption_key));
+    dogecoin_mem_zero(verification_key, sizeof(verification_key));
+    if (encrypted_seed)
+    {
+        dogecoin_free(encrypted_seed);
+    }
+    if (fp)
+    {
+        fclose(fp);
+    }
+    return result;
 #else
     (void) seed;
     (void) size;
@@ -1533,6 +1543,9 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_seed_with_sw(SEED seed, const int
 
     // Derive the verification key from the password and verification salt using PBKDF2
     uint8_t derived_verification_key[AES_KEY_SIZE];
+    uint8_t encryption_key[AES_KEY_SIZE];
+    uint8_t* encrypted_seed = NULL;
+    dogecoin_bool result = false;
     pbkdf2_hmac_sha256((const uint8_t*)password, strlen(password), salt_verification, SALT_SIZE, PBKDF2_ITERATIONS, derived_verification_key, AES_KEY_SIZE);
 
     // Hash the derived verification key
@@ -1543,28 +1556,19 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_seed_with_sw(SEED seed, const int
     if (dogecoin_mem_cmp_ct(stored_verification_key_hash, derived_verification_key_hash, SHA512_DIGEST_LENGTH) != 0)
     {
         fprintf(stderr, "ERROR: Incorrect password.\n");
-        fclose(fp);
-        dogecoin_mem_zero(password, strlen(password));
-        dogecoin_free(password);
-        return false;
+        goto cleanup;
     }
 
     // Derive the encryption key from the password and encryption salt using PBKDF2
-    uint8_t encryption_key[AES_KEY_SIZE];
     pbkdf2_hmac_sha256((const uint8_t*)password, strlen(password), salt_encryption, SALT_SIZE, PBKDF2_ITERATIONS, encryption_key, AES_KEY_SIZE);
-
-    // Clear the password
-    dogecoin_mem_zero(password, strlen(password));
-    dogecoin_free(password);
 
     // Read the encrypted seed from the file or blob
     size_t encrypted_size = ENCRYPTED_SEED_SIZE;
-    uint8_t* encrypted_seed = malloc(encrypted_size);
+    encrypted_seed = malloc(encrypted_size);
     if (!encrypted_seed)
     {
         fprintf(stderr, "ERROR: Memory allocation failed.\n");
-        fclose(fp);
-        return false;
+        goto cleanup;
     }
 
     if (fp != NULL)
@@ -1572,12 +1576,8 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_seed_with_sw(SEED seed, const int
         if (fread(encrypted_seed, 1, encrypted_size, fp) != encrypted_size)
         {
             fprintf(stderr, "ERROR: Failed to read encrypted seed from file.\n");
-            fclose(fp);
-            dogecoin_free(encrypted_seed);
-            return false;
+            goto cleanup;
         }
-
-        fclose(fp);
     }
     else
     {
@@ -1587,15 +1587,33 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_seed_with_sw(SEED seed, const int
     // Decrypt the seed using AES
     dogecoin_bool padding_used = false;
     size_t decrypted_actual_size = aes256_cbc_decrypt(encryption_key, iv, encrypted_seed, encrypted_size, padding_used, seed);
-    dogecoin_free(encrypted_seed);
 
     if (decrypted_actual_size == 0)
     {
         fprintf(stderr, "ERROR: AES decryption failed.\n");
-        return false;
+        goto cleanup;
     }
 
-    return true;
+    result = true;
+
+cleanup:
+    // Scrub the PBKDF2-derived key material before returning (CWE-226).
+    dogecoin_mem_zero(derived_verification_key, sizeof(derived_verification_key));
+    dogecoin_mem_zero(encryption_key, sizeof(encryption_key));
+    if (password)
+    {
+        dogecoin_mem_zero(password, strlen(password));
+        dogecoin_free(password);
+    }
+    if (encrypted_seed)
+    {
+        dogecoin_free(encrypted_seed);
+    }
+    if (fp)
+    {
+        fclose(fp);
+    }
+    return result;
 #else
     (void) seed;
     (void) file_num;

--- a/src/seal.c
+++ b/src/seal.c
@@ -3648,6 +3648,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw_to_yubikey(const SEE
     {
         fprintf(stderr, "ERROR: Failed to decode management key.\n");
         dogecoin_mem_zero(mgm_key, strlen(mgm_key));
+        dogecoin_mem_zero(binary_mgm_key, sizeof(binary_mgm_key));
         dogecoin_free(mgm_key);
         ykpiv_done(state);
         return false;
@@ -3666,6 +3667,9 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_encrypt_seed_with_sw_to_yubikey(const SEE
 
     dogecoin_mem_zero(mgm_key, strlen(mgm_key));
     dogecoin_free(mgm_key);
+    // The decoded management key is dead after ykpiv_authenticate; scrub it so
+    // it does not linger on the stack through the save/return paths (CWE-226).
+    dogecoin_mem_zero(binary_mgm_key, sizeof(binary_mgm_key));
 
     // Write the encrypted blob directly to the YubiKey using the defined tag
     if (ykpiv_save_object(state, SEED_DATA_TAG(file_num), encrypted_blob, encrypted_blob_size) != YKPIV_OK)
@@ -3716,10 +3720,14 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_seed_with_sw_from_yubikey(SEED se
     {
         fprintf(stderr, "ERROR: Incorrect PIN. Tries left: %d\n", tries);
         ykpiv_done(state);
+        if (pin) dogecoin_mem_zero(pin, strlen(pin));
         dogecoin_free(pin);
         return false;
     }
 
+    // The PIN is dead after ykpiv_verify; scrub it before releasing the
+    // getpass() buffer back to the allocator (CWE-226).
+    if (pin) dogecoin_mem_zero(pin, strlen(pin));
     dogecoin_free(pin);
 
     // Retrieve the encrypted blob from the YubiKey
@@ -3789,6 +3797,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw_to_yubike
     {
         fprintf(stderr, "ERROR: Failed to decode management key.\n");
         dogecoin_mem_zero(mgm_key, strlen(mgm_key));
+        dogecoin_mem_zero(binary_mgm_key, sizeof(binary_mgm_key));
         dogecoin_free(mgm_key);
         ykpiv_done(state);
         return false;
@@ -3807,6 +3816,9 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw_to_yubike
 
     dogecoin_mem_zero(mgm_key, strlen(mgm_key));
     dogecoin_free(mgm_key);
+    // The decoded management key is dead after ykpiv_authenticate; scrub it so
+    // it does not linger on the stack through the save/return paths (CWE-226).
+    dogecoin_mem_zero(binary_mgm_key, sizeof(binary_mgm_key));
 
     // Write the encrypted blob directly to the YubiKey using the defined tag
     if (ykpiv_save_object(state, HDNODE_DATA_TAG(file_num), encrypted_blob, encrypted_blob_size) != YKPIV_OK)
@@ -3857,10 +3869,14 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_hdnode_with_sw_from_yubikey(dogec
     {
         fprintf(stderr, "ERROR: Incorrect PIN. Tries left: %d\n", tries);
         ykpiv_done(state);
+        if (pin) dogecoin_mem_zero(pin, strlen(pin));
         dogecoin_free(pin);
         return false;
     }
 
+    // The PIN is dead after ykpiv_verify; scrub it before releasing the
+    // getpass() buffer back to the allocator (CWE-226).
+    if (pin) dogecoin_mem_zero(pin, strlen(pin));
     dogecoin_free(pin);
 
     // Retrieve the encrypted blob from the YubiKey
@@ -3933,6 +3949,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw_to_yubi
     {
         fprintf(stderr, "ERROR: Failed to decode management key.\n");
         dogecoin_mem_zero(mgm_key, strlen(mgm_key));
+        dogecoin_mem_zero(binary_mgm_key, sizeof(binary_mgm_key));
         dogecoin_free(mgm_key);
         ykpiv_done(state);
         return false;
@@ -3951,6 +3968,9 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw_to_yubi
 
     dogecoin_mem_zero(mgm_key, strlen(mgm_key));
     dogecoin_free(mgm_key);
+    // The decoded management key is dead after ykpiv_authenticate; scrub it so
+    // it does not linger on the stack through the save/return paths (CWE-226).
+    dogecoin_mem_zero(binary_mgm_key, sizeof(binary_mgm_key));
 
     // Write the encrypted blob directly to the YubiKey using the defined tag
     if (ykpiv_save_object(state, MNEMONIC_DATA_TAG(file_num), encrypted_blob, encrypted_blob_size) != YKPIV_OK)
@@ -4001,10 +4021,14 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_mnemonic_with_sw_from_yubikey(MNE
     {
         fprintf(stderr, "ERROR: Incorrect PIN. Tries left: %d\n", tries);
         ykpiv_done(state);
+        if (pin) dogecoin_mem_zero(pin, strlen(pin));
         dogecoin_free(pin);
         return false;
     }
 
+    // The PIN is dead after ykpiv_verify; scrub it before releasing the
+    // getpass() buffer back to the allocator (CWE-226).
+    if (pin) dogecoin_mem_zero(pin, strlen(pin));
     dogecoin_free(pin);
 
     // Retrieve the encrypted blob from the YubiKey

--- a/src/seal.c
+++ b/src/seal.c
@@ -630,6 +630,9 @@ static dogecoin_bool linux_tpm_encrypt_blob(const uint8_t* in, size_t in_size, c
                               &scheme,
                               NULL,
                               &cipher);
+    // Scrub the plaintext copy: Esys_RSA_Encrypt has consumed it and `plain`
+    // is not referenced on any subsequent path (success or error) (CWE-226).
+    dogecoin_mem_zero(&plain, sizeof(plain));
     if (result != TSS2_RC_SUCCESS) {
         dogecoin_mem_zero(&authValuePrimary, sizeof(authValuePrimary));
         Esys_FlushContext(context, keyHandle);
@@ -837,6 +840,12 @@ static dogecoin_bool linux_tpm_decrypt_blob(uint8_t* out, size_t out_size, const
 
     result = Esys_RSA_Decrypt(context, keyHandle, ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE, &cipher, &scheme, &label, &plain);
     if (result != TSS2_RC_SUCCESS || plain == NULL || plain->size > out_size) {
+        // On the size-overflow branch the decrypt succeeded, so `plain` holds
+        // recovered plaintext; scrub it before Esys_Free returns it to the heap
+        // allocator (CWE-226). tpm_cleanup/Esys_Free do not zero.
+        if (plain != NULL) {
+            dogecoin_mem_zero(plain->buffer, sizeof(plain->buffer));
+        }
         tpm_cleanup(NULL, plain, TPM_CLEANUP_SENTINEL);
         Esys_TR_Close(context, &keyHandle);
         tpm_cleanup(&context, TPM_CLEANUP_SENTINEL);
@@ -847,6 +856,8 @@ static dogecoin_bool linux_tpm_decrypt_blob(uint8_t* out, size_t out_size, const
     if (actual_size) {
         *actual_size = plain->size;
     }
+    // Scrub the recovered plaintext before freeing the ESAPI buffer (CWE-226).
+    dogecoin_mem_zero(plain->buffer, sizeof(plain->buffer));
     tpm_cleanup(NULL, plain, TPM_CLEANUP_SENTINEL);
     Esys_TR_Close(context, &keyHandle);
     tpm_cleanup(&context, TPM_CLEANUP_SENTINEL);

--- a/src/seal.c
+++ b/src/seal.c
@@ -2195,41 +2195,38 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_
 
     // Generate a random IV for AES encryption
     uint8_t iv[AES_IV_SIZE];
+    SEED seed = {0};
+    uint8_t* encrypted_data = NULL;
+    dogecoin_bool result = false;
     if (!dogecoin_random_bytes(iv, sizeof(iv), 1))
     {
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
 
     // Derive the HD node from the seed
-    SEED seed = {0};
     if (!dogecoin_random_bytes(seed, sizeof(seed), 1))
     {
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
     dogecoin_hdnode_from_seed(seed, sizeof(seed), out);
 
     // Encrypt the HD node with AES
     size_t encrypted_size = sizeof(dogecoin_hdnode);
     dogecoin_bool padding_used = false;
-    uint8_t* encrypted_data = malloc(encrypted_size);
+    encrypted_data = malloc(encrypted_size);
     if (!encrypted_data)
     {
         fprintf(stderr, "ERROR: Memory allocation failed.\n");
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
 
     size_t encrypted_actual_size = aes256_cbc_encrypt(encryption_key, iv, (uint8_t*)out, encrypted_size, padding_used, encrypted_data);
     if (encrypted_actual_size == 0)
     {
         fprintf(stderr, "ERROR: AES encryption failed.\n");
-        dogecoin_free(encrypted_data);
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
 
     // Write the IV, salts, verification key hash, and encrypted HD node to the file
@@ -2241,6 +2238,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_
         fwrite(verification_key_hash, 1, sizeof(verification_key_hash), fp);
         fwrite(encrypted_data, 1, encrypted_actual_size, fp);
         fclose(fp);
+        fp = NULL;
     }
     else if (encrypted_blob_out != NULL && encrypted_blob_size != NULL)
     {
@@ -2252,10 +2250,22 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_hdnode_encrypt_with_sw(dogecoin_
         *encrypted_blob_size = sizeof(iv) + SALT_SIZE + SALT_SIZE + sizeof(verification_key_hash) + encrypted_actual_size;
     }
 
-    // Free the encrypted data
-    dogecoin_free(encrypted_data);
+    result = true;
 
-    return true;
+cleanup:
+    // Scrub the PBKDF2-derived keys and the intermediate seed before returning (CWE-226).
+    dogecoin_mem_zero(encryption_key, sizeof(encryption_key));
+    dogecoin_mem_zero(verification_key, sizeof(verification_key));
+    dogecoin_mem_zero(seed, sizeof(seed));
+    if (encrypted_data)
+    {
+        dogecoin_free(encrypted_data);
+    }
+    if (fp)
+    {
+        fclose(fp);
+    }
+    return result;
 #else
     (void) out;
     (void) file_num;
@@ -2398,6 +2408,9 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_hdnode_with_sw(dogecoin_hdnode* o
 
     // Derive the verification key from the password and verification salt using PBKDF2
     uint8_t derived_verification_key[AES_KEY_SIZE];
+    uint8_t encryption_key[AES_KEY_SIZE];
+    uint8_t* encrypted_data = NULL;
+    dogecoin_bool result = false;
     pbkdf2_hmac_sha256((const uint8_t*)password, strlen(password), salt_verification, SALT_SIZE, PBKDF2_ITERATIONS, derived_verification_key, AES_KEY_SIZE);
 
     // Hash the derived verification key
@@ -2408,28 +2421,19 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_hdnode_with_sw(dogecoin_hdnode* o
     if (dogecoin_mem_cmp_ct(stored_verification_key_hash, derived_verification_key_hash, SHA512_DIGEST_LENGTH) != 0)
     {
         fprintf(stderr, "ERROR: Incorrect password.\n");
-        fclose(fp);
-        dogecoin_mem_zero(password, strlen(password));
-        dogecoin_free(password);
-        return false;
+        goto cleanup;
     }
 
     // Derive the encryption key from the password and encryption salt using PBKDF2
-    uint8_t encryption_key[AES_KEY_SIZE];
     pbkdf2_hmac_sha256((const uint8_t*)password, strlen(password), salt_encryption, SALT_SIZE, PBKDF2_ITERATIONS, encryption_key, AES_KEY_SIZE);
-
-    // Clear the password
-    dogecoin_mem_zero(password, strlen(password));
-    dogecoin_free(password);
 
     // Read the encrypted HD node from the file or blob
     size_t encrypted_size = sizeof(dogecoin_hdnode);
-    uint8_t* encrypted_data = malloc(encrypted_size);
+    encrypted_data = malloc(encrypted_size);
     if (!encrypted_data)
     {
         fprintf(stderr, "ERROR: Memory allocation failed.\n");
-        fclose(fp);
-        return false;
+        goto cleanup;
     }
 
     if (fp != NULL)
@@ -2437,12 +2441,8 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_hdnode_with_sw(dogecoin_hdnode* o
         if (fread(encrypted_data, 1, encrypted_size, fp) != encrypted_size)
         {
             fprintf(stderr, "ERROR: Failed to read encrypted HD node from file.\n");
-            fclose(fp);
-            dogecoin_free(encrypted_data);
-            return false;
+            goto cleanup;
         }
-
-        fclose(fp);
     }
     else
     {
@@ -2452,15 +2452,33 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_hdnode_with_sw(dogecoin_hdnode* o
     // Decrypt the HD node with software decryption (AES)
     dogecoin_bool padding_used = false;
     size_t decrypted_actual_size = aes256_cbc_decrypt(encryption_key, iv, encrypted_data, encrypted_size, padding_used, (uint8_t*)out);
-    dogecoin_free(encrypted_data);
 
     if (decrypted_actual_size == 0)
     {
         fprintf(stderr, "ERROR: AES decryption failed.\n");
-        return false;
+        goto cleanup;
     }
 
-    return true;
+    result = true;
+
+cleanup:
+    // Scrub the PBKDF2-derived key material before returning (CWE-226).
+    dogecoin_mem_zero(derived_verification_key, sizeof(derived_verification_key));
+    dogecoin_mem_zero(encryption_key, sizeof(encryption_key));
+    if (password)
+    {
+        dogecoin_mem_zero(password, strlen(password));
+        dogecoin_free(password);
+    }
+    if (encrypted_data)
+    {
+        dogecoin_free(encrypted_data);
+    }
+    if (fp)
+    {
+        fclose(fp);
+    }
+    return result;
 #else
     (void) out;
     (void) file_num;
@@ -3059,13 +3077,14 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
     dogecoin_free(password);
 
     // Generate the BIP-39 mnemonic
+    uint8_t* encrypted_data = NULL;
+    dogecoin_bool result = false;
     size_t mnemonicSize = 0;
     int mnemonicResult = dogecoin_generate_mnemonic("256", lang, space, NULL, words, NULL, &mnemonicSize, mnemonic);
     if (mnemonicResult == -1)
     {
         fprintf(stderr, "ERROR: Failed to generate mnemonic\n");
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
 
     // Encrypt the mnemonic with AES
@@ -3073,18 +3092,16 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
     if (!dogecoin_random_bytes(iv, sizeof(iv), 1))
     {
         fprintf(stderr, "ERROR: Failed to generate random bytes.\n");
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
 
     size_t encrypted_size = ENCRYPTED_MNEMONIC_SIZE;
     dogecoin_bool padding_used = false;
-    uint8_t* encrypted_data = malloc(encrypted_size);
+    encrypted_data = malloc(encrypted_size);
     if (!encrypted_data)
     {
         fprintf(stderr, "ERROR: Memory allocation failed.\n");
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
     memset(encrypted_data, 0, encrypted_size);
 
@@ -3092,9 +3109,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
     if (encrypted_actual_size == 0)
     {
         fprintf(stderr, "ERROR: AES encryption failed.\n");
-        dogecoin_free(encrypted_data);
-        fp ? fclose(fp) : 0;
-        return false;
+        goto cleanup;
     }
 
     // Write the IV, salts, verification key hash, and encrypted mnemonic to the file
@@ -3106,6 +3121,7 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
         fwrite(verification_key_hash, 1, sizeof(verification_key_hash), fp);
         fwrite(encrypted_data, 1, encrypted_actual_size, fp);
         fclose(fp);
+        fp = NULL;
     }
     else if (encrypted_blob_out != NULL && encrypted_blob_size != NULL)
     {
@@ -3117,10 +3133,21 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_generate_mnemonic_encrypt_with_sw(MNEMONI
         *encrypted_blob_size = sizeof(iv) + SALT_SIZE + SALT_SIZE + sizeof(verification_key_hash) + encrypted_actual_size;
     }
 
-    // Free the encrypted data
-    dogecoin_free(encrypted_data);
+    result = true;
 
-    return true;
+cleanup:
+    // Scrub the PBKDF2-derived key material before returning (CWE-226).
+    dogecoin_mem_zero(encryption_key, sizeof(encryption_key));
+    dogecoin_mem_zero(verification_key, sizeof(verification_key));
+    if (encrypted_data)
+    {
+        dogecoin_free(encrypted_data);
+    }
+    if (fp)
+    {
+        fclose(fp);
+    }
+    return result;
 #else
     (void) mnemonic;
     (void) file_num;
@@ -3250,6 +3277,9 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_mnemonic_with_sw(MNEMONIC mnemoni
 
     // Derive the verification key from the password and verification salt using PBKDF2
     uint8_t derived_verification_key[AES_KEY_SIZE];
+    uint8_t encryption_key[AES_KEY_SIZE];
+    uint8_t* encrypted_data = NULL;
+    dogecoin_bool result = false;
     pbkdf2_hmac_sha256((const uint8_t*)password, strlen(password), salt_verification, SALT_SIZE, PBKDF2_ITERATIONS, derived_verification_key, AES_KEY_SIZE);
 
     // Hash the derived verification key
@@ -3260,28 +3290,19 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_mnemonic_with_sw(MNEMONIC mnemoni
     if (dogecoin_mem_cmp_ct(stored_verification_key_hash, derived_verification_key_hash, SHA512_DIGEST_LENGTH) != 0)
     {
         fprintf(stderr, "ERROR: Incorrect password.\n");
-        fclose(fp);
-        dogecoin_mem_zero(password, strlen(password));
-        dogecoin_free(password);
-        return false;
+        goto cleanup;
     }
 
     // Derive the encryption key from the password and encryption salt using PBKDF2
-    uint8_t encryption_key[AES_KEY_SIZE];
     pbkdf2_hmac_sha256((const uint8_t*)password, strlen(password), salt_encryption, SALT_SIZE, PBKDF2_ITERATIONS, encryption_key, AES_KEY_SIZE);
-
-    // Clear the password
-    dogecoin_mem_zero(password, strlen(password));
-    dogecoin_free(password);
 
     // Read the encrypted mnemonic from the file or blob
     size_t encrypted_size = ENCRYPTED_MNEMONIC_SIZE;
-    uint8_t* encrypted_data = malloc(encrypted_size);
+    encrypted_data = malloc(encrypted_size);
     if (!encrypted_data)
     {
         fprintf(stderr, "ERROR: Memory allocation failed.\n");
-        fclose(fp);
-        return false;
+        goto cleanup;
     }
 
     if (fp != NULL)
@@ -3289,12 +3310,8 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_mnemonic_with_sw(MNEMONIC mnemoni
         if (fread(encrypted_data, 1, encrypted_size, fp) != encrypted_size)
         {
             fprintf(stderr, "ERROR: Failed to read encrypted mnemonic from file.\n");
-            fclose(fp);
-            dogecoin_free(encrypted_data);
-            return false;
+            goto cleanup;
         }
-
-        fclose(fp);
     }
     else
     {
@@ -3304,15 +3321,33 @@ LIBDOGECOIN_API dogecoin_bool dogecoin_decrypt_mnemonic_with_sw(MNEMONIC mnemoni
     // Decrypt the mnemonic with AES
     dogecoin_bool padding_used = false;
     size_t decrypted_actual_size = aes256_cbc_decrypt(encryption_key, iv, encrypted_data, encrypted_size, padding_used, (uint8_t*)mnemonic);
-    dogecoin_free(encrypted_data);
 
     if (decrypted_actual_size == 0)
     {
         fprintf(stderr, "ERROR: AES decryption failed.\n");
-        return false;
+        goto cleanup;
     }
 
-    return true;
+    result = true;
+
+cleanup:
+    // Scrub the PBKDF2-derived key material before returning (CWE-226).
+    dogecoin_mem_zero(derived_verification_key, sizeof(derived_verification_key));
+    dogecoin_mem_zero(encryption_key, sizeof(encryption_key));
+    if (password)
+    {
+        dogecoin_mem_zero(password, strlen(password));
+        dogecoin_free(password);
+    }
+    if (encrypted_data)
+    {
+        dogecoin_free(encrypted_data);
+    }
+    if (fp)
+    {
+        fclose(fp);
+    }
+    return result;
 #else
     (void) mnemonic;
     (void) file_num;


### PR DESCRIPTION
## Summary

Key-material-lifetime audit of `src/seal.c` (CWE-226). The seal module scrubbed the user *password* on every path but never zeroed the AES keys **derived** from it, nor the plaintext handled by the hardware backends — defeating the point, since those are the values that actually protect the encrypted seed. This closes every zeroization gap across all three backends: software, Linux TPM (TSS2), and YubiKey.

Four commits, most to least by risk:

1. **Software seed path** — `dogecoin_encrypt_seed_with_sw` / `dogecoin_decrypt_seed_with_sw`: scrub `encryption_key`, `verification_key`, `derived_verification_key`. Each function had 4+ returns after key derivation, so every post-derivation exit is consolidated through a single `goto cleanup` block rather than scattering per-return scrubs (partial per-return scrubbing is exactly how the original omission happened).
2. **Software hdnode/mnemonic paths** — same fix + the intermediate BIP32 `SEED` in `generate_hdnode_encrypt_with_sw` (freshly generated secret left on the stack).
3. **Linux TSS2 TPM** — `linux_tpm_encrypt_blob` leaked the raw plaintext copy (`TPM2B_PUBLIC_KEY_RSA plain`); `linux_tpm_decrypt_blob` returned the decrypted plaintext (`plain->buffer`) to the heap allocator in the clear (`Esys_Free` does not zero). Both scrubbed now.
4. **YubiKey** — `binary_mgm_key` (decoded PIV management key) leaked on the encrypt success/save paths; the `pin` was `free()`d without zeroing on both decrypt paths. Both scrubbed now.

The `goto cleanup` refactor is **zeroization-only and control-flow-equivalent**. It incidentally removes two latent bugs on error paths: a double-`free` of `encrypted_seed` in the software seed decrypt, and an `fclose(NULL)` in the blob-mode wrong-password decrypt.

## Relationship to other PRs

- **#343 (`seal: remove redundant free in software seed decryption`)** fixes the same double-`free` this PR's `goto cleanup` also removes. If #343 merges first there will be a trivial conflict in that region; happy to rebase, or #343 can be closed in favour of this broader change — maintainer's call.
- Windows NCrypt (`USE_TPM2`) was reviewed and needs no change (it never materializes a software key or intermediate plaintext copy). No PKCS11 backend exists.

## Testing

- `clang -O2` clean build in all three configs (default, `--enable-tss2`, `--enable-yubikey`); no new warnings on `seal.c`.
- **Software**: `test_tpm()` exercises seed/hdnode/mnemonic encrypt→decrypt round-trips (file + blob) — all pass.
- **Linux TPM**: validated against a live `swtpm` simulator — seed/hdnode/mnemonic round-trips pass; a direct probe recovered a fixed 64-byte seed byte-for-byte.
- **YubiKey**: validated against a physical YubiKey 5 (PIV) — encrypt→decrypt round-trip recovers the seed byte-for-byte.
- All scrubs use `dogecoin_mem_zero` (volatile, non-elidable) and are confirmed present in the `-O2` objects.
- Self-review (line-by-line + removed-behavior audit) found no correctness or behavioral-equivalence defects.
