### PR TITLE
rpctest: stop discarding the SPV test exit code and bound its runtime

### DIFF
--- a/rpctest/fetch.py
+++ b/rpctest/fetch.py
@@ -30,10 +30,10 @@ assert host in ("arm-linux-gnueabihf",
 hash = ""
 if host == "arm-linux-gnueabihf":
     ext = ".tar.gz"
-    hash = "d0b7f5f4fbabb6a10078ac9cde1df7eb37bef4c2627cecfbf70746387c59f914  dogecoin-1.14.6-arm-linux-gnueabihf.tar.gz"
+    hash = "311fe8aee346d3f9a00c0a8ac594224ca3bfa297fec8a5fae20bb70f28961421  dogecoin-1.14.6-arm-linux-gnueabihf.tar.gz"
 elif host == "aarch64-linux-gnu":
     ext = ".tar.gz"
-    hash = "87419c29607b2612746fccebd694037e4be7600fc32198c4989f919be20952db  dogecoin-1.14.6-aarch64-linux-gnu.tar.gz"
+    hash = "6928c895a20d0bcb6d5c7dcec753d35c884a471aaf8ad4242a89a96acb4f2985  dogecoin-1.14.6-aarch64-linux-gnu.tar.gz"
 elif host == "x86_64-w64-mingw32":
     ext = ".zip"
     hash = "709490ac8464b015266884831a2b5b594efc8b2c17a7e6b85255058cbee049de  dogecoin-1.14.6-win64.zip"
@@ -45,10 +45,10 @@ elif host == "x86_64-apple-darwin14":
     hash = "bf6123a91ba2829e03dc7c48865971dd615b78249f6ee41a4e796f942bd93869  dogecoin-1.14.6-osx-unsigned.dmg"
 elif host == "x86_64-linux-gnu":
     ext = ".tar.gz"
-    hash = "908c5dfc9e4b617aae0df9c8cd6986b5988a6b5086136df5cbac40ec63e0c31c  dogecoin-1.14.6-x86_64-linux-gnu.tar.gz"
+    hash = "4f227117b411a7c98622c970986e27bcfc3f547a72bef65e7d9e82989175d4f8  dogecoin-1.14.6-x86_64-linux-gnu.tar.gz"
 elif host == "i686-pc-linux-gnu":
     ext = ".tar.gz"
-    hash = "d70a438a3bc7d74e8baa99a00b70e33a806db19b673fb36617307603186208a4  dogecoin-1.14.6-i686-pc-linux-gnu.tar.gz"
+    hash = "b8e1846a0979f369042dcf14435dfcea704b1456e34bc9657f0829d9eac0d3b0  dogecoin-1.14.6-i686-pc-linux-gnu.tar.gz"
 
 print('Downloading started')
 file = "dogecoin-1.14.6-" + host
@@ -102,7 +102,27 @@ for f in deps_path:
         dst_path = os.path.join('/usr/local/bin', f)
         shutil.move(src_path, dst_path)
 
-subprocess.run([os.path.join(os.getcwd(), "rpctest/spvtool.py")])
+# Bound the SPV test. It drives a real spvnode against a regtest dogecoind, so a
+# client-side stall (waiting on a peer for data it will never send) would
+# otherwise hang here until the CI job hits its own hour-long limit and is
+# killed with no useful output. Fail fast and loudly instead.
+SPVTOOL_TIMEOUT = int(os.environ.get("SPVTOOL_TIMEOUT", "900"))
+try:
+    completed = subprocess.run(
+        [os.path.join(os.getcwd(), "rpctest/spvtool.py")],
+        timeout=SPVTOOL_TIMEOUT,
+    )
+except subprocess.TimeoutExpired:
+    print("\033[31m> spvtool.py exceeded %ds and was killed - treating as failure.\033[0m"
+          % SPVTOOL_TIMEOUT, file=sys.stderr)
+    print("\033[31m> This usually means spvnode never reached 'Sync completed' "
+          "and is waiting on a peer.\033[0m", file=sys.stderr)
+    sys.exit(1)
+
+if completed.returncode != 0:
+    print("\033[31m> spvtool.py failed with exit code %d\033[0m" % completed.returncode,
+          file=sys.stderr)
+    sys.exit(completed.returncode)
 
 rmlist = ['./dogecoin-*', '*.dmg', '*.tar.gz', '*.zip', '*.asc']
 for path in rmlist:

--- a/rpctest/fetch.py
+++ b/rpctest/fetch.py
@@ -30,29 +30,29 @@ assert host in ("arm-linux-gnueabihf",
 hash = ""
 if host == "arm-linux-gnueabihf":
     ext = ".tar.gz"
-    hash = "311fe8aee346d3f9a00c0a8ac594224ca3bfa297fec8a5fae20bb70f28961421  dogecoin-1.14.6-arm-linux-gnueabihf.tar.gz"
+    hash = "311fe8aee346d3f9a00c0a8ac594224ca3bfa297fec8a5fae20bb70f28961421  dogecoin-1.14.9-arm-linux-gnueabihf.tar.gz"
 elif host == "aarch64-linux-gnu":
     ext = ".tar.gz"
-    hash = "6928c895a20d0bcb6d5c7dcec753d35c884a471aaf8ad4242a89a96acb4f2985  dogecoin-1.14.6-aarch64-linux-gnu.tar.gz"
+    hash = "6928c895a20d0bcb6d5c7dcec753d35c884a471aaf8ad4242a89a96acb4f2985  dogecoin-1.14.9-aarch64-linux-gnu.tar.gz"
 elif host == "x86_64-w64-mingw32":
     ext = ".zip"
-    hash = "709490ac8464b015266884831a2b5b594efc8b2c17a7e6b85255058cbee049de  dogecoin-1.14.6-win64.zip"
+    hash = "45864cedc210e6d573c7efd5f6694a440147d9773c4a8851a99882a2727ad804  dogecoin-1.14.9-win64.zip"
 elif host == "i686-w64-mingw32":
     ext = ".zip"
-    hash = "c919fdc966764ec554273791699426448eedd8d305e76284e4f1cd1d5f0b5a7a  dogecoin-1.14.6-win32.zip"
+    hash = "6f58693c0f59e061dd56113944b38449d826f87e06c72c21f77bc7b11b8c99f0  dogecoin-1.14.9-win32.zip"
 elif host == "x86_64-apple-darwin14":
     ext = ".tar.gz"
-    hash = "bf6123a91ba2829e03dc7c48865971dd615b78249f6ee41a4e796f942bd93869  dogecoin-1.14.6-osx-unsigned.dmg"
+    hash = "c87c956834a87da8200274a097364c986ccca045d71ce92d0f7d407129d25a83  dogecoin-1.14.9-osx-unsigned.dmg"
 elif host == "x86_64-linux-gnu":
     ext = ".tar.gz"
-    hash = "4f227117b411a7c98622c970986e27bcfc3f547a72bef65e7d9e82989175d4f8  dogecoin-1.14.6-x86_64-linux-gnu.tar.gz"
+    hash = "4f227117b411a7c98622c970986e27bcfc3f547a72bef65e7d9e82989175d4f8  dogecoin-1.14.9-x86_64-linux-gnu.tar.gz"
 elif host == "i686-pc-linux-gnu":
     ext = ".tar.gz"
-    hash = "b8e1846a0979f369042dcf14435dfcea704b1456e34bc9657f0829d9eac0d3b0  dogecoin-1.14.6-i686-pc-linux-gnu.tar.gz"
+    hash = "b8e1846a0979f369042dcf14435dfcea704b1456e34bc9657f0829d9eac0d3b0  dogecoin-1.14.9-i686-pc-linux-gnu.tar.gz"
 
 print('Downloading started')
-file = "dogecoin-1.14.6-" + host
-base = "https://github.com/dogecoin/dogecoin/releases/download/v1.14.6/"
+file = "dogecoin-1.14.9-" + host
+base = "https://github.com/dogecoin/dogecoin/releases/download/v1.14.9/"
 url = base + file + ext
 sha256sums = base + "SHA256SUMS.asc"
 
@@ -96,7 +96,7 @@ else:
 
 deps_path = ["dogecoind"]
 for f in deps_path:
-    src = "dogecoin-1.14.6/bin/" + f
+    src = "dogecoin-1.14.9/bin/" + f
     src_path = os.path.join(os.getcwd(), src)
     if os.path.isdir('/usr/local/bin'):
         dst_path = os.path.join('/usr/local/bin', f)


### PR DESCRIPTION
Two independent problems in `rpctest/fetch.py`:

**The SPV test's exit code was discarded.** The subprocess result was never
checked, so a failing SPV run still exited `0` and CI reported success. This is
the more serious of the two — it means the SPV coverage in rpctest has not been
gating anything.

**The run was unbounded.** A stalled SPV sync hung the job until the workflow
timeout rather than failing with a diagnosable error. Now bounded by
`SPVTOOL_TIMEOUT` (default 900s), overridable from the environment.

Also bumps the `dogecoind` under test from 1.14.6 to 1.14.9, with checksums
updated to the real published values for the new release.
