### PR TITLE
ci: build CMake natively, both WITH_NET settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -729,6 +729,51 @@ jobs:
           UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
         run: make check -j"$(getconf _NPROCESSORS_ONLN)" V=1
 
+  # ---------------------------------------------------------------------------
+  # CMake build-system parity gate.
+  #
+  # CMake is only exercised by the three x86_64-win-native legs, all of which
+  # build WITH_NET=ON. Every Linux leg uses autotools. So CMakeLists.txt and
+  # Makefile.am can describe different libraries indefinitely and nothing
+  # notices, and WITH_NET=OFF is never built under CMake at all.
+  #
+  # That blind spot has produced three separate link failures: compact_filter.c
+  # and compact_block.c were each unconditional in Makefile.am but inside
+  # IF(WITH_NET) in CMake while their tests were registered unconditionally, and
+  # cf_checkpoints.c was PRIVATE where it had to be PUBLIC. Each surfaced only on
+  # Windows, which made a build-system disagreement look platform-specific.
+  #
+  # Builds both configurations natively and runs the suite for each. Neither the
+  # depends tree nor autotools is involved: libevent and secp256k1 are vendored
+  # in-tree and CMake drives them itself.
+  # ---------------------------------------------------------------------------
+  cmake-parity:
+    name: x86_64-linux-cmake
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: install packages
+        run: |
+          sudo apt-get update
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
+            cmake build-essential python3 libgmp-dev
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: build and test (WITH_NET=OFF)
+        run: |
+          cmake -B build-nonet -DWITH_NET=OFF -DUSE_TESTS=ON
+          cmake --build build-nonet -j"$(getconf _NPROCESSORS_ONLN)"
+          ./build-nonet/tests
+
+      - name: build and test (WITH_NET=ON)
+        run: |
+          cmake -B build-net -DWITH_NET=ON -DUSE_TESTS=ON
+          cmake --build build-net -j"$(getconf _NPROCESSORS_ONLN)"
+          ./build-net/tests
+
   sign-x86_64-win:
     needs: build
     runs-on: windows-2022

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,8 +106,18 @@ IF(WITH_NET)
         file(COPY "${PROJECT_SOURCE_DIR}/src/libevent/include/event2" DESTINATION "${PROJECT_SOURCE_DIR}/include")
         find_path(LIBEVENT_INCLUDE_DIR event.h PATHS "${PROJECT_SOURCE_DIR}/include/event2" REQUIRED)
         find_path(LIBEVENT_INCLUDE_DIR event-config.h PATHS "${PROJECT_SOURCE_DIR}/include/event2" REQUIRED)
-        FIND_LIBRARY(LIBEVENT NAMES event HINTS "${PROJECT_SOURCE_DIR}/src/libevent/build/lib/${CMAKE_BUILD_TYPE}" REQUIRED)
-        FIND_LIBRARY(LIBEVENT_PTHREADS NAMES event_pthreads HINTS "${PROJECT_SOURCE_DIR}/src/libevent/build/lib/${CMAKE_BUILD_TYPE}" REQUIRED)
+        # Multi-config generators (MSVC) put the library under lib/<CONFIG>;
+        # single-config ones (Makefiles, Ninja) put it in lib/ directly. Search
+        # both, or the Linux build cannot find the libevent it just built and
+        # silently depends on a system copy being installed instead.
+        FIND_LIBRARY(LIBEVENT NAMES event
+            HINTS "${PROJECT_SOURCE_DIR}/src/libevent/build/lib/${CMAKE_BUILD_TYPE}"
+                  "${PROJECT_SOURCE_DIR}/src/libevent/build/lib"
+            REQUIRED)
+        FIND_LIBRARY(LIBEVENT_PTHREADS NAMES event_pthreads
+            HINTS "${PROJECT_SOURCE_DIR}/src/libevent/build/lib/${CMAKE_BUILD_TYPE}"
+                  "${PROJECT_SOURCE_DIR}/src/libevent/build/lib"
+            REQUIRED)
     ENDIF()
 ENDIF()
 


### PR DESCRIPTION
CMake is exercised by exactly three CI legs — `x86_64-win-native`,
`-rel`, `-notpm` — and all three build `WITH_NET=ON`. Every Linux leg uses
autotools. Two consequences:

1. `CMakeLists.txt` and `Makefile.am` can describe **different libraries**
   indefinitely and nothing notices.
2. `WITH_NET=OFF` is never built under CMake at all.

### This has already cost three link failures

| file | divergence |
|---|---|
| `compact_filter.c` | unconditional in `Makefile.am`, inside `IF(WITH_NET)` in CMake, while `compact_filter_tests.c` was registered unconditionally in both — so `-DWITH_NET=OFF` compiled the tests but not the code under test |
| `compact_block.c` | same shape, and `compact_block_tests.c` was **never added to the CMake tests target at all** |
| `cf_checkpoints.c` | `PRIVATE` where it needed to be `PUBLIC` |

Each surfaced only on Windows, which made a build-system disagreement look
platform-specific and sent the first diagnosis in the wrong direction every
time.

### What this adds

A self-contained native job building both configurations and running the suite
for each, following the pattern the `sanitizers` job already uses. Neither
`depends` nor autotools is involved — `libevent` and `secp256k1` are vendored
in-tree and CMake drives them itself — so the job needs only `cmake` and a
compiler, and finishes well inside the 8-minute norm for a native leg.

### Verified against the actual broken commits

Not asserted from reasoning — checked out and built:

```
6f75cd0a~  compact_filter gated     WITH_NET=OFF: 55 undefined references
1719c22a   compact_block tests      WITH_NET=OFF:  1,  WITH_NET=ON: 1
```

The second fails in **both** configurations, so the `WITH_NET=ON` half is not
redundant with the Windows legs: it catches a CMake/`Makefile.am` divergence on
Linux in a couple of minutes, rather than after the slow Windows legs run.

**Not claimed:** the `cf_checkpoints` `PRIVATE`/`PUBLIC` case does not reproduce
here — it is a Windows DLL data-symbol export issue and still needs the
`win-native` legs. This gate would not have caught that one.

Both configurations pass on `0.1.5-dev`.

## It found one immediately

On its first run the new job failed — on a bug in `CMakeLists.txt`, not in the
job.

The libevent search hinted only at `src/libevent/build/lib/${CMAKE_BUILD_TYPE}`,
the multi-config layout. MSVC writes `lib/Debug` and `lib/Release`, so the
`win-native` legs resolve it. Makefiles and Ninja are single-config and write
`lib/` directly, so on Linux the hint names a directory that does not exist.

`FIND_LIBRARY` then falls through to the default search path, and the two
outcomes are both bad:

- **system libevent installed** → silently links the system copy instead of the
  one the build just compiled from `src/libevent`
- **none installed** → `REQUIRED` fails, immediately after
  `[100%] Linking C static library lib/libevent.a`

Fixed by searching both layouts. Verified by inspecting the resolved cache
entry rather than by the build succeeding — succeeding *was* the failure mode:

```
LIBEVENT:FILEPATH=.../src/libevent/build/lib/libevent.a
```

with `/usr/lib/x86_64-linux-gnu/libevent.a` present on the same host, which is
what had been masking it locally.

That makes three classes this gate covers: CMake/`Makefile.am` source
divergence, `WITH_NET=OFF` never being built under CMake, and now CMake paths
that only hold on multi-config generators.
