### PR TITLE
docs: security assurance case, audit plan, and sanitizer sweep

### DIFF
--- a/contrib/assurance/sanitizer_sweep.sh
+++ b/contrib/assurance/sanitizer_sweep.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# sanitizer_sweep.sh — reproducible ASan+UBSan sweep of the libdogecoin test
+# suite, for the security assurance case.
+#
+# Runs the full `tests` binary under sanitizers over a clean checkout and
+# records every finding. The intent is documentation, not fixing: it enumerates
+# which sanitizer faults are reachable on the target branch so they can be tied
+# to their fix PRs.
+#
+# Two passes are run because the two sanitizers recover differently:
+#   * UBSan pass: undefined behavior is recoverable, so a single run enumerates
+#     ALL reachable UB sites (the process continues past each).
+#   * ASan pass: a real memory fault is not recoverable; ASan halts at the first
+#     one. The pass therefore reports the first-reached memory error. If that is
+#     fixed, a re-run reveals the next. This is noted in the output so a reader
+#     does not mistake "one ASan finding" for "only one exists."
+#
+# Usage:   contrib/assurance/sanitizer_sweep.sh [output_log]
+# Env:     JOBS (default nproc)
+# Requires: clang, autotools, libevent-dev. Run from a clean tree.
+# Exit 0 if the sweep completed; findings are data, not errors.
+
+set -uo pipefail
+
+OUT="${1:-sanitizer_sweep.log}"
+JOBS="${JOBS:-$(nproc)}"
+
+build_and_run() {
+    local label="$1" san_cflags="$2" san_ldflags="$3"
+    echo "[*] [$label] configuring..." | tee -a "$OUT"
+    make distclean >/dev/null 2>&1
+    ./autogen.sh >/dev/null 2>&1
+    ./configure CC=clang CXX=clang++ \
+        CFLAGS="$san_cflags -fno-omit-frame-pointer -g -O1" \
+        CXXFLAGS="$san_cflags -fno-omit-frame-pointer -g -O1" \
+        LDFLAGS="$san_ldflags" \
+        --enable-static --disable-shared >/dev/null 2>&1
+    make -C src/secp256k1 >/dev/null 2>&1
+    echo "[*] [$label] building test suite..." | tee -a "$OUT"
+    if ! make tests -j"$JOBS" >/dev/null 2>&1; then
+        echo "[!] [$label] build failed" | tee -a "$OUT"; return 1
+    fi
+    echo "[*] [$label] running tests..." | tee -a "$OUT"
+    echo "----- BEGIN $label OUTPUT -----" >>"$OUT"
+    ./tests >>"$OUT" 2>&1
+    echo "----- END $label OUTPUT (test exit $?) -----" >>"$OUT"
+}
+
+{
+  echo "=== libdogecoin sanitizer sweep ==="
+  echo "date:      $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "commit:    $(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  echo "branch:    $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+  echo "clang:     $(clang --version | head -1)"
+  echo "==================================="
+  echo
+} | tee "$OUT"
+
+# Pass 1: UBSan (recoverable) — enumerates all UB sites in one run.
+export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0:report_error_type=1"
+build_and_run "UBSAN" "-fsanitize=undefined" "-fsanitize=undefined"
+
+# Pass 2: ASan (+leaks). Halts at first memory fault by nature.
+export ASAN_OPTIONS="abort_on_error=0:halt_on_error=0:detect_leaks=1"
+build_and_run "ASAN" "-fsanitize=address" "-fsanitize=address"
+
+{
+  echo
+  echo "=== sweep summary ==="
+  printf 'UBSan runtime errors:    %s\n' "$(grep -c 'runtime error:' "$OUT")"
+  printf 'AddressSanitizer errors: %s\n' "$(grep -c 'ERROR: AddressSanitizer' "$OUT")"
+  printf 'LeakSanitizer errors:    %s\n' "$(grep -c 'ERROR: LeakSanitizer' "$OUT")"
+  echo
+  echo "distinct finding messages:"
+  grep -E 'runtime error:|ERROR: AddressSanitizer|ERROR: LeakSanitizer' "$OUT" \
+    | sed -E 's/^.*(runtime error:|ERROR: (AddressSanitizer|LeakSanitizer))/\1/' \
+    | sort | uniq -c | sort -rn
+  echo
+  echo "NOTE: ASan halts at the first unrecovered memory fault; if one is shown,"
+  echo "re-run after fixing it to reveal any subsequent memory findings."
+  echo "====================="
+} | tee -a "$OUT"
+
+echo "[*] sweep complete — log at ${OUT}"

--- a/doc/assurance/SECURITY_ASSURANCE.md
+++ b/doc/assurance/SECURITY_ASSURANCE.md
@@ -1,0 +1,260 @@
+# libdogecoin Security Assurance Case
+
+**Status:** Living document — draft
+**Scope target:** `0.1.5-dev` and derived release branches
+**Companion:** `libdogecoin_audit_plan.md` (the plan this executes)
+**Last updated:** see git history
+
+---
+
+## 1. What this document is
+
+This is the assurance case for the libdogecoin security audit: a single place
+that states what the audit defends against, how the codebase was exercised
+against it, what was found and where each finding is being fixed, and what is
+explicitly out of scope. It is written to be legible to an outside reviewer —
+someone who was not in the room — so that "libdogecoin was audited" can be
+substantiated rather than asserted.
+
+It is deliberately *not* a claim that libdogecoin is free of vulnerabilities.
+For a C library handling key material that is not an achievable or honest
+claim. The claim it supports is narrower and defensible: a declared threat
+model was systematically exercised with complementary methods, findings were
+tracked to disposition, and the limits of the effort are stated.
+
+This is a living document. As the audit PRs merge and later phases run, the
+tables below move from "open" to "merged" and from "in progress" to "complete."
+
+## 2. Threat model and security tiers
+
+The tiers below are the security level of difficulty the audit commits to.
+Publishing Tier 3 — what is *not* defended — is part of the assurance case,
+not an omission from it.
+
+### Tier 1 — In scope, must defend (release-blocking)
+
+- Memory-safety violations reachable from untrusted input: network messages,
+  serialized transactions/PSBTs, BIP38-encrypted keys, base58/bech32 strings,
+  imported wallet data. (CWE-119/125/787, CWE-190/191, CWE-416/415)
+- Undefined behavior in consensus-adjacent or crypto paths: signed overflow,
+  misaligned loads, shift UB. (CWE-758, CWE-190)
+- Secret-dependent timing in key handling: privkey operations, BIP38 decrypt,
+  HMAC/scalar comparisons. (CWE-208, CWE-385)
+- Failure to zeroize key material, or key material reachable after free.
+  (CWE-226, CWE-244, CWE-416)
+- Injection/parsing confusion in string handling: format strings, unchecked
+  lengths, magic-number assumptions. (CWE-134, CWE-131)
+
+### Tier 2 — In scope, best-effort (documented, fixed opportunistically)
+
+- Resource exhaustion from adversarial input: allocation bombs, unbounded
+  counts driving allocation. (CWE-400, CWE-789)
+- API-misuse hazards: functions safe only under undocumented preconditions.
+- Thread-safety races beyond the registry-mutex and stateless work.
+  (CWE-362)
+
+### Tier 3 — Explicitly out of scope (declared, not defended)
+
+- Microarchitectural attacks (Spectre-class; cache attacks beyond
+  straightforward secret-indexed lookups).
+- Fault injection / glitching / physical attacks.
+- Compromised toolchain or build environment (covered separately by
+  reproducible-build work, not this audit).
+- Side channels in language bindings or downstream consumers (bindings
+  audited only at the FFI boundary).
+
+## 3. Methods applied
+
+Each method maps to the CWE classes it credibly covers and the artifact it
+produces. Status reflects the current state, not the plan.
+
+| Method | Tooling | CWE coverage | Artifact | Status |
+|---|---|---|---|---|
+| Static analysis (dataflow) | CodeQL `security-extended` | CWE Top 25 | Security-tab results, per-PR | Landing (PR #359) |
+| Static analysis (pattern) | cppcheck `--enable=all`, CWE-tagged | 119/125/787, 190, 401/415/416, 476 | XML report artifact + triage | Landing (PR #359) |
+| Static analysis (semantic) | clang-tidy `cert-*`,`bugprone-*`,`clang-analyzer-*` | 190, 197, 758, 476, 686 | Advisory report artifact | Landing (PR #359) |
+| Dynamic (sanitizers) | ASan/UBSan over full test suite | 119/125/787, 190, 758, 457 | Clean-run logs per branch | In progress; sweep reproduces #324/#325 on `0.1.5-dev` |
+| Sanitizer CI gate | `make check` under ASan+UBSan | as above, continuous | Gating CI job | Open, draft (PR #328) |
+| Fuzzing | libFuzzer harnesses (tx, block, wtx, logdb, protocol, PSBT, BIP38) | 119/125/787, 400, parser-state confusion | Corpora, crash triage | Infra open (PR #351); PSBT integrated (#357); BIP38 harness pending #351+#277 |
+| Coverage measurement | llvm-cov over fuzz targets | validates fuzzing reach | Reachability report | Open (PR #360) |
+| Constant-time verification | (planned) dudect / binary-level | 208, 385 | Per-function CT verdict | Not yet started |
+| Hand audit | Line-by-line of high-stakes paths | logic flaws tools miss (131, 640-class) | Signed-off review notes | Ongoing (BIP38/sweep, PSBT, key paths) |
+
+Two methods are worth calling out. **Coverage measurement** (PR #360) is what
+turns "the fuzzers ran" into "here is the attack surface they exercise": the
+BIP38 harness, for example, was shown by replay to reach base58 decode but not
+the scrypt/AES stages until a valid-key seed corpus was added, after which
+`ctaes.c` reached ~84% and the EC-multiplied decrypt branch went from zero
+coverage to reached. **Constant-time verification** is declared but not yet
+started — source-level review can flag likely secret-dependent branches, but
+confirming the compiled binary is constant-time under the release toolchain is
+outstanding work, and this document does not claim it.
+
+## 4. Findings and disposition
+
+The audit surfaced findings across memory safety, undefined behavior,
+resource exhaustion, and correctness. Each is tracked to a fix PR against
+`0.1.5-dev`. Disposition labels follow the audit plan: **confirmed** (fix
+filed), with false-positive / out-of-scope / hardening handled in the
+per-tool triage backlogs.
+
+### Memory safety (Tier 1)
+
+| Finding | Location | PR | Notes |
+|---|---|---|---|
+| OOB write in `hmac_sha256_prepare` | `src/sha2.c` | #324 | Independently reproduced by ASan sweep on clean `0.1.5-dev`; reached via block-header scrypt hash |
+| Heap overflow in `sign_raw_transaction` in-place write | `src/transaction` | #331 | |
+| Stack overflow + unbounded alloc in logdb record deser | `src/logdb` | #345 | |
+| Double-free in software seed decryption | `src/seal.c` | #343 | |
+| Registry/eviction fixes: never-reused ids, stop evicting live entries | map/eckey/utxo/registry | #333, #335, #336, #337 | #336 also stops leaking evicted live keys |
+
+### Undefined behavior (Tier 1)
+
+| Finding | Location | PR | Notes |
+|---|---|---|---|
+| Signed-overflow shift in big-endian word assembly | `src/bip32.c`, bip37 | #325 | Independently reproduced by UBSan sweep on clean `0.1.5-dev` (HD key derivation path) |
+| Unaligned word loads in `sha256_transform` | `src/sha2.c` | #326 | Independently reproduced by UBSan sweep (misaligned-pointer-use at `sha2.c:994`) |
+| Signed-overflow UB in bit assembly | `src/arith_uint256.c`, `src/jpeg.c` | #327 | Independently reproduced by UBSan sweep (invalid-shift-base at `arith_uint256.c:128`, `jpeg.c:220`) |
+| UB + count truncation in auxpow deserialization | `src/block.c` | #334 | |
+| Integer overflow in `cstr_alloc_min_sz` sizing | `src/cstr.c` | #344 | |
+
+**Function-type-mismatch UB (candidate — NEW, not covered by any open PR).**
+The sanitizer sweep surfaced six `function-type-mismatch` sites (CWE-686) that
+reconciliation against the full open-PR list confirms are **not** addressed by
+any existing audit PR: `spv.c:534/660/725` (header-db callbacks),
+`vector.c:82` (`elem_free_f`), `jpeg.c:413/446` (huff callbacks). Root cause is
+the generic-callback idiom (typed function stored in a `void(*)(void*)`-style
+field, called through the mismatched type). Real UB, provisionally low
+severity (works on target ABIs), portability/CFI hazard. Recommended as a
+single Tier-2 hardening PR. See `sanitizer_sweep_report.md` §3.
+
+### Resource exhaustion (Tier 2)
+
+| Finding | Location | PR | Notes |
+|---|---|---|---|
+| Unbounded getheaders locator allocation | `src/protocol.c` | #339 | Also observed as a bounded OOM by the protocol fuzz harness |
+| Unbounded OP_PUSHDATA allocation | `src/script.c` | #338 | In `copy_without_op_codeseperator` |
+| Unbounded transaction record length on disk load | `src/wallet` | #342 | |
+| Unbounded allocation in logdb record deser | `src/logdb` | #345 | Shares PR with the logdb stack-overflow fix |
+
+### Correctness / robustness (Tier 1/2)
+
+| Finding | Location | PR | Notes |
+|---|---|---|---|
+| Verify message payload checksum before dispatch | `src/net` | #341 | |
+| Dispatch only this message's payload to handlers | `src/net` | #340 | Message-boundary confusion |
+| Clean failure on malformed WIF in `sign_raw_transaction` | `src/transaction` | #332 | |
+| buffer-type + unterminated copy fix | such (`coin_amount`/`subtotal`) | #358 | |
+| PQC wrapper output-length assertions, reject tampered input | test/PQC | #348 | |
+| cmake: liboqs link, Raccoon-G test suite | build | #347, #346 | Build-system hardening |
+
+*Reconciled against `gh pr list` (authoritative). All PR numbers above are
+confirmed against branch names and titles as of this revision.*
+
+### Tooling and infrastructure
+
+| Item | PR | Status |
+|---|---|---|
+| Phase 0 static-analysis workflows (CodeQL filter fix + cppcheck + clang-tidy) | #359 | Approved, draft — pending un-draft/merge |
+| libFuzzer harness infrastructure | #351 | Approved, open |
+| Coverage reachability tooling | #360 | Open, stacked on #351 |
+| PSBT (BIP174) fuzz harness + fixes | #357 | Open |
+| ASAN+UBSAN CI gate | #328 | Open, draft |
+| PQC test assertions / cmake liboqs / raccoon-g build | #346, #347, #348 | Open |
+
+## 5. Independent corroboration
+
+The ASan/UBSan sweep of a clean `0.1.5-dev` checkout independently reproduced
+two findings that already have fix PRs:
+
+- The `hmac_sha256_prepare` OOB write (#324), reached through
+  `dogecoin_block_header_scrypt_hash` → pbkdf2 → hmac — i.e. from block
+  header validation, a consensus path.
+- The `bip32.c` fingerprint shift UB (#325), reached through HD key
+  derivation.
+
+This matters for the assurance case in two ways: it confirms the fixes address
+faults that are still live on the release branch (motivating their merge), and
+it demonstrates the dynamic-analysis method catches what the plan says it
+should. The sweep itself is reproducible from the documented ASan+UBSan build
+(`CC=clang CFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -g -O1"`,
+static build, full `tests` suite).
+
+## 6. Fuzzing reachability summary
+
+| Harness | Surface | Notable result |
+|---|---|---|
+| PSBT (BIP174) | serialized PSBT parsing | reproduced a heap overflow on pre-fix tree (200-byte write into 33-byte pubkey buffer) |
+| protocol | p2p message deserialization | surfaced the getheaders unbounded allocation (#339), bounded in CI via `-malloc_limit_mb` |
+| BIP38 (pending) | encrypted-key decrypt | seed corpus reaches scrypt (~53%) and AES/ctaes (~84%); EC-multiplied branch reached only after EC-key seed enrichment |
+
+The coverage tooling (#360) is what makes these numbers assurance evidence
+rather than anecdote: it reports which first-party source the harnesses
+actually reach, and its uncovered-priority output is what drives where the
+next harness or corpus investment goes. Known reachability gaps are recorded
+there rather than hidden.
+
+### BIP38 harness — completed campaign
+
+A 4-hour libFuzzer campaign (ASan+UBSan) from the EC-enriched seed corpus
+against the BIP38 decrypt harness completed **crash-clean**:
+
+- 329,171 executions over 14,401 s (~22 exec/s — scrypt-bound by design; each
+  surviving input runs the full KDF).
+- Final coverage `cov: 380, ft: 834, corp: 95`; 84 new units added during the
+  run. No crash, OOM, or timeout artifact; `slowest_unit_time_sec: 0`.
+- Coverage progression across runs: 84 (random input) → 346 (non-EC corpus,
+  overnight plateau) → 380 (EC-enriched corpus, this run). The gain past 346 is
+  attributable to the EC-multiplied seed enrichment reaching the
+  `bip38_decrypt_ec_multiplied_bytes` branch, which no mutation of non-EC seeds
+  could reach.
+
+This establishes a crash-clean baseline for the reachable BIP38 decrypt
+surface at the exercised coverage. It is a baseline, not a completeness claim:
+the intermediate-passphrase-code parser is not exercised by this harness (a
+separate harness would be required), and coverage of `bip38.c` remains partial
+per the #360 reachability report.
+
+## 7. Declared limits (what this assurance case does NOT establish)
+
+- **No constant-time guarantee.** CT verification is not yet done; timing side
+  channels in key handling are in-scope (Tier 1) but currently only
+  source-reviewed, not binary-verified.
+- **No Tier 3 coverage.** Microarchitectural, fault-injection, physical, and
+  toolchain-compromise attacks are out of scope by declaration.
+- **Bindings audited at the boundary only.** The Python/other bindings are
+  covered at the FFI surface, not internally.
+- **Coverage is not completeness.** Fuzzing reaches a measured subset of the
+  attack surface; files at low or zero coverage (per the #360 report) are not
+  claimed to be exercised.
+- **Findings inventory is a snapshot.** New findings may arise as later phases
+  (CT verification, deeper hand audit, longer fuzzing) run.
+
+## 8. Maintenance policy
+
+Once the tooling PRs merge, the following gate ongoing changes into
+`0.1.5-dev`:
+
+- CodeQL `security-extended` on every PR (fixed by #359 to actually run on
+  `0.1.5-dev`).
+- cppcheck gating on `error` severity; widening to `warning` after the initial
+  backlog is triaged.
+- clang-tidy advisory (report artifact, non-gating) until its baseline is
+  dispositioned.
+- ASan+UBSan `make check` gate once #328 lands.
+
+Every new suppression in the cppcheck baseline or clang-tidy config carries a
+one-line rationale; no finding is closed without a disposition label. Sanitizer
+and fuzzing sweeps are re-run on a cadence to be set by the team, with results
+appended to Section 5/6.
+
+## 9. Open items feeding the next revision
+
+- Un-draft and merge #359; confirm the first full-tree static-analysis run.
+- File the function-type-mismatch cluster (§4 UB) as a new Tier-2 hardening PR
+  — sweep-confirmed as not covered by any existing PR.
+- Merge the sanitizer sweep as a checked-in assurance artifact
+  (`contrib/assurance/sanitizer_sweep.sh` + report); decide on #328.
+- Land #351 → rebase #360 → open the BIP38 harness PR once #277 also lands.
+- Begin constant-time verification (dudect in CI + a one-time binary-level
+  pass on the release toolchain).

--- a/doc/assurance/SECURITY_ASSURANCE.md
+++ b/doc/assurance/SECURITY_ASSURANCE.md
@@ -92,7 +92,32 @@ fixed-vs-random secret input classes. Two primitives are verified constant-time
 copied; max |t| = 2.2 over 38M measurements) and BIP38's `bip38_mem_eq` (|t| =
 1.8 over 72M). A positive control that branches on the secret is flagged at
 |t| = 691, confirming the harness can detect a leak and the passes are real.
-Remaining secret-dependent paths beyond these two primitives are not yet
+
+A survey of the remaining secret-dependent comparison surface found that the
+library's CT coverage is **structurally more complete than two primitives
+suggests**, because the secret-gated comparisons in the codebase route through
+those verified primitives rather than through ad-hoc `memcmp`:
+
+- The seal verification-hash checks (`seal.c`, three sites) use
+  `dogecoin_mem_cmp_ct` — the verified primitive.
+- The BIP38 address-hash checks (`bip38.c`) use `bip38_mem_eq` — the verified
+  primitive.
+- Private-key validity checking delegates to `secp256k1_ec_seckey_verify`,
+  which is constant-time by upstream design.
+- The residual `memcmp` sites (base58 checksum compare, BIP38 magic-prefix
+  compare) operate on **public** values, not secrets, so they are not
+  CT-relevant even though `memcmp` is not itself constant-time.
+
+One path was examined and found **not cleanly verifiable by this method**:
+`dogecoin_base58_decode` has legitimate input-length- and magnitude-dependent
+loop counts, so a fixed-vs-random-*value* dudect comparison cannot isolate a
+value-dependent signal — a large deliberately-injected leak failed to move the
+t-statistic (the positive control did not fire), so no trustworthy verdict can
+be given by dudect here. Its threat-model exposure is low regardless (WIF
+decode is a local one-shot import, not an attacker-repeatable oracle), so it is
+recorded as a declared limitation rather than a verified pass or a known leak.
+Extending CT verification therefore means new *methods* for non-fixed-time
+operations, not more dudect comparison harnesses — the comparison surface is
 covered.
 
 ## 4. Findings and disposition
@@ -264,10 +289,14 @@ the same `#351`+`#277` base as the decrypt harness.
 
 ## 7. Declared limits (what this assurance case does NOT establish)
 
-- **Constant-time verification is partial.** Two core comparison primitives
-  are binary-verified constant-time at `-O2` (#365); other secret-dependent
-  paths (e.g. HMAC comparisons, base58/WIF handling of key bytes) are so far
-  only source-reviewed, not binary-verified.
+- **Constant-time verification is scoped, not absent.** Two core comparison
+  primitives are binary-verified constant-time at `-O2` (#365), and the
+  library's secret-gated comparisons route through them (seal and BIP38 hash
+  checks) or through secp256k1; the remaining `memcmp` sites compare public
+  values. What is *not* established: CT of non-fixed-time operations that
+  process secret bytes (e.g. base58 decode of a WIF), which are not cleanly
+  measurable by fixed-vs-random-value dudect and would need a different method.
+  Their threat-model exposure is low (local import, not an attacker oracle).
 - **No Tier 3 coverage.** Microarchitectural, fault-injection, physical, and
   toolchain-compromise attacks are out of scope by declaration.
 - **Bindings audited at the boundary only.** The Python/other bindings are
@@ -305,9 +334,11 @@ appended to Section 5/6.
   (`contrib/assurance/sanitizer_sweep.sh` + report); decide on #328.
 - Land #351 → rebase #360 → open the BIP38 harness PR once #277 also lands
   (both decrypt and code-parser harnesses + seed generators are staged).
-- Constant-time verification: **established (#365)** for two primitives; extend
-  to remaining secret-dependent paths (HMAC compares, WIF/base58 key handling)
-  and wire the bounded CT gate into CI.
+- Constant-time verification: **established (#365)** for two primitives, and
+  the comparison surface is covered (secret-gated compares route through them
+  or secp256k1). Remaining CT work is *method*, not more comparison harnesses:
+  a technique for non-fixed-time operations (base58/bignum) if their exposure
+  is ever reclassified upward, and wiring the bounded CT gate into CI.
 - Key-material zeroization (CWE-226): key/eckey/bip32 (#362) and seal (#363)
   drafted; **wallet-init master-seed leak fix pending** (highest severity).
   Resolve the #343/#363 double-free overlap.

--- a/doc/assurance/SECURITY_ASSURANCE.md
+++ b/doc/assurance/SECURITY_ASSURANCE.md
@@ -118,15 +118,17 @@ per-tool triage backlogs.
 | UB + count truncation in auxpow deserialization | `src/block.c` | #334 | |
 | Integer overflow in `cstr_alloc_min_sz` sizing | `src/cstr.c` | #344 | |
 
-**Function-type-mismatch UB (candidate — NEW, not covered by any open PR).**
-The sanitizer sweep surfaced six `function-type-mismatch` sites (CWE-686) that
-reconciliation against the full open-PR list confirms are **not** addressed by
-any existing audit PR: `spv.c:534/660/725` (header-db callbacks),
-`vector.c:82` (`elem_free_f`), `jpeg.c:413/446` (huff callbacks). Root cause is
-the generic-callback idiom (typed function stored in a `void(*)(void*)`-style
-field, called through the mismatched type). Real UB, provisionally low
-severity (works on target ABIs), portability/CFI hazard. Recommended as a
-single Tier-2 hardening PR. See `sanitizer_sweep_report.md` §3.
+**Function-type-mismatch UB (NEW — fixed in #361).**
+The sanitizer sweep surfaced six `function-type-mismatch` sites (CWE-686)
+confirmed by reconciliation against the full open-PR list to be not covered by
+any prior audit PR: `spv.c:534/660/725` (header-db callbacks), `vector.c:82`
+(`elem_free_f`), `jpeg.c:413/446` (huff callbacks). Root cause is the
+generic-callback idiom (typed function stored in a `void(*)(void*)`-style
+field, called through the mismatched type). Fixed in **#361** via typed
+trampolines that carry the correct generic signature and cast only the data
+pointer; verified with a before/after UBSan run showing the six findings
+eliminated and the residual four (owned by #325/#326/#327) untouched. See
+`sanitizer_sweep_report.md` §3.
 
 ### Resource exhaustion (Tier 2)
 
@@ -155,11 +157,12 @@ confirmed against branch names and titles as of this revision.*
 
 | Item | PR | Status |
 |---|---|---|
-| Phase 0 static-analysis workflows (CodeQL filter fix + cppcheck + clang-tidy) | #359 | Approved, draft — pending un-draft/merge |
+| Phase 0 static-analysis workflows (CodeQL filter fix + cppcheck + clang-tidy) | #359 | Approved; un-drafted, open — pending merge |
 | libFuzzer harness infrastructure | #351 | Approved, open |
 | Coverage reachability tooling | #360 | Open, stacked on #351 |
 | PSBT (BIP174) fuzz harness + fixes | #357 | Open |
 | ASAN+UBSAN CI gate | #328 | Open, draft |
+| Function-pointer type-mismatch UB fix (typed trampolines) | #361 | Open — found by this sweep; verified UBSan-clean |
 | PQC test assertions / cmake liboqs / raccoon-g build | #346, #347, #348 | Open |
 
 ## 5. Independent corroboration
@@ -252,7 +255,7 @@ appended to Section 5/6.
 
 - Un-draft and merge #359; confirm the first full-tree static-analysis run.
 - File the function-type-mismatch cluster (§4 UB) as a new Tier-2 hardening PR
-  — sweep-confirmed as not covered by any existing PR.
+  — **done: #361**, verified UBSan-clean for that class.
 - Merge the sanitizer sweep as a checked-in assurance artifact
   (`contrib/assurance/sanitizer_sweep.sh` + report); decide on #328.
 - Land #351 → rebase #360 → open the BIP38 harness PR once #277 also lands.

--- a/doc/assurance/SECURITY_ASSURANCE.md
+++ b/doc/assurance/SECURITY_ASSURANCE.md
@@ -77,7 +77,7 @@ produces. Status reflects the current state, not the plan.
 | Sanitizer CI gate | `make check` under ASan+UBSan | as above, continuous | Gating CI job | Open, draft (PR #328) |
 | Fuzzing | libFuzzer harnesses (tx, block, wtx, logdb, protocol, PSBT, BIP38) | 119/125/787, 400, parser-state confusion | Corpora, crash triage | Infra open (PR #351); PSBT integrated (#357); BIP38 harness pending #351+#277 |
 | Coverage measurement | llvm-cov over fuzz targets | validates fuzzing reach | Reachability report | Open (PR #360) |
-| Constant-time verification | (planned) dudect / binary-level | 208, 385 | Per-function CT verdict | Not yet started |
+| Constant-time verification | dudect / Welch t-test, `-O2` | 208, 385 | Per-function CT verdict | Established (#365); 2 primitives verified |
 | Hand audit | Line-by-line of high-stakes paths | logic flaws tools miss (131, 640-class) | Signed-off review notes | Ongoing (BIP38/sweep, PSBT, key paths) |
 
 Two methods are worth calling out. **Coverage measurement** (PR #360) is what
@@ -85,10 +85,15 @@ turns "the fuzzers ran" into "here is the attack surface they exercise": the
 BIP38 harness, for example, was shown by replay to reach base58 decode but not
 the scrypt/AES stages until a valid-key seed corpus was added, after which
 `ctaes.c` reached ~84% and the EC-multiplied decrypt branch went from zero
-coverage to reached. **Constant-time verification** is declared but not yet
-started — source-level review can flag likely secret-dependent branches, but
-confirming the compiled binary is constant-time under the release toolchain is
-outstanding work, and this document does not claim it.
+coverage to reached. **Constant-time verification** is now established (#365):
+a dudect harness measures the compiled binary at `-O2` via a Welch t-test over
+fixed-vs-random secret input classes. Two primitives are verified constant-time
+— `dogecoin_mem_cmp_ct` (the real exported comparison primitive, linked not
+copied; max |t| = 2.2 over 38M measurements) and BIP38's `bip38_mem_eq` (|t| =
+1.8 over 72M). A positive control that branches on the secret is flagged at
+|t| = 691, confirming the harness can detect a leak and the passes are real.
+Remaining secret-dependent paths beyond these two primitives are not yet
+covered.
 
 ## 4. Findings and disposition
 
@@ -153,6 +158,38 @@ eliminated and the residual four (owned by #325/#326/#327) untouched. See
 *Reconciled against `gh pr list` (authoritative). All PR numbers above are
 confirmed against branch names and titles as of this revision.*
 
+### Key-material lifetime (Tier 1) — CWE-226 audit
+
+A dedicated pass audited every path that handles private keys, seeds, or
+passphrase-derived key material for correct zeroization — checking that secret
+temporaries are scrubbed on *all* exit paths (not only the success path) and
+that the scrub covers the full buffer (not `sizeof` a pointer). The pass found
+a systematic class of leaks spanning the whole key lifecycle: generation,
+derivation, encoding, and at-rest encryption. It also verified the negative
+space (Windows NCrypt path materialises no plaintext; no PKCS11 backend
+exists) and rejected false positives (stack *arrays* where `sizeof` is correct
+in `bip32.c`/`seal.c`).
+
+| Finding | Location | PR | Notes |
+|---|---|---|---|
+| WIF decode zeroed `sizeof(pointer)` (8 B) not the buffer | `src/key.c` | #362 | ~30 B of the decoded private key left in freed heap |
+| eckey constructors never scrubbed the WIF temp | `src/eckey.c` | #362 | Both `new_eckey` paths; all exits |
+| CKD left the retained private-key copy `p` unscrubbed | `src/bip32.c` | #362 | `z` beside it was scrubbed; plain omission |
+| Software seal derived AES keys never scrubbed | `src/seal.c` | #363 | encrypt + decrypt; password was scrubbed but the keys derived from it were not |
+| TPM path returned decrypted **plaintext** to the allocator in the clear | `src/seal.c` | #363 | `Esys_Free` does not zero; the seed/mnemonic itself leaked |
+| YubiKey path: PIN freed without zeroing, mgmt key unscrubbed | `src/seal.c` | #363 | validated against a physical YubiKey 5 (PIV) |
+| Master seed + master hdnode left on the stack in wallet init | `src/wallet.c` | (pending) | **Highest severity** — the HD root; reconstructs every derived key |
+
+Verification: `dogecoin_mem_zero` was confirmed to be a `volatile` byte-wise
+write (`mem.c` → `memset_safe`) that survives `-O2` and is not elidable, so all
+scrubs in this class are effective rather than optimised away. The seal fixes
+were validated against the software path, a Linux TPM (swtpm) simulator, and a
+physical YubiKey; byte-for-byte seed round-trips confirmed. Two incidental
+error-path bugs (an `encrypted_seed` double-free and an `fclose(NULL)`) were
+fixed by the seal-path cleanup consolidation. The `#324`-`#348` series double-
+free work in `#343` overlaps the seal double-free; disposition tracked in #363.
+
+
 ### Tooling and infrastructure
 
 | Item | PR | Status |
@@ -164,6 +201,10 @@ confirmed against branch names and titles as of this revision.*
 | ASAN+UBSAN CI gate | #328 | Open, draft |
 | Function-pointer type-mismatch UB fix (typed trampolines) | #361 | Open — found by this sweep; verified UBSan-clean |
 | PQC test assertions / cmake liboqs / raccoon-g build | #346, #347, #348 | Open |
+| Key-material zeroization (key/eckey/bip32) | #362 | Draft — CWE-226 series |
+| Key-material zeroization (seal: sw/TPM/YubiKey) | #363 | Draft — hardware-validated; overlaps #343 |
+| Constant-time verification tests (dudect) | #365 | Draft — 2 primitives verified |
+| Security assurance case + audit artifacts | #366 | Draft — this document |
 
 ## 5. Independent corroboration
 
@@ -214,15 +255,19 @@ against the BIP38 decrypt harness completed **crash-clean**:
 
 This establishes a crash-clean baseline for the reachable BIP38 decrypt
 surface at the exercised coverage. It is a baseline, not a completeness claim:
-the intermediate-passphrase-code parser is not exercised by this harness (a
-separate harness would be required), and coverage of `bip38.c` remains partial
-per the #360 reachability report.
+coverage of `bip38.c` remains partial per the #360 reachability report. The
+intermediate-passphrase-code and confirmation-code parsers — a distinct
+untrusted-input surface the decrypt harness does not reach — now have their own
+harness and seed generator (reaching `bip38_parse_intermediate_code` and
+`confirm_passphrase_ex`, ~30% of `bip38.c` from the code-parser side), pending
+the same `#351`+`#277` base as the decrypt harness.
 
 ## 7. Declared limits (what this assurance case does NOT establish)
 
-- **No constant-time guarantee.** CT verification is not yet done; timing side
-  channels in key handling are in-scope (Tier 1) but currently only
-  source-reviewed, not binary-verified.
+- **Constant-time verification is partial.** Two core comparison primitives
+  are binary-verified constant-time at `-O2` (#365); other secret-dependent
+  paths (e.g. HMAC comparisons, base58/WIF handling of key bytes) are so far
+  only source-reviewed, not binary-verified.
 - **No Tier 3 coverage.** Microarchitectural, fault-injection, physical, and
   toolchain-compromise attacks are out of scope by declaration.
 - **Bindings audited at the boundary only.** The Python/other bindings are
@@ -258,6 +303,13 @@ appended to Section 5/6.
   — **done: #361**, verified UBSan-clean for that class.
 - Merge the sanitizer sweep as a checked-in assurance artifact
   (`contrib/assurance/sanitizer_sweep.sh` + report); decide on #328.
-- Land #351 → rebase #360 → open the BIP38 harness PR once #277 also lands.
-- Begin constant-time verification (dudect in CI + a one-time binary-level
-  pass on the release toolchain).
+- Land #351 → rebase #360 → open the BIP38 harness PR once #277 also lands
+  (both decrypt and code-parser harnesses + seed generators are staged).
+- Constant-time verification: **established (#365)** for two primitives; extend
+  to remaining secret-dependent paths (HMAC compares, WIF/base58 key handling)
+  and wire the bounded CT gate into CI.
+- Key-material zeroization (CWE-226): key/eckey/bip32 (#362) and seal (#363)
+  drafted; **wallet-init master-seed leak fix pending** (highest severity).
+  Resolve the #343/#363 double-free overlap.
+- Reconcile #366 (this document) against merged PR numbers before un-drafting;
+  it is a living record and should track the series rather than lead it.

--- a/doc/assurance/SECURITY_ASSURANCE.md
+++ b/doc/assurance/SECURITY_ASSURANCE.md
@@ -75,7 +75,7 @@ produces. Status reflects the current state, not the plan.
 | Static analysis (semantic) | clang-tidy `cert-*`,`bugprone-*`,`clang-analyzer-*` | 190, 197, 758, 476, 686 | Advisory report artifact | Landing (PR #359) |
 | Dynamic (sanitizers) | ASan/UBSan over full test suite | 119/125/787, 190, 758, 457 | Clean-run logs per branch | In progress; sweep reproduces #324/#325 on `0.1.5-dev` |
 | Sanitizer CI gate | `make check` under ASan+UBSan | as above, continuous | Gating CI job | Open, draft (PR #328) |
-| Fuzzing | libFuzzer harnesses (tx, block, wtx, logdb, protocol, PSBT, BIP38) | 119/125/787, 400, parser-state confusion | Corpora, crash triage | Infra open (PR #351); PSBT integrated (#357); BIP38 harness pending #351+#277 |
+| Fuzzing | libFuzzer harnesses (tx, block, wtx, logdb, protocol, PSBT, BIP38 decrypt + code parser, wallet records) | 119/125/787, 400, parser-state confusion | Corpora, crash triage | Infra open (#351); PSBT integrated (#357); BIP38 + wallet harnesses staged, pending #351(+#277). **Surface complete** — every untrusted-input parser has a harness |
 | Coverage measurement | llvm-cov over fuzz targets | validates fuzzing reach | Reachability report | Open (PR #360) |
 | Constant-time verification | dudect / Welch t-test, `-O2` | 208, 385 | Per-function CT verdict | Established (#365); 2 primitives verified |
 | Hand audit | Line-by-line of high-stakes paths | logic flaws tools miss (131, 640-class) | Signed-off review notes | Ongoing (BIP38/sweep, PSBT, key paths) |
@@ -223,6 +223,7 @@ free work in `#343` overlaps the seal double-free; disposition tracked in #363.
 | libFuzzer harness infrastructure | #351 | Approved, open |
 | Coverage reachability tooling | #360 | Open, stacked on #351 |
 | PSBT (BIP174) fuzz harness + fixes | #357 | Open |
+| BIP38 + wallet fuzz harnesses (staged on #351) | (pending) | Built + verified; open when #351 lands |
 | ASAN+UBSAN CI gate | #328 | Open, draft |
 | Function-pointer type-mismatch UB fix (typed trampolines) | #361 | Open — found by this sweep; verified UBSan-clean |
 | PQC test assertions / cmake liboqs / raccoon-g build | #346, #347, #348 | Open |
@@ -251,11 +252,21 @@ static build, full `tests` suite).
 
 ## 6. Fuzzing reachability summary
 
+Every untrusted-input parser in the library now has a libFuzzer harness. The
+surface is comprehensive: network messages, transactions, blocks, PSBTs,
+wallet-transaction and logdb records, encrypted BIP38 keys and BIP38
+code-strings, and wallet-file records all have coverage.
+
 | Harness | Surface | Notable result |
 |---|---|---|
-| PSBT (BIP174) | serialized PSBT parsing | reproduced a heap overflow on pre-fix tree (200-byte write into 33-byte pubkey buffer) |
+| tx | transaction deserialize + serialize round-trip | baseline parser coverage |
+| block | block/auxpow-block deserialize | baseline parser coverage |
+| wtx / logdb | wallet-tx and logdb record deserialize | baseline parser coverage |
 | protocol | p2p message deserialization | surfaced the getheaders unbounded allocation (#339), bounded in CI via `-malloc_limit_mb` |
-| BIP38 (pending) | encrypted-key decrypt | seed corpus reaches scrypt (~53%) and AES/ctaes (~84%); EC-multiplied branch reached only after EC-key seed enrichment |
+| PSBT (BIP174) | serialized PSBT parsing | reproduced a heap overflow on pre-fix tree (200-byte write into 33-byte pubkey buffer) |
+| BIP38 decrypt (pending #351+#277) | encrypted-key decrypt | seed corpus reaches scrypt (~53%) and AES/ctaes (~84%); EC branch reached only after EC-key seed enrichment; 4h campaign crash-clean (see below) |
+| BIP38 code parser (pending #351+#277) | intermediate/confirmation code parsing | reaches `bip38_parse_intermediate_code`, `confirm_passphrase_ex`; ~30% of `bip38.c` from the parser side |
+| wallet (pending #351) | wallet-file record deserialize (`wtx_deserialize` + `addr_deserialize`, chaining into `tx_deserialize`) | 11.8M-exec ASan+UBSan run crash-clean, cov 158 / ft 571 / corp 116 — resilient to malformed wallet records |
 
 The coverage tooling (#360) is what makes these numbers assurance evidence
 rather than anecdote: it reports which first-party source the harnesses
@@ -286,6 +297,17 @@ untrusted-input surface the decrypt harness does not reach — now have their ow
 harness and seed generator (reaching `bip38_parse_intermediate_code` and
 `confirm_passphrase_ex`, ~30% of `bip38.c` from the code-parser side), pending
 the same `#351`+`#277` base as the decrypt harness.
+
+### Surface completeness
+
+As of this revision, every untrusted-input parser identified in the threat
+model has a harness. The remaining fuzzing work is depth (longer campaigns,
+richer seed corpora, higher per-file coverage) and CI integration (running the
+harnesses on a cadence, tracking coverage regressions), not breadth — there is
+no known parser reachable from untrusted input that lacks a harness. "Complete"
+here means the *breadth* of the input surface is covered; it does not claim the
+absence of bugs in the covered parsers, only that each has been exercised and
+the reachable-but-crash-clean results are recorded above.
 
 ## 7. Declared limits (what this assurance case does NOT establish)
 
@@ -332,8 +354,11 @@ appended to Section 5/6.
   — **done: #361**, verified UBSan-clean for that class.
 - Merge the sanitizer sweep as a checked-in assurance artifact
   (`contrib/assurance/sanitizer_sweep.sh` + report); decide on #328.
-- Land #351 → rebase #360 → open the BIP38 harness PR once #277 also lands
-  (both decrypt and code-parser harnesses + seed generators are staged).
+- Land #351 → rebase #360 → open the staged fuzz-harness PRs once #351 (and
+  #277 for BIP38) land. Harness *breadth* is complete (BIP38 decrypt + code
+  parser, wallet records, plus the base tx/block/wtx/logdb/protocol/PSBT set);
+  remaining fuzzing work is depth — longer campaigns, richer corpora, CI cadence
+  — not new parsers.
 - Constant-time verification: **established (#365)** for two primitives, and
   the comparison surface is covered (secret-gated compares route through them
   or secp256k1). Remaining CT work is *method*, not more comparison harnesses:

--- a/doc/assurance/audit_plan.md
+++ b/doc/assurance/audit_plan.md
@@ -1,0 +1,90 @@
+# libdogecoin Security Audit Plan
+
+**Status:** Draft for team review
+**Scope target:** `0.1.5-dev` and release branches
+**Owners:** TBD (proposed: split per phase below)
+
+---
+
+## 1. Purpose
+
+Establish a scheduled, bounded audit program with defined outputs. The goal is not to prove the absence of vulnerabilities — that isn't achievable for a C library handling key material — but to (a) declare an explicit threat model, (b) systematically exercise the codebase against it with complementary methods, and (c) produce artifacts that constitute an assurance case a third party can evaluate.
+
+## 2. Threat model and security tiers
+
+Before running tools, we decide what we defend against. Proposed tiering:
+
+**Tier 1 — In scope, must defend (release-blocking):**
+
+- Memory-safety violations reachable from untrusted input: network messages, serialized transactions/PSBTs, BIP38-encrypted keys, base58/bech32 strings, imported wallet data. (CWE-119/125/787, CWE-190/191, CWE-416/415)
+- Undefined behavior in consensus-adjacent or crypto paths, including signed overflow, misaligned loads, and shift UB. (CWE-758, CWE-190)
+- Secret-dependent timing in key handling: privkey operations, BIP38 decryption, HMAC/scalar comparisons. (CWE-208, CWE-385)
+- Failure to zeroize key material, or key material reachable after free. (CWE-226, CWE-244, CWE-416)
+- Injection/parsing confusion in string handling: format strings, unchecked lengths, magic-number assumptions. (CWE-134, CWE-131)
+
+**Tier 2 — In scope, best-effort (documented, fixed opportunistically):**
+
+- Resource exhaustion from adversarial input (allocation bombs, decompression-style amplification in parsers). (CWE-400, CWE-789)
+- API-misuse hazards: functions that are safe only if callers follow undocumented preconditions. Document or harden.
+- Thread-safety races beyond what the registry-mutex and stateless work already covered. (CWE-362)
+
+**Tier 3 — Explicitly out of scope (declared, not defended):**
+
+- Microarchitectural attacks (Spectre-class, cache attacks beyond straightforward secret-indexed lookups).
+- Fault injection / glitching, physical attacks.
+- Compromised toolchain or build environment (addressed separately by reproducible-build work, not this audit).
+- Side channels in bindings or downstream consumers (Python bindings audited only at the FFI boundary).
+
+Publishing Tier 3 is what defines our security level of difficulty: the assurance case states its own limits.
+
+## 3. Method matrix
+
+Each method maps to the CWE classes it credibly covers and the artifact it produces. Breadth methods run over the whole library; depth methods are reserved for the high-stakes paths in §4.
+
+| Method | Tooling | CWE coverage | Artifact produced |
+|---|---|---|---|
+| Static analysis (pattern) | cppcheck `--enable=all --cwe` (emits CWE IDs directly) | 119, 125, 787, 190, 401, 415, 416, 476 | Findings report with CWE tags, triage log |
+| Static analysis (semantic) | clang-tidy: `cert-*`, `bugprone-*`, `clang-analyzer-*` | 190, 197, 758, 476, 686 | CI check + baseline suppression file |
+| Static analysis (dataflow) | CodeQL C/C++ security-extended suite (GH Actions, free for public repos) | CWE Top 25 mapped queries | SARIF results in Security tab, per-PR gating |
+| Interprocedural analysis | Infer (`--pulse`) | 476, 401, 416 across call chains | Findings report |
+| Dynamic (sanitizers) | ASan/UBSan/MSan sweeps over full test suite (extends PRs #324–327 methodology) | 119, 125, 787, 190, 758, 457 | Clean-run log per sanitizer per branch |
+| Fuzzing | libFuzzer harnesses from PR #351 (wtx, logdb, protocol, block, PSBT) + new BIP38 harness | 119, 125, 787, 400, parser-state confusion | Corpus, crash triage log, **coverage report** |
+| Coverage measurement | `-fprofile-instr-generate` on fuzz targets, llvm-cov HTML | n/a (validates fuzzing claims) | Reachability report: which attack surface the fuzzers actually exercise |
+| Constant-time verification | dudect (statistical, CI-friendly); ctgrind/valgrind client requests or Binsec/Rel for binary-level confirmation | 208, 385 | Per-function CT verdict at `-O2` on release toolchain |
+| AI-assisted review | Model review passes per module, findings filed as candidate issues only | breadth across all classes | Candidate-finding list feeding human triage |
+| Hand audit | Line-by-line review of §4 paths, attacker-controlled-data annotation | logic flaws tools miss (131, 640-class, protocol misuse) | Signed-off review notes per module |
+
+Two notes on the matrix. First, the coverage report is the highest-leverage single addition: we already have fuzzers, but the assurance case is much stronger when we can show *what they reach* rather than just that they ran. Second, the constant-time row closes an important loop: source-level pattern findings (like the recent leak) are hypotheses until verified on the compiled binary, because the compiler can reintroduce secret-dependent branches at optimization time. dudect in CI gives ongoing statistical confidence; a one-time Binsec/Rel or ctgrind pass on the release binary gives the stronger verdict.
+
+## 4. High-stakes paths (hand-audit + depth methods)
+
+These get human line-by-line review with the explicit question "what does the attacker control here," plus CT verification where secrets are involved:
+
+1. **BIP38 encrypt/decrypt** (PR #277 / #358 surface) — passphrase handling, scrypt parameters, AES key schedule, decrypted-key zeroization, error paths that could act as padding/format oracles.
+2. **Key derivation and privkey operations** — bip32 derivation (already had the signed-shift fix), WIF encode/decode, scalar comparisons, `dogecoin_privkey` lifecycle end to end (alloc → use → zeroize → free).
+3. **HMAC/hash primitives** — building on the hmac-sha256 OOB and sha256 unaligned-load fixes; verify the remaining primitives against the same failure classes.
+4. **PSBT parser** (PR #317) — the largest untrusted-input surface; length fields, map key/value confusion, combinator/merge logic where two attacker-supplied PSBTs interact.
+5. **Base58/bech32 and address parsing** — checksum handling, length assumptions, and verification of the recent magic-number/string-length hardening in #277.
+6. **FFI boundary** (python-libdogecoin cffi surface) — audited only at the boundary: buffer ownership, length conventions, who frees what.
+
+## 5. Phases and sequencing
+
+**Phase 0 — Baseline (≈1 week of calendar time, low effort):** Land CodeQL, clang-tidy, and cppcheck in CI with a baseline suppression file so only new findings gate PRs. Existing findings dump into a triage backlog. Artifact: CI config + backlog issue list.
+
+**Phase 1 — Breadth (2–3 weeks, parallelizable):** Triage the Phase 0 backlog by CWE severity and reachability from untrusted input. Run sanitizer sweeps on `0.1.5-dev`. Add the BIP38 fuzz harness and generate the coverage report for all harnesses. AI-assisted review passes run here as candidate-generation, feeding the same triage queue as the tools — same queue, same disposition labels (confirmed / false-positive / won't-fix-with-rationale).
+
+**Phase 2 — Depth (scheduled per module, ~1 module per week per reviewer):** Hand audits of §4 paths in priority order (BIP38 first, as the most recently changed key-material surface; PSBT second, largest parser). CT verification of the crypto paths on the release toolchain. Each module concludes with signed-off review notes.
+
+**Phase 3 — Assurance case assembly:** Collate into a single `SECURITY_ASSURANCE.md`: threat model (§2), method matrix with links to artifacts, per-module audit status, declared out-of-scope items, and a maintenance policy (which checks gate PRs going forward, cadence for re-running sweeps).
+
+## 6. Triage and disposition rules
+
+Every finding — tool, AI, or human — gets one of four labels: **confirmed** (issue filed, fix scheduled by tier), **false positive** (suppressed with a one-line rationale in the baseline file), **true-but-out-of-scope** (documented against Tier 3), or **hardening** (not exploitable but worth fixing; batched). No finding is closed without a label. This is what makes the audit legible to an outside reviewer later.
+
+## 7. Division of labor (proposal)
+
+Tools and CI wiring are mechanical and can be split freely. Hand audits should pair one primary reviewer with one confirmer per module — the primary annotates attacker-controlled data flow, the confirmer checks the annotation rather than re-deriving it, which halves the cost of two-person review. AI review passes are cheap to run per module and slot in wherever a human wants a second set of eyes before sign-off, with the standing rule that AI findings are candidates, never dispositions.
+
+---
+
+*Open questions for the team: (1) Do we gate releases on Tier 1 clean status only, or Tier 1 + triaged Tier 2? (2) Does the assurance doc live in-repo or on the wiki? (3) dudect CI integration currently has no owner — it stays unscheduled until someone claims it.*

--- a/doc/assurance/sanitizer_sweep_report.md
+++ b/doc/assurance/sanitizer_sweep_report.md
@@ -1,0 +1,113 @@
+# libdogecoin Sanitizer Sweep Report
+
+**Target:** `0.1.5-dev` @ `0dc5533f636d` (Merge PR #354)
+**Toolchain:** clang 18.1.3, ASan + UBSan, `-O1 -g`
+**Method:** two-pass sweep of the full `tests` suite — see
+`contrib/assurance/sanitizer_sweep.sh` (reproducible).
+**Companion:** `SECURITY_ASSURANCE.md` §5 (independent corroboration).
+
+---
+
+## 1. Purpose and method
+
+This is a documentation sweep, not a fix pass. It records which sanitizer
+faults are reachable on a **pristine** `0.1.5-dev` checkout, so each can be tied
+to a fix PR (confirming the fix addresses a live fault) or flagged as a
+candidate new finding.
+
+Two passes are run because the sanitizers recover differently:
+
+- **UBSan pass** — undefined behavior is recoverable, so one run enumerates
+  *all* reachable UB sites (execution continues past each). This is the
+  complete UB inventory below.
+- **ASan pass** — a real memory fault is not recoverable; ASan halts at the
+  first. The pass reports the first-reached memory error; fixing it and
+  re-running reveals the next. Only one memory finding is reported here for
+  that reason, and it is not a claim that only one exists.
+
+The build is static, `-O1 -g`, no `-fno-sanitize-recover` on the UBSan pass
+(so it does not halt at the first UB). Raw logs: `sanitizer_sweep.log`
+(UBSan pass), `asan_only.log` (ASan pass).
+
+## 2. Findings that confirm existing fix PRs
+
+Each of these reproduces on pristine `0.1.5-dev`, i.e. the fault is **live on
+the release branch** and the referenced PR fixes it. This is the assurance
+argument for merging the audit series: the fixes are not hypothetical.
+
+| Sanitizer finding | Site | Class | Fix PR |
+|---|---|---|---|
+| global-buffer-overflow, write | `sha2.c:994` `sha256_transform` | CWE-787 | **#324** — sha2 OOB in `hmac_sha256_prepare` |
+| misaligned-pointer-use, `sha2_word32` load | `sha2.c:994` | CWE-1319 / UB | **#326** — avoid unaligned word loads |
+| invalid-shift-base, `146 << 24` | `bip32.c:240` | CWE-190 / signed-shift UB | **#325** — bip32/bip37 signed-overflow shift |
+| invalid-shift-base, `16644864 << 8` | `jpeg.c:220` | CWE-190 | **#327** — arith_uint256/jpeg shift UB |
+| invalid-shift-base, `1 << 31` | `arith_uint256.c:128` | CWE-190 | **#327** — arith_uint256/jpeg shift UB |
+
+Notes:
+- The `sha2.c:994` line hosts *two* distinct findings — a global-buffer-overflow
+  (memory, ASan) and a misaligned load (UB, UBSan) — corresponding to the two
+  separate PRs #324 and #326. Both are at the `sha256_transform` block-word
+  access reached through the block-header scrypt hash path, i.e. from block
+  validation (a consensus path).
+- The bip32 shift is reached through HD key derivation.
+
+## 3. Candidate finding NOT matched to a known PR — needs triage
+
+The sweep surfaced a cluster of **function-type-mismatch** UB (CWE-686) that
+does not obviously correspond to an existing audit PR. **This needs
+confirmation against the open PR list before it is treated as new** — it may
+already be covered by a PR whose title did not make the connection obvious.
+
+| Site | Function called through wrong pointer type |
+|---|---|
+| `vector.c:82` | `dogecoin_wallet_addr_free` via `elem_free_f` |
+| `spv.c:534` | `dogecoin_headers_db_new` via callback |
+| `spv.c:660` | `dogecoin_headers_db_free` via callback |
+| `spv.c:725` | `dogecoin_headers_db_load` via callback |
+| `jpeg.c:413` | `jpec_huff_encode_block` via callback |
+| `jpeg.c:446` | `jpec_huff_del` via callback |
+
+**What this is:** the generic-callback idiom. Structures store a cleanup/op
+callback as a generic type (e.g. `vector`'s `elem_free_f` is
+`void (*)(void *)`) but are assigned a concretely-typed function
+(`dogecoin_headers_db_free(dogecoin_headers_db *)`). Calling through the
+mismatched pointer type is undefined behavior under C (§6.3.2.3/8), which
+UBSan's `-fsanitize=function` flags.
+
+**Severity assessment (provisional):** low. This idiom works on every real
+platform ABI libdogecoin targets — the calling conventions are compatible — so
+it is not believed exploitable. It is nonetheless real UB and a portability/
+correctness hazard (a future compiler using CFI or type-based optimization
+could miscompile it). Standard remediations: give the callback fields correctly
+-typed signatures, or route through small correctly-typed trampoline wrappers
+that internally cast, rather than casting the function pointer itself.
+
+**Disposition:** flagged, unassigned. Recommend confirming against `gh pr list`;
+if genuinely new, file as a single "fix function-pointer type mismatches in
+generic callbacks" change (Tier 2 / hardening), since the sites share one root
+cause.
+
+## 4. Summary
+
+| Category | Count | Status |
+|---|---|---|
+| UB confirming existing PRs | 4 sites | #324/#325/#326/#327 — merge-ready evidence |
+| Memory fault confirming existing PR | 1 site | #324 |
+| Function-type-mismatch UB | 6 sites | candidate; triage vs. PR list |
+
+The sweep is reproducible from a clean tree via
+`contrib/assurance/sanitizer_sweep.sh`. Re-running after the audit-series PRs
+merge should show the §2 findings cleared, leaving (if unaddressed) only the
+§3 function-type-mismatch cluster — which makes this report a concrete
+before/after checkpoint for the audit's memory-safety and UB claims.
+
+## 5. Caveat on completeness
+
+- The ASan pass reports only the first memory fault (see §1). A full memory
+  enumeration requires iterating: fix, re-run, repeat. This report does not
+  claim §2's single ASan finding is the only memory fault.
+- Coverage is limited to what the **test suite** exercises. Paths not hit by
+  `tests` are not swept here; fuzzing (see `SECURITY_ASSURANCE.md` §6) covers a
+  different, input-driven slice.
+- The function-type-mismatch severity call in §3 is provisional and should be
+  reviewed by someone with the ABI context before final disposition.

--- a/doc/assurance/sanitizer_sweep_report.md
+++ b/doc/assurance/sanitizer_sweep_report.md
@@ -12,8 +12,9 @@
 
 This is a documentation sweep, not a fix pass. It records which sanitizer
 faults are reachable on a **pristine** `0.1.5-dev` checkout, so each can be tied
-to a fix PR (confirming the fix addresses a live fault) or flagged as a
-candidate new finding.
+to a fix PR (confirming the fix addresses a live fault) or flagged as a new
+finding. This sweep did both: it corroborated four existing fix PRs and
+surfaced one new finding class (§3), now fixed in #361.
 
 Two passes are run because the sanitizers recover differently:
 
@@ -82,10 +83,12 @@ could miscompile it). Standard remediations: give the callback fields correctly
 -typed signatures, or route through small correctly-typed trampoline wrappers
 that internally cast, rather than casting the function pointer itself.
 
-**Disposition:** flagged, unassigned. Recommend confirming against `gh pr list`;
-if genuinely new, file as a single "fix function-pointer type mismatches in
-generic callbacks" change (Tier 2 / hardening), since the sites share one root
-cause.
+**Disposition:** confirmed new (reconciled against the full open-PR list — not
+covered by any prior audit PR) and **fixed in #361**. The fix routes each site
+through a small correctly-typed trampoline that carries the generic
+`void(*)(void*)` signature and casts only the data pointer, rather than casting
+the function pointer. A before/after UBSan run confirmed the six findings are
+eliminated with no behavioural change and the residual four (§2) untouched.
 
 ## 4. Summary
 
@@ -93,13 +96,15 @@ cause.
 |---|---|---|
 | UB confirming existing PRs | 4 sites | #324/#325/#326/#327 — merge-ready evidence |
 | Memory fault confirming existing PR | 1 site | #324 |
-| Function-type-mismatch UB | 6 sites | candidate; triage vs. PR list |
+| Function-type-mismatch UB | 6 sites | **fixed in #361** (typed trampolines, UBSan-verified) |
 
 The sweep is reproducible from a clean tree via
 `contrib/assurance/sanitizer_sweep.sh`. Re-running after the audit-series PRs
-merge should show the §2 findings cleared, leaving (if unaddressed) only the
-§3 function-type-mismatch cluster — which makes this report a concrete
-before/after checkpoint for the audit's memory-safety and UB claims.
+merge should show the §2 findings cleared; the §3 function-type-mismatch
+cluster is already resolved by #361. Re-running the sweep after all of
+#324/#325/#326/#327 and #361 merge should show a UBSan/ASan-clean test suite
+for these classes — which makes this report a concrete before/after checkpoint
+for the audit's memory-safety and UB claims.
 
 ## 5. Caveat on completeness
 


### PR DESCRIPTION
## Summary

Adds the security assurance case and supporting audit artifacts that frame the ongoing security-hardening series (the CWE-226 zeroization work, the fuzz harnesses, the UB fixes, the DoS bounds, etc.). This is the umbrella document explaining *what* is being assured, *how*, and *what remains*.

## Changes

- **`doc/assurance/SECURITY_ASSURANCE.md`** — the assurance case: threat model, security goals, the claim/argument/evidence structure, and per-area status.
- **`doc/assurance/audit_plan.md`** — the audit plan (scope, tiers, methodology).
- **`doc/assurance/sanitizer_sweep_report.md`** — results of the sanitizer sweep.
- **`contrib/assurance/sanitizer_sweep.sh`** — the reproducible ASan/UBSan sweep script backing the report.

Second commit updates the case to record that the function-pointer type-mismatch UB is fixed in #361.

## Notes

- Documentation + one contrib script only; no library code changes, no build impact.
- Cross-references the audit-series PRs (function-pointer UB #361, and the zeroization / fuzz / DoS PRs).

Living document — intended to be updated as further audit items land.
