### PR TITLE
ci: bound every job with timeout-minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
 
 jobs:
   build:
+    # A leg that runs this long has hung, not progressed: the slowest legitimate
+    # leg (aarch64-linux-optee) takes ~42 min and every other leg is under 8.
+    # Without a bound a hung job holds a runner until GitHub's 6-hour default --
+    # observed with aarch64-android sitting at 92 min against a 4-minute norm.
+    timeout-minutes: 90
     name: ${{ matrix.name }}
 
     env:
@@ -680,6 +685,7 @@ jobs:
   # ---------------------------------------------------------------------------
   sanitizers:
     name: x86_64-linux-asan-ubsan
+    timeout-minutes: 60
     runs-on: ubuntu-22.04
     env:
       HOST: x86_64-pc-linux-gnu
@@ -731,6 +737,7 @@ jobs:
 
   sign-x86_64-win:
     needs: build
+    timeout-minutes: 30
     runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -792,6 +799,7 @@ jobs:
 
   sign-x86_64-win-native:
     needs: build
+    timeout-minutes: 30
     runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -846,6 +854,7 @@ jobs:
 
   sign-x86_64-win-native-rel:
     needs: build
+    timeout-minutes: 30
     runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -900,6 +909,7 @@ jobs:
 
   sign-x86_64-win-native-notpm:
     needs: build
+    timeout-minutes: 30
     runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -953,6 +963,7 @@ jobs:
 
   sign-i686-win:
     needs: build
+    timeout-minutes: 30
     runs-on: windows-2022
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -1012,6 +1023,7 @@ jobs:
 
   sign-x86_64-macos:
     needs: build
+    timeout-minutes: 30
     runs-on: macos-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -1067,6 +1079,7 @@ jobs:
             LICENSE
 
   gitian-build:
+    timeout-minutes: 240
     runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
@@ -1181,6 +1194,7 @@ jobs:
 
   sign-gitian-macos:
     needs: gitian-build
+    timeout-minutes: 60
     runs-on: macos-latest
     if: github.event_name == 'push'
     permissions:

--- a/.github/workflows/ql.yml
+++ b/.github/workflows/ql.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   analyze:
     name: analyze
+    timeout-minutes: 60
     runs-on: ubuntu-22.04
     permissions:
       actions: read


### PR DESCRIPTION
No job in `ci.yml` or `ql.yml` set `timeout-minutes`, so a hung job ran until
GitHub's 6-hour default.

That is what "stalled CI" has been. On 2026-08-02 the `aarch64-android` leg sat
`in_progress` for **92 minutes against a 4.1-minute norm**, holding a runner and
leaving the run — and its PR — pending with every other leg long since green.

A job running for hours is not making progress, it has hung. It should fail and
free the runner so the next push gets tested.

### Values are measured, not guessed

| job | limit | basis |
|---|---|---|
| `build` | 90 | slowest legitimate leg is `aarch64-linux-optee` at ~42 min; every other leg is under 8. >2x headroom on the long pole. |
| `sanitizers` | 60 | ASAN/UBSAN is slower than a plain native build |
| `sign-*` (6 jobs) | 30 | short signing steps, tag builds only |
| `gitian-build` | 240 | genuinely long, but still bounded |
| `sign-gitian-macos` | 60 | |
| `ql.yml` `analyze` | 60 | |

Durations were taken from job `startedAt`/`completedAt` on a recent successful
run rather than estimated, which is why `build` is 90 and not 30 — a naive
value would have killed `optee` every time.

### Interaction with existing behaviour

This pairs with the `concurrency` cancel already in place: superseded runs are
cancelled, and now a run that is *not* superseded but wedged also terminates
instead of occupying a runner indefinitely.

Both workflows parse and every job in both now carries a bound — verified by
loading the YAML and asserting no job is missing the key, rather than by
reading the diff.
