### PR TITLE
wallet: zeroize master seed, hdnode, and mnemonic in wallet_init (CWE…

### DIFF
--- a/src/wallet.c
+++ b/src/wallet.c
@@ -432,18 +432,17 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
         // create a new key
         dogecoin_hdnode node;
         SEED seed;
+        MNEMONIC mnemonic = {0}; // hoisted so the cleanup label can scrub it
 
         if (mnemonic_in) {
             // generate seed from mnemonic
             if (dogecoin_seed_from_mnemonic(mnemonic_in, pass, seed) == -1) {
                 showError("Invalid mnemonic\n");
-                dogecoin_wallet_free(wallet);
-                return NULL;
+                goto created_fail;
             }
         } else if (encrypted && !master_key) {
 
             dogecoin_bool tpmSuccess = false;
-            MNEMONIC mnemonic = {0};
 
             if (tpm) {
                 // decrypt encrypted mnemonic with TPM
@@ -457,16 +456,14 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
             if (!tpmSuccess) {
                 if (!dogecoin_decrypt_mnemonic_with_sw(mnemonic, file_num, NULL, NULL)) {
                     showError("Decrypting mnemonic from software failed\n");
-                    dogecoin_wallet_free(wallet);
-                    return NULL;
+                    goto created_fail;
                 }
             }
 
             // generate seed from mnemonic
             if (dogecoin_seed_from_mnemonic(mnemonic, pass, seed) == -1) {
                 showError("Invalid mnemonic\n");
-                dogecoin_wallet_free(wallet);
-                return NULL;
+                goto created_fail;
             }
         } else if (encrypted && master_key) {
 
@@ -484,8 +481,7 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
             if (!tpmSuccess) {
                 if (!dogecoin_decrypt_hdnode_with_sw(&node, file_num, NULL, NULL)) {
                     showError("Decrypting master key from software failed\n");
-                    dogecoin_wallet_free(wallet);
-                    return NULL;
+                    goto created_fail;
                 }
             }
         } else {
@@ -493,8 +489,7 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
             res = dogecoin_random_bytes(seed, sizeof(seed), true);
             if (!res) {
                 showError("Generating random bytes failed\n");
-                dogecoin_wallet_free(wallet);
-                return NULL;
+                goto created_fail;
             }
             if (prompt_ok) {
                 printf("No mnemonic/key, store random seed in encrypted file? (Y/n): ");
@@ -515,8 +510,7 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
                             bool overwrite = (buffer[0] == 'Y' || buffer[0] == 'y');
                             // encrypt seed for storage with software
                             if (dogecoin_encrypt_seed_with_sw(seed, sizeof(seed), file_id, overwrite, NULL, NULL, NULL) == false) {
-                                dogecoin_wallet_free(wallet);
-                                return NULL;
+                                goto created_fail;
                             }
                         }
                     }
@@ -528,6 +522,24 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
             dogecoin_hdnode_from_seed(seed, sizeof(seed), &node);
         }
         dogecoin_wallet_set_master_key_copy(wallet, &node);
+
+        goto created_cleanup; // success: skip the failure handler below
+    created_fail:
+        dogecoin_wallet_free(wallet);
+        wallet = NULL;
+    created_cleanup:
+        /* Scrub the master seed, master hdnode, and decrypted mnemonic before
+         * leaving this block (CWE-226). dogecoin_wallet_set_master_key_copy()
+         * deep-copies the key into the wallet, so these stack temporaries are
+         * pure residue afterward; on the failure paths they may hold a
+         * partially-derived secret. dogecoin_mem_zero is a volatile,
+         * non-elidable write. */
+        dogecoin_mem_zero(seed, sizeof(seed));
+        dogecoin_mem_zero(&node, sizeof(node));
+        dogecoin_mem_zero(mnemonic, sizeof(mnemonic));
+        if (!wallet) {
+            return NULL;
+        }
     } else {
         // ensure we have a key/address
         if (wallet->masterkey == NULL && address == NULL) {


### PR DESCRIPTION
…-226)

Tier-1 key-material-lifetime fix. dogecoin_wallet_init() built the wallet's root secrets on the stack and never scrubbed them:

  - SEED seed              - the master seed (mnemonic-derived or random)
  - dogecoin_hdnode node   - holds the master private_key[32]
  - MNEMONIC mnemonic      - the decrypted BIP39 mnemonic (encrypted path)

dogecoin_wallet_set_master_key_copy() deep-copies the key into the wallet (dogecoin_hdnode_copy), so after that call these three temporaries are pure stack residue -- yet they survived on every exit. Recovering any of them from stack memory compromises the entire HD wallet (every derived key), not a single key. CWE-226.

Fix: consolidate the block's exits through a single scrub site (goto pattern). The success path does set_master_key_copy() then `goto created_cleanup`; the six error paths `goto created_fail` (which frees the wallet and NULLs it) and fall into the same cleanup. The cleanup scrubs all three secrets with dogecoin_mem_zero (volatile, non-elidable) and returns NULL iff the wallet was freed. `mnemonic` was hoisted from its inner branch scope to the block top so the single cleanup can reach it.

Seven in-scope exit paths now covered (previously all leaked):
  1. invalid mnemonic (mnemonic_in)                     ~L438
  2. decrypt mnemonic from software failed              ~L458
  3. invalid mnemonic (after decrypt)                   ~L466
  4. decrypt master key from software failed            ~L485
  5. random seed generation failed                      ~L493
  6. encrypt-seed-for-storage failed                    ~L517
  7. success fall-through after set_master_key_copy     ~L530

Zeroization-only and control-flow-equivalent: the scrubs touch only stack locals, never wallet state, and every error path still frees the wallet and returns NULL exactly as before. The `exit(EXIT_FAILURE)` branch is in the `else` (not-created) arm where the secrets are out of scope, so it is untouched. dogecoin_wallet_new() was checked and stack-allocates no secrets.

Verification:
  - clang -O2 clean build, no new warnings on wallet.c.
  - Full test suite passes (test_wallet, test_wallet_basics, test_wallet_reorg_utxo_update, test_wallet_balance_accounts_for_spends, test_reorg, test_spv), exit 0.
  - Behaviour-equivalence: a wallet built from a fixed BIP39 mnemonic derives the identical master xpub and address before and after the change.
  - The three added dogecoin_mem_zero calls are present in the -O2 wallet object (confirmed not elided).