### PR TITLE
context: move context definitions into dogecoin/context.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,7 @@ noinst_HEADERS = \
     include/dogecoin/chacha20.h \
     include/dogecoin/chainparams.h \
     include/dogecoin/common.h \
+    include/dogecoin/context.h \
     include/dogecoin/cstr.h \
     include/dogecoin/ctaes.h \
     include/dogecoin/ecc.h \

--- a/include/dogecoin/context.h
+++ b/include/dogecoin/context.h
@@ -1,0 +1,67 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2024-2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#ifndef __LIBDOGECOIN_CONTEXT_H__
+#define __LIBDOGECOIN_CONTEXT_H__
+
+#include <dogecoin/chainparams.h>
+#include <dogecoin/dogecoin.h>
+
+LIBDOGECOIN_BEGIN_DECL
+
+struct dogecoin_transaction_context;
+struct dogecoin_eckey_context;
+
+typedef struct dogecoin_context_ {
+    const dogecoin_chainparams* chain_params;
+    struct dogecoin_transaction_context* tx_ctx;
+    struct dogecoin_eckey_context* key_ctx;
+    void* ecc_ctx;
+    void* rng_state;
+    void* refcount_lock;
+    int enable_net;
+    int error_code;
+    uint32_t refcount;
+    int thread_safe; //!nonzero when constructed via dogecoin_ctx_new_ts()
+    char last_error[256];
+} dogecoin_context;
+
+LIBDOGECOIN_API dogecoin_context* dogecoin_context_new(dogecoin_bool testnet, dogecoin_bool enable_net);
+LIBDOGECOIN_API void dogecoin_context_acquire(dogecoin_context* ctx);
+LIBDOGECOIN_API void dogecoin_context_release(dogecoin_context* ctx);
+LIBDOGECOIN_API const dogecoin_chainparams* dogecoin_context_get_chainparams(const dogecoin_context* ctx);
+LIBDOGECOIN_API struct dogecoin_transaction_context* dogecoin_context_get_transaction_context(dogecoin_context* ctx);
+LIBDOGECOIN_API struct dogecoin_eckey_context* dogecoin_context_get_eckey_context(dogecoin_context* ctx);
+LIBDOGECOIN_API void* dogecoin_context_get_ecc_context(dogecoin_context* ctx);
+LIBDOGECOIN_API void* dogecoin_context_get_rng_state(dogecoin_context* ctx);
+LIBDOGECOIN_API void dogecoin_context_set_error(dogecoin_context* ctx, int code, const char* msg);
+LIBDOGECOIN_API int dogecoin_context_get_error_code(const dogecoin_context* ctx);
+LIBDOGECOIN_API const char* dogecoin_context_get_error(const dogecoin_context* ctx);
+LIBDOGECOIN_API int dogecoin_generate_keypair_ex(dogecoin_context* ctx, char* wif, size_t* wif_size, char* addr, size_t* addr_size);
+
+LIBDOGECOIN_END_DECL
+
+#endif // __LIBDOGECOIN_CONTEXT_H__

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -254,9 +254,7 @@ int getDecodedPrivKeyWif(const char privkey_wif[PRIVKEYWIFLEN], const dogecoin_b
 /* bip32 utilities */
 #define DOGECOIN_BIP32_CHAINCODE_SIZE 32
 
-/* BIP 32 512-bit seed */
-#define MAX_SEED_SIZE 64
-typedef uint8_t SEED [MAX_SEED_SIZE];
+/* BIP 32 512-bit seed; MAX_SEED_SIZE and SEED come from dogecoin.h */
 
 typedef struct
 {
@@ -1049,7 +1047,7 @@ dogecoin_bool dogecoin_pqc_carrier_verify_reveal(
     size_t sig_len,
     uint8_t out_sighash[32]);
 
-/* Falcon-512 (requires USE_LIBOQS).  Caller must free *pk/*sk/*sig with dogecoin_free(). */
+/* Falcon-512 (requires USE_LIBOQS).  Caller must free pk, sk and sig with dogecoin_free(). */
 dogecoin_bool dogecoin_falcon512_keypair(uint8_t** pk, size_t* pk_len, uint8_t** sk, size_t* sk_len);
 dogecoin_bool dogecoin_falcon512_sign(const uint8_t* sk, size_t sk_len, const uint8_t* msg, size_t msg_len, uint8_t** sig, size_t* sig_len);
 dogecoin_bool dogecoin_falcon512_verify(const uint8_t* pk, size_t pk_len, const uint8_t* msg, size_t msg_len, const uint8_t* sig, size_t sig_len);
@@ -1057,7 +1055,7 @@ dogecoin_bool dogecoin_falcon512_commit_bytes(const uint8_t* pk, size_t pk_len, 
 dogecoin_bool dogecoin_tx_add_falcon512_commit(dogecoin_tx* tx, const uint8_t commit32[DOGECOIN_PQC_FALCON_COMMIT_LEN]);
 dogecoin_bool dogecoin_tx_extract_falcon512_commit(const dogecoin_tx* tx, uint8_t out_commit32[DOGECOIN_PQC_FALCON_COMMIT_LEN]);
 
-/* Dilithium2 (requires USE_LIBOQS).  Caller must free *pk/*sk/*sig with dogecoin_free(). */
+/* Dilithium2 (requires USE_LIBOQS).  Caller must free pk, sk and sig with dogecoin_free(). */
 dogecoin_bool dogecoin_dilithium2_keypair(uint8_t** pk, size_t* pk_len, uint8_t** sk, size_t* sk_len);
 dogecoin_bool dogecoin_dilithium2_sign(const uint8_t* sk, size_t sk_len, const uint8_t* msg, size_t msg_len, uint8_t** sig, size_t* sig_len);
 dogecoin_bool dogecoin_dilithium2_verify(const uint8_t* pk, size_t pk_len, const uint8_t* msg, size_t msg_len, const uint8_t* sig, size_t sig_len);
@@ -1065,7 +1063,7 @@ dogecoin_bool dogecoin_dilithium2_commit_bytes(const uint8_t* pk, size_t pk_len,
 dogecoin_bool dogecoin_tx_add_dilithium2_commit(dogecoin_tx* tx, const uint8_t commit32[DOGECOIN_PQC_DILITHIUM_COMMIT_LEN]);
 dogecoin_bool dogecoin_tx_extract_dilithium2_commit(const dogecoin_tx* tx, uint8_t out_commit32[DOGECOIN_PQC_DILITHIUM_COMMIT_LEN]);
 
-/* Raccoon-G-44 (requires USE_RACCOON_G).  Caller must free *pk/*sk/*sig/*child_* with dogecoin_free(). */
+/* Raccoon-G-44 (requires USE_RACCOON_G).  Caller must free pk, sk, sig and child outputs with dogecoin_free(). */
 dogecoin_bool dogecoin_raccoong44_is_available(void);
 dogecoin_bool dogecoin_raccoong44_keypair(uint8_t** pk, size_t* pk_len, uint8_t** sk, size_t* sk_len);
 dogecoin_bool dogecoin_raccoong44_sign(const uint8_t* sk, size_t sk_len, const uint8_t* msg, size_t msg_len, uint8_t** sig, size_t* sig_len);

--- a/src/context.c
+++ b/src/context.c
@@ -24,7 +24,9 @@
 
 */
 
-#include <dogecoin/libdogecoin.h>
+#include <dogecoin/address.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/context.h>
 #include <dogecoin/mem.h>
 #include <dogecoin/random.h>
 

--- a/test/context_tests.c
+++ b/test/context_tests.c
@@ -7,7 +7,8 @@
 #include <string.h>
 
 #include <test/utest.h>
-#include <dogecoin/libdogecoin.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/context.h>
 
 void test_context_keypair_ex()
 {


### PR DESCRIPTION
Adds include/dogecoin/context.h so src/context.c and test/context_tests.c no longer include the public dogecoin/libdogecoin.h API header, removes the duplicate SEED typedef and fixes nested comment markers in libdogecoin.h.