### PR TITLE
ci: force IPv4 in the openenclave build container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -610,15 +610,16 @@ jobs:
                 docker run -v $PWD:/src -w /src ubuntu:20.04 bash -c "\
                   # Install dependencies
                   export DEBIAN_FRONTEND=noninteractive && \
+                  printf 'Acquire::ForceIPv4 \"true\";\n' > /etc/apt/apt.conf.d/99force-ipv4 && \
                   apt-get update && \
                   apt-get install -y wget gnupg2 cmake && \
                   cd /src/src/openenclave && \
                   echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
-                  wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
+                  wget -4 -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
                   echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-11 main' | tee /etc/apt/sources.list.d/llvm-toolchain-focal-11.list && \
-                  wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+                  wget -4 -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
                   echo 'deb [arch=amd64] https://packages.microsoft.com/ubuntu/20.04/prod focal main' | tee /etc/apt/sources.list.d/msprod.list && \
-                  wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+                  wget -4 -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
                   apt update && \
                   apt -y install clang-11 libssl-dev gdb libsgx-enclave-common libsgx-quote-ex libprotobuf17 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client open-enclave && \
                   apt -y install dkms && \


### PR DESCRIPTION
## Problem

The `x86_64-linux-openenclave` leg has been intermittently red (the only failing check on the in-flight registry-stack PRs #333–#337). A CI network diagnostic in a focal container pinned the root cause:

- The leg builds inside an `ubuntu:20.04` container that **resolves both A and AAAA** for its apt endpoints — Intel SGX (Akamai), LLVM (Fastly), Microsoft (msedge) and the Ubuntu archive (Cloudflare) are all dual-stack — but has **no working IPv6**: no default v6 route, and a direct IPv6 connect fails outright (GitHub-hosted runners are IPv4-only; the Docker bridge is IPv4-only).
- When a client attempts the IPv6 address first and that dead path **stalls** instead of failing fast, `wget -q` yields an empty stream that `apt-key` reports three commands later as `gpg: no valid OpenPGP data found` (**exit 2**). The same broken path produced the intermittent **exit-100** `archive.ubuntu.com` fetch failures. It's a coin flip because it depends on whether the v6 attempt fails fast (IPv4 fallback works) or hangs.

## Fix

Force IPv4 for the whole leg:
- write `Acquire::ForceIPv4 "true"` before any apt operation — covers `apt-get update`, the repo package installs, and the archive;
- add `-4` to the three key fetches.

Nothing then touches the broken v6 path. One-line to revert if runners gain IPv6.

## Verification

- Local `ubuntu:20.04` container: `apt-config` honours the setting; all three `wget -4 | apt-key add` fetches succeed.
- **CI on the fork** (branch `0.1.5-dev-fix-openenclave-force-ipv4`): the `x86_64-linux-openenclave` leg is **green** — keys fetched over IPv4, `open-enclave 0.19.4 [54.5 MB]` + the `libsgx-*` packages downloaded cleanly (the package/archive path, which is what actually hung), and `cmake && make && make simulate` completed.