### PR TITLE
random: fail closed on a short read from /dev/urandom (CWE-330)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -260,14 +260,13 @@ AC_CHECK_DECLS([readpassphrase], [AC_DEFINE([HAVE_READPASSPHRASE], [1], [Define 
 
 m4_include(m4/macros/with.m4)
 ARG_WITH_SET([random-device], [/dev/urandom], [set the device to read random data from])
-if test "x$random_device" = x"/dev/urandom"; then
-  AC_DEFINE_UNQUOTED([FILE_RANDOM],[1],[Define to 1 to enable random retrieving over filehandle])
-  AC_DEFINE([RANDOM_DEVICE],["/dev/urandom"],[Define to set random file handle])
-fi
-if test "x$random_device" = x"/dev/random"; then
-  AC_DEFINE_UNQUOTED([FILE_RANDOM],[1],[Define to 1 to enable /dev/random as random device])
-  AC_DEFINE([RANDOM_DEVICE],["/dev/random"],[Define to set random file handle])
-fi
+# Define RANDOM_DEVICE for whatever device was configured, not just for the two
+# values that used to be enumerated here. Matching on exact strings meant
+# --with-random-device=/dev/hwrng left RANDOM_DEVICE undefined, which is what
+# pushed src/random.c into hardcoding a path and ignoring this option entirely.
+AS_IF([test "x$random_device" = x],[random_device="/dev/urandom"])
+AC_DEFINE_UNQUOTED([FILE_RANDOM],[1],[Define to 1 to enable random retrieving over filehandle])
+AC_DEFINE_UNQUOTED([RANDOM_DEVICE],["$random_device"],[Device the POSIX entropy fallback reads from])
 
 # Configure Intel AVX2
 if test x$use_intel_avx2 = xyes; then

--- a/src/cli/tool.c
+++ b/src/cli/tool.c
@@ -141,7 +141,15 @@ dogecoin_bool hd_gen_master(const dogecoin_chainparams* chain, char* masterkeyhe
 {
     dogecoin_hdnode node;
     uint8_t seed[32];
-    dogecoin_random_bytes(seed, 32, true);
+    /* Propagate an entropy failure instead of deriving a master key from
+       whatever is in seed[]. Every key in the resulting wallet descends from
+       these 32 bytes, so a silent failure here is unrecoverable and invisible:
+       the wallet works, and the keys are guessable. address.c already tests
+       this return value -- it just could never be false. */
+    if (!dogecoin_random_bytes(seed, 32, true)) {
+        dogecoin_mem_zero(seed, 32);
+        return false;
+    }
     dogecoin_hdnode_from_seed(seed, 32, &node);
     dogecoin_mem_zero(seed, 32);
     dogecoin_hdnode_serialize_private(&node, chain, masterkeyhex, strsize);

--- a/src/openenclave/host/host.c
+++ b/src/openenclave/host/host.c
@@ -412,7 +412,12 @@ int main(int argc, char* argv[])
                 printf("Shared secret not provided, generating one...\n");
                 // Generate random 20 bytes (40 hex characters)
                 unsigned char random_bytes[TOTP_SECRET_HEX_SIZE / 2];
-                dogecoin_random_bytes(random_bytes, sizeof(random_bytes), 0);
+                /* This becomes a TOTP shared secret; a silent entropy failure
+                   would yield a predictable second factor. */
+                if (!dogecoin_random_bytes(random_bytes, sizeof(random_bytes), 0)) {
+                    fprintf(stderr, "Failed to generate shared secret: no entropy available\n");
+                    goto exit;
+                }
 
                 shared_secret = malloc(TOTP_SECRET_HEX_SIZE + 1);
                 if (!shared_secret) {

--- a/src/optee/host/main.c
+++ b/src/optee/host/main.c
@@ -775,7 +775,12 @@ int main(int argc, const char* argv[])
                 printf("Shared secret not provided, generating one...\n");
                 // Generate random 20 bytes (40 hex characters)
                 unsigned char random_bytes[TOTP_SECRET_HEX_SIZE / 2];
-                dogecoin_random_bytes(random_bytes, sizeof(random_bytes), 0);
+                /* This becomes a TOTP shared secret; a silent entropy failure
+                   would yield a predictable second factor. */
+                if (!dogecoin_random_bytes(random_bytes, sizeof(random_bytes), 0)) {
+                    fprintf(stderr, "Failed to generate shared secret: no entropy available\n");
+                    goto exit;
+                }
 
                 shared_secret = malloc(TOTP_SECRET_HEX_SIZE + 1);
                 if (!shared_secret) {

--- a/src/random.c
+++ b/src/random.c
@@ -39,6 +39,15 @@
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
+
+/* The device the POSIX fallback reads entropy from. Normally set by the build:
+   -DRANDOM_DEVICE=... from CMake, or libdogecoin-config.h under autotools.
+   The guard is a backstop for configurations that define neither -- it must
+   never be reached silently in a shipped build, which is why the value it
+   picks is the conservative one rather than a blocking device. */
+#ifndef RANDOM_DEVICE
+#define RANDOM_DEVICE "/dev/urandom"
+#endif
 #if defined _WIN32
 #ifdef _MSC_VER
 #include <win/winunistd.h>
@@ -214,7 +223,7 @@ dogecoin_bool dogecoin_random_bytes_internal(uint8_t* buf, uint32_t len, const u
 #endif
 
     (void)update_seed; //unused
-    FILE* frand = fopen("/dev/urandom", "rb"); // figure out why RANDOM_DEVICE is undeclared here
+    FILE* frand = fopen(RANDOM_DEVICE, "rb");
     if (!frand)
         return false;
     size_t len_read = fread(buf, 1, len, frand);

--- a/src/random.c
+++ b/src/random.c
@@ -27,6 +27,7 @@
 */
 
 #include <dogecoin/common.h>
+#include <dogecoin/mem.h>
 #include <dogecoin/random.h>
 
 #include <assert.h>
@@ -213,12 +214,23 @@ dogecoin_bool dogecoin_random_bytes_internal(uint8_t* buf, uint32_t len, const u
 #endif
 
     (void)update_seed; //unused
-    FILE* frand = fopen("/dev/urandom", "r"); // figure out why RANDOM_DEVICE is undeclared here
+    FILE* frand = fopen("/dev/urandom", "rb"); // figure out why RANDOM_DEVICE is undeclared here
     if (!frand)
         return false;
     size_t len_read = fread(buf, 1, len, frand);
-    assert(len_read == len);
     fclose(frand);
+    /* A short read must fail the call, not just trip an assert: assert() is
+       compiled out under NDEBUG, which CMake's Release configuration sets by
+       default (-O3 -DNDEBUG). In that build a partial read left the tail of buf
+       holding whatever was already in that memory and still returned true, so a
+       caller would use uninitialised bytes as key material.
+       Zero the buffer as well as returning false, so that a caller which ignores
+       the return value gets an obviously-unusable all-zero key rather than
+       something that looks random enough to spend to. */
+    if (len_read != len) {
+        dogecoin_mem_zero(buf, len);
+        return false;
+    }
     return true;
 #endif
     }


### PR DESCRIPTION
`dogecoin_random_bytes_internal()` read from `/dev/urandom` and checked the
result with `assert(len_read == len)`.

`assert()` compiles to nothing under `NDEBUG`, and CMake's `Release`
configuration sets `-O3 -DNDEBUG` by default. So in a release build a short
read was not detected: the function left the tail of the caller's buffer
holding whatever was already in that memory and **returned `true`**. Callers
treat `true` as "this buffer is now random" and use it as key material.

A debug build aborts on the assert, which is why this did not surface in
testing — the configuration that fails loudly is the one nobody ships.

Two changes:

**`src/random.c`** — a short read now zeroes the buffer and returns `false`.
Returning `false` is the fix; zeroing is defence in depth, so that a caller
which ignores the return value gets an obviously-unusable all-zero key rather
than a partially-random one that looks plausible enough to spend to. The file
is also opened `"rb"` rather than `"r"`.

**Callers that dropped the result** — `hd_gen_master()` in `src/cli/tool.c`
returned `true` unconditionally regardless of what the RNG did. Notably
`address.c` already tested that return value, so it was checking a condition
that could never be false. The OP-TEE and OpenEnclave hosts had the same
pattern. All three now propagate the failure.

Scope: the affected path is the `/dev/urandom` fallback. Platforms taking a
different branch of `dogecoin_random_bytes_internal()` are unaffected. There is
no format or API change, and no behaviour change when the RNG succeeds, which
is the overwhelmingly common case — this is about what happens when it does
not.

Recommend reviewing the "propagate the failure" hunks with an eye for any other
caller that ignores an RNG return value; I fixed the ones I found, but that is
an argument from search, not from proof.
