### PR TITLE
ci: match bare *-dev branches in push triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: CI
 
 on:
   push:
-    branches: [ "*-dev-*"]
+    branches: [ "*-dev*" ]
     tags: [ "v*" ]
   pull_request:
     branches: [ "*" ]

--- a/.github/workflows/ql.yml
+++ b/.github/workflows/ql.yml
@@ -4,7 +4,7 @@ name: CodeQL
 on:
   push:
     branches:
-      - '*-dev-*'
+      - '*-dev*'
       - 'main'
   pull_request:
     # The branches below must be a subset of the branches above


### PR DESCRIPTION
The push filters used the glob "*-dev-*", which requires a trailing segment after "-dev-" and therefore never matches bare dev branches like "0.1.5-dev". Merges into 0.1.5-dev pushed with no workflow listening, so no CI ran on merge commits (PRs still ran via the pull_request filter).

Add "*-dev" to the push branch lists in ci.yml and ql.yml so pushes to bare dev branches trigger CI and CodeQL.