### PR TITLE
such: fix nondeterministic wrong amount when editing an output amount

### DIFF
--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -503,8 +503,8 @@ void transaction_output_menu(int txindex, int is_testnet) {
     int running_transaction_output_menu = 1;
     while (running_transaction_output_menu) {
         char* destinationaddress;
-        char* coin_amount[21];
-        dogecoin_mem_zero(coin_amount, 21);
+        char coin_amount[32];
+        dogecoin_mem_zero(coin_amount, sizeof(coin_amount));
         uint64_t koinu_amount;
         uint64_t tx_out_total = 0;
         const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
@@ -518,8 +518,8 @@ void transaction_output_menu(int txindex, int is_testnet) {
             printf("\n--------------------------------\n");
             printf("output index:       %d\n", i);
             printf("script public key:  %s\n", utils_uint8_to_hex((const uint8_t*)tx_out->script_pubkey->str, tx_out->script_pubkey->len));
-            koinu_to_coins_str(tx_out->value, (char*)coin_amount);
-            printf("amount:             %s\n", (char*)coin_amount);
+            koinu_to_coins_str(tx_out->value, coin_amount);
+            printf("amount:             %s\n", coin_amount);
             // selected should only equal anything other than -1 upon setting
             // loop index in conditional targetting last iteration:
             selected == i ? printf("selected:           [X]\n") : 0;
@@ -540,14 +540,25 @@ void transaction_output_menu(int txindex, int is_testnet) {
                                             break;
                                             }
                                         else {
-                                            koinu_amount = coins_to_koinu_str((char*)coin_amount);
+                                            koinu_amount = coins_to_koinu_str(coin_amount);
                                             vector_remove_idx(tx->transaction->vout, i);
                                             dogecoin_tx_add_address_out(tx->transaction, chain, koinu_amount, destinationaddress);
                                             }
                                         break;
                                     case 2:
-                                        memcpy_safe(coin_amount, (char*)getl("new amount"), 21);
-                                        koinu_amount = coins_to_koinu_str((char*)coin_amount);
+                                        /* Snapshot the new amount into the bounded, NUL-terminated
+                                         * coin_amount buffer before parsing. getl() returns a pointer
+                                         * into a single static buffer; the previous fixed 21-byte
+                                         * memcpy_safe() left coin_amount un-terminated whenever the
+                                         * input had no NUL within those 21 bytes, so check_length()/
+                                         * coins_to_koinu_str() then ran strlen()/parsed over
+                                         * uninitialised stack -> a nondeterministic wrong amount (the
+                                         * "editing an amount enters incorrectly" / "getl garbage"
+                                         * report) plus a dogecoin_string[] overflow. snprintf bounds
+                                         * and terminates it; over-long amounts are then cleanly
+                                         * rejected by check_length. */
+                                        snprintf(coin_amount, sizeof(coin_amount), "%s", getl("new amount"));
+                                        koinu_amount = coins_to_koinu_str(coin_amount);
                                         if (!koinu_amount) {
                                             printf("number is invalid or set to 0\n");
                                         } else tx_out->value = koinu_amount;
@@ -570,10 +581,10 @@ void transaction_output_menu(int txindex, int is_testnet) {
             // escape encompassing while loop so we return to previous menu
             if (i == length - 1) {
                 printf("\n\n");
-                char* subtotal[21];
-                dogecoin_mem_zero(subtotal, 21);
-                koinu_to_coins_str(tx_out_total, (char*)subtotal);
-                printf("subtotal - desired fee: %s\n", (char*)subtotal);
+                char subtotal[32];
+                dogecoin_mem_zero(subtotal, sizeof(subtotal));
+                koinu_to_coins_str(tx_out_total, subtotal);
+                printf("subtotal - desired fee: %s\n", subtotal);
                 printf("\n");
                 printf("1. select output to edit\n");
                 printf("2. main menu\n");


### PR DESCRIPTION
Reported symptom: in `such -c transaction`, editing the amount of a previously-added output sometimes stores the wrong value, and getl() was observed "getting garbage and producing garbage" during edit sessions.

Root cause (valgrind-confirmed): in transaction_output_menu the edit-amount path did

    memcpy_safe(coin_amount, (char*)getl("new amount"), 21);
    koinu_amount = coins_to_koinu_str((char*)coin_amount);

memcpy_safe() copies a FIXED 21 bytes with no NUL guarantee, and coin_amount was declared `char* coin_amount[21]` (an array of 21 pointers, 168 bytes) of which only 21 bytes were zeroed. Whenever the entered amount had no NUL within the first 21 copied bytes (e.g. an amount >= 21 chars, or a short amount whose NUL fell past byte 20), coin_amount was left un-terminated over uninitialised stack. coins_to_koinu_str() -> check_length() then ran strlen() over that uninitialised memory (nondeterministic length) and copied `length` bytes into its 21-byte dogecoin_string[], so the parsed amount depended on stack garbage (the "enters incorrectly") and could overflow dogecoin_string[] by 1+ bytes.

Reproduction (deterministic, on the preloaded 2-output sample tx):

    printf '%s\n' 2 1 2 1 0 1 2 '1234567890123456789012345' 2 2 3 7 11 \
      | ./such -c transaction

Before: valgrind reports "Conditional jump ... depends on uninitialised value(s)" at check_length (koinu.c:86) / coins_to_koinu_str (koinu.c:179,212, 214) from transaction_output_menu (such.c:550); the resulting out[0] value varies run to run.

Fix (minimal, behaviour-preserving except the corrected value): snapshot the getl() result into the bounded, NUL-terminated coin_amount buffer with snprintf (the same pattern already used for the "amount" case in sub_menu), and correct the coin_amount / subtotal declarations from `char*[21]` (168 bytes, used-as-char-buffer by accident, only 21 zeroed) to a real, fully-zeroed `char[32]`. 32 bytes safely holds the widest coin string (~21 chars for the max supply) plus NUL. Over-long amounts are now cleanly rejected by check_length() instead of parsing uninitialised memory.

Validation:
  - valgrind: the reproduction sequence is clean (exit 0); the previous uninitialised reads at koinu.c:86/179/212/214 are gone.
  - Correctness preserved: 11 representative amounts (0.00000001 .. 12345.6789, integers, 8-dp) round-trip to the exact expected koinu through the edit.
  - Determinism restored: the 25-char reproduction leaves out[0] unchanged at 500000000 on 10/10 runs (previously nondeterministic garbage).
  - Editing an address still preserves the amount; editing an amount does not alter the address.
  - make tests passes (test_transaction, test_tx_serialization, test_tx_sign, test_tx_sighash, ...).

Only the CLI edit menu is changed; no library behaviour is altered.