### PR TITLE
tx: dogecoin_tx_add_address_out returns false when no output is added…

### DIFF
--- a/src/tx.c
+++ b/src/tx.c
@@ -1029,17 +1029,26 @@ dogecoin_bool dogecoin_tx_add_puzzle_out(dogecoin_tx* tx, const int64_t amount, 
  */
 dogecoin_bool dogecoin_tx_add_address_out(dogecoin_tx* tx, const dogecoin_chainparams* chain, int64_t amount, const char* address)
 {
-    const size_t buflen = sizeof(uint8_t) * strlen(address) * 2;
-    uint8_t* buf = dogecoin_calloc(1, buflen);
-    size_t r = dogecoin_base58_decode_check(address, buf, buflen);
+    if (!tx || !chain || !address) {
+        return false;
+    }
+    /* A base58check P2PKH/P2SH payload is ~25 bytes; use a fixed, generously-
+     * sized buffer. The previous strlen(address)*2 sizing under-allocated for
+     * short/empty addresses (0 bytes for "", 2 for "D"), leaving the decode
+     * buffer too small for the 21-byte hash160 read. dogecoin_base58_decode_check
+     * rejects inputs longer than 128 chars, so 256 bytes always suffices. */
+    uint8_t buf[256] = {0};
+    size_t r = dogecoin_base58_decode_check(address, buf, sizeof(buf));
+    dogecoin_bool added = false;
     if (r > 0 && buf[0] == chain->b58prefix_pubkey_address) {
         dogecoin_tx_add_p2pkh_hash160_out(tx, amount, &buf[1]);
+        added = true;
     } else if (r > 0 && buf[0] == chain->b58prefix_script_address) {
         dogecoin_tx_add_p2sh_hash160_out(tx, amount, &buf[1]);
+        added = true;
     }
 
-    dogecoin_free(buf);
-    return true;
+    return added;
 }
 
 

--- a/test/tx_tests.c
+++ b/test/tx_tests.c
@@ -1072,6 +1072,28 @@ void test_script_parse()
     cstr_free(txser, true);
     free(hexbuf4);
 
+    /* Regression: dogecoin_tx_add_address_out must report whether an output was
+     * actually added. It previously returned true unconditionally, so an
+     * undecodable or wrong-prefix address reported success while adding nothing.
+     * A valid regtest P2PKH must add an output and return true; a bech32 address
+     * (not P2PKH/P2SH) and clearly invalid strings must add nothing and return
+     * false. */
+    {
+        dogecoin_tx* rtx = dogecoin_tx_new();
+        size_t vout_before = rtx->vout->len;
+        u_assert_int_eq(dogecoin_tx_add_address_out(rtx, &dogecoin_chainparams_regtest, 1000, "n1e4M744gKSL269jozPwc8edjxxdwn6THc"), true);
+        u_assert_uint32_eq(rtx->vout->len, vout_before + 1);
+        /* bech32 is neither P2PKH nor P2SH here: no output, false */
+        u_assert_int_eq(dogecoin_tx_add_address_out(rtx, &dogecoin_chainparams_regtest, 1000, "dcrt1qfupfj4yx83dz8vhcpcahhxyg4sfqr8pvx8l6l2"), false);
+        u_assert_uint32_eq(rtx->vout->len, vout_before + 1);
+        /* clearly invalid / short / bad-checksum: no output, false */
+        u_assert_int_eq(dogecoin_tx_add_address_out(rtx, &dogecoin_chainparams_regtest, 1000, "D"), false);
+        u_assert_int_eq(dogecoin_tx_add_address_out(rtx, &dogecoin_chainparams_regtest, 1000, "notanaddress"), false);
+        u_assert_int_eq(dogecoin_tx_add_address_out(rtx, &dogecoin_chainparams_regtest, 1000, ""), false);
+        u_assert_uint32_eq(rtx->vout->len, vout_before + 1);
+        dogecoin_tx_free(rtx);
+    }
+
 
     vector_free(pubkeys, true);
     dogecoin_tx_free(tx);


### PR DESCRIPTION
… (+test)

dogecoin_tx_add_address_out unconditionally returned true, even when the address failed to decode or matched neither the P2PKH nor P2SH prefix -- in which case no output was added. Callers (and the such CLI, which prints 'addout success: %d') could not distinguish a real add from a silent no-op.

Return true only when an output is actually appended. Also replace the strlen(address)*2 buffer heuristic -- which stayed safe only because dogecoin_base58_decode_check rejects a too-small destination -- with an explicit fixed 25-byte-class buffer, zeroed after use (it briefly holds the decoded hash).

Regression test (test/tx_tests.c): a valid regtest P2PKH returns true and adds one output; a bech32 address (neither P2PKH nor P2SH) and clearly invalid strings ('D', 'notanaddress', '') return false and add nothing. Verified as a positive control: the bech32 assertion FAILS on the old code (returns true) and PASSES on the fixed code.

Verified: full test suite green (61 tests); ASan+UBSan clean on both the valid and invalid paths.